### PR TITLE
Fixed bug for MT.1005 and MT.1027

### DIFF
--- a/powershell/public/Test-MtCaEmergencyAccessExists.ps1
+++ b/powershell/public/Test-MtCaEmergencyAccessExists.ps1
@@ -40,14 +40,16 @@ Function Test-MtCaEmergencyAccessExists {
             $CheckId = $ExcludedUserObjectGUID
         }
         # Get displayName of the emergency access account or group
-        if ($EmergencyAccessUUIDType -eq "user") {
-            $DisplayName = Invoke-MtGraphRequest -RelativeUri "users/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
-        } else {
-            $DisplayName = Invoke-MtGraphRequest -RelativeUri "groups/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
-        }
+        if ($CheckId) {
+            if ($EmergencyAccessUUIDType -eq "user") {
+                $DisplayName = Invoke-MtGraphRequest -RelativeUri "users/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
+            } else {
+                $DisplayName = Invoke-MtGraphRequest -RelativeUri "groups/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
+            }
 
-        Write-Verbose "Emergency access account or group: $CheckId"
-        $testResult = "Automatically detected emergency access $($EmergencyAccessUUIDType): $DisplayName ($CheckId)`n`n"
+            Write-Verbose "Emergency access account or group: $CheckId"
+            $testResult = "Automatically detected emergency access $($EmergencyAccessUUIDType): $DisplayName ($CheckId)`n`n"
+        }
 
         $policiesWithoutEmergency = $policies | Where-Object { $CheckId -notin $_.conditions.users.excludeUsers -and $CheckId -notin $_.conditions.users.excludeGroups }
 

--- a/powershell/public/Test-MtPrivPermanentDirectoryRole.ps1
+++ b/powershell/public/Test-MtPrivPermanentDirectoryRole.ps1
@@ -65,11 +65,14 @@ Learn more about the best practices for privileges users:
         $PrincipalWithSpSecret = ($DirectAssignments.principal | Where-Object { $_.principal.servicePrincipalType -eq "Application" -and $null -ne $_.principal.passwordCredentials } ).appId
 
         # Check if any Service Principal with App Registration has a Client secret
-        $PrincipalWithAppSecret = ($PrivilegedAppIds | ForEach-Object { Invoke-MtGraphRequest "applications(appId='$($_)')" -ApiVersion beta } | Where-Object { $null -ne $_.passwordCredentials }).appId
+        If ($PrivilegedAppIds) {
+          $PrincipalWithAppSecret = ($PrivilegedAppIds | ForEach-Object { Invoke-MtGraphRequest "applications(appId='$($_)')" -ApiVersion beta } | Where-Object { $null -ne $_.passwordCredentials }).appId
+        }
         # Return results filters Privileged Assignments with Client Secret
-        $PrincipalWithSecrets = @()
         $PrincipalWithSecrets = $PrincipalWithSpSecret + $PrincipalWithAppSecret
-        $DirectAssignments | Where-Object { $_.Principal.AppId -in $PrincipalWithSecrets }
+        If ($PrincipalWithSecrets) {
+          $DirectAssignments | Where-Object { $_.Principal.AppId -in $PrincipalWithSecrets }
+        }
 
         $testDescription = "
 Review your Service Principals with Client Secrets and $($FilteredAccessLevel) privileges.


### PR DESCRIPTION
### MT.1005: Fix automatically detection of emergency access when no excluded users or groups exists in any conditional access policies

https://github.com/maester365/maester/issues/20#issuecomment-2071777707

### MT.1027: Fixed bug if no Service Principals with App Registrations exists, which causes the test to fail.

Below will return 'Bad Request' if '$PrivilegedAppIds' is null.
```powershell
$PrincipalWithAppSecret = ($PrivilegedAppIds | ForEach-Object { Invoke-MtGraphRequest "applications(appId='$($_)')" -ApiVersion beta } | Where-Object { $null -ne $_.passwordCredentials }).appId
```
Fixed by checking if '$PrivilegedAppIds' has a value.
```powershell
If ($PrivilegedAppIds) {
  $PrincipalWithAppSecret = ($PrivilegedAppIds | ForEach-Object { Invoke-MtGraphRequest "applications(appId='$($_)')" -ApiVersion beta } | Where-Object { $null -ne $_.passwordCredentials }).appId
}
```

Below will return the values of '$DirectAssignments' because '$_.Principal.AppId' does not exist and '$PrincipalWithSecrets' is null, which results in 'Where-Object' to find where 'null' is equal to 'null'.
```powershell
$DirectAssignments | Where-Object { $_.Principal.AppId -in $PrincipalWithSecrets }
```
Fixed by checking if '$PrincipalWithSecrets' has a value.
```powershell
If ($PrincipalWithSecrets) {
  $DirectAssignments | Where-Object { $_.Principal.AppId -in $PrincipalWithSecrets }
}
```