### PR TITLE
Support spaces in "${workspaceFolder}" and point towards "Maester.psd1"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,13 @@
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
+  "version": "0.2.1",
   "configurations": [
     {
       "name": "PowerShell: Module Interactive Session",
       "type": "PowerShell",
       "request": "launch",
-      "script": "Import-Module -Force ${workspaceFolder}/powershell/Maester.psm1"
+      "script": "Import-Module -Force '${workspaceFolder}/powershell/Maester.psd1'"
     }
   ]
 }


### PR DESCRIPTION
Support spaces in "${workspaceFolder}" and point towards "Maester.psd1" to load correct module version in VSCode instance instead of version "0.0" and thus receiving a warning when invoking Maester.