### PR TITLE
Improved admin detection for CA rules

### DIFF
--- a/powershell/public/Test-MtCaDeviceComplianceAdminsExists.ps1
+++ b/powershell/public/Test-MtCaDeviceComplianceAdminsExists.ps1
@@ -64,7 +64,10 @@ See [Require compliant or Microsoft Entra hybrid joined device for administrator
   foreach ($policy in $policies) {
     $PolicyIncludesAllRoles = $true
     $AdministrativeRolesToCheck | ForEach-Object {
-      if ( $_ -notin $policy.conditions.users.includeRoles  ) {
+      if ( ( $_ -notin $policy.conditions.users.includeRoles `
+        -and $policy.conditions.users.includeUsers -ne 'All' ) `
+        -or $_ -in $policy.conditions.users.excludeRoles `
+      ) {
         $PolicyIncludesAllRoles = $false
       }
     }

--- a/powershell/public/Test-MtCaMfaForAdmin.ps1
+++ b/powershell/public/Test-MtCaMfaForAdmin.ps1
@@ -41,7 +41,10 @@ Function Test-MtCaMfaForAdmin {
     foreach ($policy in $policies) {
         $PolicyIncludesAllRoles = $true
         $AdministrativeRolesToCheck | ForEach-Object {
-            if ( $_ -notin $policy.conditions.users.includeRoles  ) {
+            if ( ( $_ -notin $policy.conditions.users.includeRoles `
+              -and $policy.conditions.users.includeUsers -ne 'All' ) `
+              -or $_ -in $policy.conditions.users.excludeRoles `
+            ) {
                 $PolicyIncludesAllRoles = $false
             }
         }


### PR DESCRIPTION
Updates the detection for conditional access rules to include the following logic

the policy must be either scope to specific admin roles or include all users and the admin roles are not excluded from the policy. 