### PR TITLE
Add 'Policy.Read.ConditionalAccess' graph scope

### DIFF
--- a/powershell/public/Get-MtGraphScope.ps1
+++ b/powershell/public/Get-MtGraphScope.ps1
@@ -41,6 +41,7 @@ Function Get-MtGraphScope {
         'PrivilegedAccess.Read.AzureAD'
         'IdentityRiskEvent.Read.All'
         'RoleEligibilitySchedule.Read.Directory'
+        'Policy.Read.ConditionalAccess'
     )
 
     if ($SendMail) {


### PR DESCRIPTION
This pull request adds the 'Policy.Read.ConditionalAccess' graph scope to the existing list of graph scopes in the Get-MtGraphScope function. This scope is required for accessing conditional access policies in Entra ID and the WhatIf/evaluate Graph Endpoint