### PR TITLE
Add test to check if PowerShell scripts run without exceptions

### DIFF
--- a/powershell/tests/functions/Help.Tests.ps1
+++ b/powershell/tests/functions/Help.Tests.ps1
@@ -60,6 +60,11 @@ Describe -Tags ('Unit', 'Acceptance') "$module Module Tests" {
             $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
             $errors.Count | Should -Be 0
         }
+
+        It "$_ should run without exceptions" {
+            $scriptBlock = [scriptblock]::Create((Get-Content "$moduleRoot/public/$_.ps1" -Raw))
+            { & $scriptBlock } | Should -Not -Throw
+        }
     }
 
     Context "Test Function" -ForEach $functionsWithTests {


### PR DESCRIPTION
This pull request adds a new test to check if PowerShell scripts run without exceptions. The test uses the `Get-Content` cmdlet to read the contents of each PowerShell script file and then executes the script using a script block. If any exceptions are thrown during the execution, the test will fail. This test helps ensure the stability and reliability of the PowerShell scripts in the project.