### PR TITLE
Addition of CISA ScubaGear Section 2

### DIFF
--- a/powershell/internal/Get-GraphObjectMarkdown.ps1
+++ b/powershell/internal/Get-GraphObjectMarkdown.ps1
@@ -22,15 +22,16 @@ Function Get-GraphObjectMarkdown {
 
         # The type of graph object, this will be used to show the right deeplink to the test results report.
         [Parameter(Mandatory = $true)]
-        [ValidateSet('ConditionalAccess', 'User', 'Group', 'Device')]
+        [ValidateSet('ConditionalAccess', 'User', 'Group', 'Device', 'IdentityProtection')]
         [string] $GraphObjectType
     )
 
     $markdownLinkTemplate = @{
-        ConditionalAccess = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/{0}"
-        User              = "https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/{0}"
-        Group             = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/{0}"
-        Device            = "https://entra.microsoft.com/#view/Microsoft_AAD_Devices/DeviceDetailsMenuBlade/~/Properties/objectId/{0}"
+        ConditionalAccess  = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/{0}"
+        User               = "https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/{0}"
+        Group              = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/{0}"
+        Device             = "https://entra.microsoft.com/#view/Microsoft_AAD_Devices/DeviceDetailsMenuBlade/~/Properties/objectId/{0}"
+        IdentityProtection = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/UsersAtRiskAlerts/fromNav/Identity"
     }
 
     # This will work for now, will need to add switch as we add support for complex urls like Applications blade, etc..

