### PR TITLE
Bump `azure/powershell` action to `v2` in GitHub docs

### DIFF
--- a/website/docs/monitoring/github.md
+++ b/website/docs/monitoring/github.md
@@ -134,7 +134,7 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: Run Maester
-      uses: azure/powershell@v1
+      uses: azure/powershell@v2
       with:
         inlineScript: |
           # Get Token


### PR DESCRIPTION
This updates the version for the `azure/powershell` GitHub Action in order to use the supported `node20` runtime.