### PR TITLE
Fix legacy block test

### DIFF
--- a/powershell/internal/Invoke-MtGraphRequestCache.ps1
+++ b/powershell/internal/Invoke-MtGraphRequestCache.ps1
@@ -31,6 +31,7 @@ Function Invoke-MtGraphRequestCache {
     }
 
     if (!$results) {
+        Write-Verbose ("Invoking Graph: $($Uri.AbsoluteUri)")
         $results = Invoke-MgGraphRequest -Method $Method -Uri $Uri -Headers $Headers -OutputType $OutputType
         if (!$isBatch -and $isMethodGet) {
             # Update cache

--- a/powershell/public/Test-MtCaBlockLegacyExchangeActiveSyncAuthentication.ps1
+++ b/powershell/public/Test-MtCaBlockLegacyExchangeActiveSyncAuthentication.ps1
@@ -32,7 +32,10 @@ See [Block legacy authentication - Microsoft Learn](https://learn.microsoft.com/
     foreach ($policy in $policies) {
         if ( $policy.grantcontrols.builtincontrols -contains 'block' `
                 -and "exchangeActiveSync" -in $policy.conditions.clientAppTypes `
-                -and $policy.conditions.applications.includeApplications -eq "00000002-0000-0ff1-ce00-000000000000" `
+                -and ( `
+                    $policy.conditions.applications.includeApplications -eq "00000002-0000-0ff1-ce00-000000000000" `
+                    -or $policy.conditions.applications.includeApplications -eq "all" `
+            ) `
                 -and $policy.conditions.users.includeUsers -eq "All" `
         ) {
             $result = $true


### PR DESCRIPTION
Refactor test for Exchange Active Sync to accept "00000002-0000-0ff1-ce00-000000000000" or "all" as `includeApplications`

Reported on Twitter: https://twitter.com/inthecloud_247/status/1779223789697368399