### PR TITLE
National Cloud Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Connect-Maester
 Invoke-Maester
 ```
 
+### Running Maester in a Nation Cloud Environment
+
+An optional parameter, `-Environment`, can be utilized to specify the name of the national cloud environment to connect to. By default global cloud is used.
+
+Allowed values include:
+
+- Global (default, if parameter is not specified)
+- China
+- Germany
+- USGov
+- USGovDOD
+
+```powershell
+Connect-Maester -Environment USGov
+```
+
+
 ## Keeping your Maester tests up to date
 
 The Maester team will add new tests over time. To get the latest updates, use the commands below to update this folder with the latest tests.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Connect-Maester
 Invoke-Maester
 ```
 
-### Running Maester in a Nation Cloud Environment
+### Running Maester in a National Cloud Environment
 
-An optional parameter, `-Environment`, can be utilized to specify the name of the national cloud environment to connect to. By default global cloud is used.
+An optional parameter, `-Environment`, can be utilized on `Connect-Maester` to specify the name of the national cloud environment to connect to. By default global cloud is used.
 
 Allowed values include:
 

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -21,9 +21,12 @@ Function Connect-Maester {
       # If specified, the cmdlet will include the scope to send email (Mail.Send).
       [switch] $SendMail,
 
-      [switch] $UseDeviceCode
+      [switch] $UseDeviceCode,
+
+      [ValidateSet("China", "Germany", "Global", "USGov", "USGovDOD")]
+      [string]$Environment = $Global
    )
 
    Write-Verbose "Connecting to Microsoft Graph"
-   Connect-MgGraph -Scopes (Get-MtGraphScope -SendMail:$SendMail) -NoWelcome -UseDeviceCode:$UseDeviceCode
+   Connect-MgGraph -Scopes (Get-MtGraphScope -SendMail:$SendMail) -NoWelcome -UseDeviceCode:$UseDeviceCode -Environment $Environment
 }


### PR DESCRIPTION
# Overview
Added Support for National Clouds

## Details:

### Connect-Maester:
- Adds a parameter named `Environment` to `Connect-Maester`, with the following options:
  - **Global** (default, if parameter is not specified)
  - China
  - Germany
  - USGov
  - USGovDOD
 
These mirror the options for the `Environment` parameter in `Connect-MgGraph`.

### Readme:
- Adds details on using `-Environment` parameter

## Testing
This was tested successfully against a `USGov` tenant.