### PR TITLE
feat: use the domain name of the help link in the report

### DIFF
--- a/report/src/components/ResultInfoDialog.jsx
+++ b/report/src/components/ResultInfoDialog.jsx
@@ -87,7 +87,7 @@ export default function ResultInfoDialog(props) {
             {props.Item.HelpUrl &&
               <div className="text-left mt-2">
                 <Button icon={ArrowTopRightOnSquareIcon} variant="light" onClick={() => openInNewTab(props.Item.HelpUrl)}>
-                  Learn more @ maester.dev
+                  Learn more @ {new URL(props.Item.HelpUrl).hostname}
                 </Button>
               </div>
             }


### PR DESCRIPTION
Minor change, we've been using `See https://our.docs.system/path/to/article/on/test` to give more info on the tests that we are running. The link was hard corded to say `Learn more @ maester.dev` This PR changes it so that it uses the hostname in the URL, so `Learn more @ our.docs.system`.