--- a/powershell/public/Add-MtTestResultDetail.ps1
+++ b/powershell/public/Add-MtTestResultDetail.ps1
@@ -52,7 +52,7 @@ Function Add-MtTestResultDetail {
         [Object[]] $GraphObjects,
 
         # The type of graph object, this will be used to show the right deeplink to the test results report.
-        [ValidateSet('ConditionalAccess', 'Users', 'Groups')]
+        [ValidateSet('ConditionalAccess', 'Users', 'Groups', 'IdentityProtection')]
         [string] $GraphObjectType,
 
         # Pester test name

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.md
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.md
@@ -1,0 +1,17 @@
+Legacy authentication SHALL be blocked.
+
+Rationale: The security risk of allowing legacy authentication protocols is they do not support MFA. Blocking legacy protocols reduces the impact of user credential theft.
+
+#### Remediation action:
+
+Follow the guide below to create a conditional access policy that blocks legacy authentication.
+
+- [Block legacy authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy#create-a-conditional-access-policy)
+
+#### Related links
+
+- [CISA Legacy Authentication - MS.AAD.1.1v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#1-legacy-authentication)
+- [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L47)
+
+<!--- Results --->
+%TestResult%

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.md
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.md
@@ -1,6 +1,6 @@
-Legacy authentication SHALL be blocked.
+Users detected as high risk SHALL be blocked.
 
-Rationale: The security risk of allowing legacy authentication protocols is they do not support MFA. Blocking legacy protocols reduces the impact of user credential theft.
+Rationale: Blocking high-risk users may prevent compromised accounts from accessing the tenant.
 
 #### Remediation action:
 
@@ -10,8 +10,8 @@ Follow the guide below to create a conditional access policy that blocks legacy 
 
 #### Related links
 
-- [CISA Legacy Authentication - MS.AAD.1.1v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#1-legacy-authentication)
-- [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L47)
+- [CISA Risk Based Policies - MS.AAD.2.1v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad21v1)
+- [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L85)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.md
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.md
@@ -1,17 +1,19 @@
-Users detected as high risk SHALL be blocked.
+Users detected as high risk SHALL be blocked. Sign-ins detected as high risk SHALL be blocked.
 
-Rationale: Blocking high-risk users may prevent compromised accounts from accessing the tenant.
+Rationale: Blocking high-risk users may prevent compromised accounts from accessing the tenant. This prevents compromised accounts from accessing the tenant.
 
 #### Remediation action:
 
-Follow the guide below to create a conditional access policy that blocks legacy authentication.
+Follow the guide below to create a conditional access policy that blocks risky logins.
 
-- [Block legacy authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy#create-a-conditional-access-policy)
+- [Block Risky Logins - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy#create-a-conditional-access-policy)
 
 #### Related links
 
 - [CISA Risk Based Policies - MS.AAD.2.1v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad21v1)
+- [CISA Risk Based Policies - MS.AAD.2.3v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad23v1)
 - [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L85)
+- [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L138)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
@@ -21,6 +21,8 @@ Function Test-MtCisaBlockHighRisk {
     [OutputType([bool])]
     param()
 
+    $result = Get-MtConditionalAccessPolicy
+
     $blockPolicies = $result | Where-Object {`
             $_.state -eq "enabled" -and `
             $_.grantControls.builtInControls -contains "block" -and `

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-    Checks if Risk Based Policies - MS.AAD.2.1v1 is set to 'blocked'
+    Checks if Risk Based Policies - MS.AAD.2.1v1 & MS.AAD.2.3v1 is set to 'blocked'
 
 .DESCRIPTION
 

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
@@ -1,0 +1,41 @@
+﻿<#
+.SYNOPSIS
+    Checks if Risk Based Policies - MS.AAD.2.1v1 is set to 'blocked'
+
+.DESCRIPTION
+
+    Users detected as high risk SHALL be blocked.
+
+    Queries /identity/conditionalAccess/policies
+    and returns the result of
+     (graph/identity/conditionalAccess/policies?$filter=(state eq 'enabled') and (grantControls/builtInControls/any(c:c eq 'block')) and (conditions/applications/includeApplications/any(c:c eq 'All')) and (conditions/userRiskLevels/any(c:c eq 'high')) and (conditions/users/includeUsers/any(c:c eq 'All'))&$count=true).'@odata.count' -ge 1
+
+.EXAMPLE
+    Test-MtCisaBlockHighRisk
+
+    Returns the result of (graph.microsoft.com/v1.0/identity/conditionalAccess/policies?$filter=(state eq 'enabled') and (grantControls/builtInControls/any(c:c eq 'block')) and (conditions/applications/includeApplications/any(c:c eq 'All')) and (conditions/userRiskLevels/any(c:c eq 'high')) and (conditions/users/includeUsers/any(c:c eq 'All'))&$count=true).'@odata.count' -ge 1
+#>
+
+Function Test-MtCisaBlockHighRisk {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    $blockPolicies = $result | Where-Object {`
+            $_.state -eq "enabled" -and `
+            $_.grantControls.builtInControls -contains "block" -and `
+            $_.applications.includeApplications -contains "all" -and `
+            $_.conditions.userRiskLevels -contains "high" -and `
+            $_.conditions.users.includeUsers -contains "All" }
+
+    $testResult = $blockPolicies.Count -ge 1
+
+    if ($testResult) {
+        $testResultMarkdown = "Your tenant has one or more policies that block high risk user logins:`n`n%TestResult%"
+    } else {
+        $testResultMarkdown = "Your tenant does not have any conditional access policies that block high risk user logins."
+    }
+    Add-MtTestResultDetail -Result $testResultMarkdown -GraphObjectType ConditionalAccess -GraphObjects $blockPolicies
+
+    return $testResult
+}

--- a/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaBlockHighRisk.ps1
@@ -26,7 +26,7 @@ Function Test-MtCisaBlockHighRisk {
     $blockPolicies = $result | Where-Object {`
             $_.state -eq "enabled" -and `
             $_.grantControls.builtInControls -contains "block" -and `
-            $_.applications.includeApplications -contains "all" -and `
+            $_.conditions.applications.includeApplications -contains "all" -and `
             $_.conditions.userRiskLevels -contains "high" -and `
             $_.conditions.users.includeUsers -contains "All" }
 

--- a/powershell/public/CISA/Entra/Test-MtCisaLegacyAuth.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaLegacyAuth.ps1
@@ -8,12 +8,12 @@
 
     Queries /identity/conditionalAccess/policies
     and returns the result of
-     (graph/identity/conditionalAccess/policies?$filter=(state eq 'enabled') and (grantControls/builtInControls/any(c:c eq 'block')) and (conditions/clientAppTypes/any(c:c eq 'exchangeActiveSync')) and (conditions/clientAppTypes/any(c:c eq 'other')) and (conditions/users/includeUsers/any(c:c eq 'All'))&$count=true).'@odata.count' -eq 1
+     (graph/identity/conditionalAccess/policies?$filter=(state eq 'enabled') and (grantControls/builtInControls/any(c:c eq 'block')) and (conditions/clientAppTypes/any(c:c eq 'exchangeActiveSync')) and (conditions/clientAppTypes/any(c:c eq 'other')) and (conditions/users/includeUsers/any(c:c eq 'All'))&$count=true).'@odata.count' -ge 1
 
 .EXAMPLE
     Test-MtCisaLegacyAuth
 
-    Returns the result of (graph.microsoft.com/v1.0/identity/conditionalAccess/policies?$filter=(state eq 'enabled') and (grantControls/builtInControls/any(c:c eq 'block')) and (conditions/clientAppTypes/any(c:c eq 'exchangeActiveSync')) and (conditions/clientAppTypes/any(c:c eq 'other')) and (conditions/users/includeUsers/any(c:c eq 'All'))&$count=true).'@odata.count' -eq 1
+    Returns the result of (graph.microsoft.com/v1.0/identity/conditionalAccess/policies?$filter=(state eq 'enabled') and (grantControls/builtInControls/any(c:c eq 'block')) and (conditions/clientAppTypes/any(c:c eq 'exchangeActiveSync')) and (conditions/clientAppTypes/any(c:c eq 'other')) and (conditions/users/includeUsers/any(c:c eq 'All'))&$count=true).'@odata.count' -ge 1
 #>
 
 Function Test-MtCisaLegacyAuth {

--- a/powershell/public/CISA/Entra/Test-MtCisaNotifyHighRisk.md
+++ b/powershell/public/CISA/Entra/Test-MtCisaNotifyHighRisk.md
@@ -1,0 +1,17 @@
+A notification SHOULD be sent to the administrator when high-risk users are detected.
+
+Rationale: Notification enables the admin to monitor the event and remediate the risk. This helps the organization proactively respond to cyber intrusions as they occur.
+
+#### Remediation action:
+
+Follow the guide below to create a conditional access policy that blocks legacy authentication.
+
+- [Configure Entra Identity Protection Notifications - Microsoft Learn](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-notifications#configure-users-at-risk-detected-alerts)
+
+#### Related links
+
+- [CISA Risk Based Policies - MS.AAD.2.2v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad22v1)
+- [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L122)
+
+<!--- Results --->
+%TestResult%

--- a/powershell/public/CISA/Entra/Test-MtCisaNotifyHighRisk.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaNotifyHighRisk.ps1
@@ -1,0 +1,40 @@
+﻿<#
+.SYNOPSIS
+    Checks if Risk Based Policies - MS.AAD.2.2v1 has recipients
+
+.DESCRIPTION
+
+    A notification SHOULD be sent to the administrator when high-risk users are detected.
+
+    Queries /identityProtection/settings/notifications
+    and returns the result of
+     (graph/identityProtection/settings/notifications)
+
+.EXAMPLE
+    Test-MtCisaNotifyHighRisk
+
+    Returns the result of (graph.microsoft.com/beta/identityProtection/settings/notifications)
+#>
+
+Function Test-MtCisaNotifyHighRisk {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    #Connect-MgGraph -UseDeviceCode -Scopes IdentityRiskEvent.Read.All
+    $result = Invoke-MtGraphRequest -RelativeUri "identityProtection/settings/notifications" -ApiVersion "beta"
+
+    $notficationRecipients = $result.notificationRecipients | Where-Object {`
+            $_.isRiskyUsersAlertsRecipient }
+
+    $testResult = $notficationRecipients.Count -ge 1
+
+    if ($testResult) {
+        $testResultMarkdown = "Your tenant has one or more recipients for notifications of risky user logins:`n`n%TestResult%"
+    } else {
+        $testResultMarkdown = "Your tenant does not have any recipients for notifications of risky user logins."
+    }
+    Add-MtTestResultDetail -Result $testResultMarkdown -GraphObjectType IdentityProtection -GraphObjects $notficationRecipients
+
+    return $testResult
+}

--- a/powershell/public/Get-MtGraphScope.ps1
+++ b/powershell/public/Get-MtGraphScope.ps1
@@ -39,6 +39,7 @@ Function Get-MtGraphScope {
         'Reports.Read.All'
         'DirectoryRecommendations.Read.All'
         'PrivilegedAccess.Read.AzureAD'
+        'IdentityRiskEvent.Read.All'
     )
 
     if ($SendMail) {

--- a/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
+++ b/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
@@ -1,0 +1,5 @@
+Describe "CISA ScubaGear MS.AAD.1.1v1" -Tag "CISA", "Security", "All" {
+    It "MS.AAD.1.1v1: Legacy authentication SHALL be blocked." {
+        Test-MtCisaLegacyAuth | Should -Be $true -Because "an enabled policy for all users blocking legacy auth access shall exist."
+    }
+}

--- a/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
+++ b/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
@@ -1,5 +1,5 @@
-Describe "CISA ScubaGear MS.AAD.2.1v1" -Tag "CISA", "Security", "All" {
-    It "MS.AAD.2.1v1: Users detected as high risk SHALL be blocked." {
+Describe "CISA ScubaGear MS.AAD.2.1v1 & MS.AAD.2.3v1" -Tag "CISA", "Security", "All" {
+    It "MS.AAD.2.1v1: Users detected as high risk SHALL be blocked. & MS.AAD.2.1v1: Sign-ins detected as high risk SHALL be blocked." {
         Test-MtCisaBlockHighRisk | Should -Be $true -Because "an enabled policy for all users blocking high risk logins shall exist."
     }
 }

--- a/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
+++ b/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
@@ -1,5 +1,5 @@
-Describe "CISA ScubaGear MS.AAD.1.1v1" -Tag "CISA", "Security", "All" {
-    It "MS.AAD.1.1v1: Legacy authentication SHALL be blocked." {
-        Test-MtCisaLegacyAuth | Should -Be $true -Because "an enabled policy for all users blocking legacy auth access shall exist."
+Describe "CISA ScubaGear MS.AAD.2.1v1" -Tag "CISA", "Security", "All" {
+    It "MS.AAD.2.1v1: Users detected as high risk SHALL be blocked." {
+        Test-MtCisaLegacyAuth | Should -Be $true -Because "an enabled policy for all users blocking high risk logins shall exist."
     }
 }

--- a/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
+++ b/tests/CISA/Test-MtCisaBlockHighRisk.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA ScubaGear MS.AAD.2.1v1" -Tag "CISA", "Security", "All" {
     It "MS.AAD.2.1v1: Users detected as high risk SHALL be blocked." {
-        Test-MtCisaLegacyAuth | Should -Be $true -Because "an enabled policy for all users blocking high risk logins shall exist."
+        Test-MtCisaBlockHighRisk | Should -Be $true -Because "an enabled policy for all users blocking high risk logins shall exist."
     }
 }

--- a/tests/CISA/Test-MtCisaNotifyHighRisk.Tests.ps1
+++ b/tests/CISA/Test-MtCisaNotifyHighRisk.Tests.ps1
@@ -1,0 +1,5 @@
+Describe "CISA ScubaGear MS.AAD.2.2v1" -Tag "CISA", "Security", "All" {
+    It "MS.AAD.2.2v1: A notification SHOULD be sent to the administrator when high-risk users are detected." {
+        Test-MtCisaNotifyHighRisk | Should -Be $true -Because "an enabled is a recipient of risky user login notifications."
+    }
+}

--- a/website/docs/sections/permissions.md
+++ b/website/docs/sections/permissions.md
@@ -3,3 +3,4 @@
 - **Reports.Read.All**
 - **DirectoryRecommendations.Read.All**
 - **PrivilegedAccess.Read.AzureAD**
+- **IdentityRiskEvent.Read.All**


### PR DESCRIPTION
Addition of section 2 for ScubaGear controls around risk based policies.

This required an additional scope for identity protection endpoints.