### PR TITLE
MSGraph connection check bypass

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -127,7 +127,11 @@ Function Invoke-Maester {
 
         # The user id of the sender of the mail. Defaults to the current user.
         # This is required when using application permissions.
-        [string] $MailUserId
+        [string] $MailUserId,
+
+        # Skip the graph connection check.
+        # This is used for running tests that does not require a graph connection.
+        [switch] $SkipGraphConnect
     )
 
     function GetDefaultFileName() {
@@ -212,7 +216,12 @@ Function Invoke-Maester {
     Clear-ModuleVariable # Reset the graph cache and urls to avoid stale data
 
     $isMail = $null -ne $MailRecipient
-    if (!(Test-MtContext -SendMail:$isMail)) { return }
+
+    if ($SkipGraphConnect) {
+        Write-Host "🔥 Skipping graph connection check" -ForegroundColor Yellow
+    } else {
+        if (!(Test-MtContext -SendMail:$isMail)) { return }
+    }
 
     $out = [PSCustomObject]@{
         OutputFolder         = $OutputFolder

--- a/website/docs/commands/Invoke-Maester.mdx
+++ b/website/docs/commands/Invoke-Maester.mdx
@@ -19,7 +19,7 @@ Invoke-Maester [[-Path] <String>] [-Tag <String[]>] [-ExcludeTag <String[]>] [-O
  [-OutputMarkdownFile <String>] [-OutputJsonFile <String>] [-OutputFolder <String>]
  [-OutputFolderFileName <String>] [-PesterConfiguration <PesterConfiguration>] [-Verbosity <String>]
  [-NonInteractive] [-PassThru] [-MailRecipient <String[]>] [-MailTestResultsUri <String>]
- [-MailUserId <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-MailUserId <String>] [-ProgressAction <ActionPreference>] [-SkipGraphConnect <Switch>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -397,6 +397,22 @@ Aliases: proga
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipGraphConnect
+
+This switch allows you to bypass the Microsoft Graph connection check.
+
+```yaml
+Type: Switch
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
This adds the option to bypass the graph connection per #162 

It simply adds an extra switch param of ```SkipGraphConnect``` to ```invoke-maester``` and then puts the ```Test-MtContext``` behind an if statement. Tested locally.

I've also updated the cmdlets document too.

Please let me know if you expected something else