### PR TITLE
Docs: Add 'Policy.Read.ConditionalAccess' scope

### DIFF
--- a/website/docs/sections/permissions.md
+++ b/website/docs/sections/permissions.md
@@ -5,3 +5,4 @@
 - **PrivilegedAccess.Read.AzureAD**
 - **IdentityRiskEvent.Read.All**
 - **RoleEligibilitySchedule.Read.Directory**
+- **Policy.Read.ConditionalAccess**


### PR DESCRIPTION
## Context

I'm currently setting up Maester to run in a DevOps pipeline.
I followed [the documentation](https://maester.dev/docs/monitoring/azure-devops/#grant-permissions-to-microsoft-graph) to grant permissions to the Microsoft Graph and got this error:
```
     | These Graph permissions are missing in the current connection =>
     | (Policy.Read.ConditionalAccess). Add the missing 'Application'
     | permissions in the Microsoft Entra portal and grant consent. You will
     | also need to Disconnect-Graph to refresh the permissions
```

I added the `Policy.Read.ConditionalAccess` permission and it worked.

After searching for related issues here, I saw the `Get-MtGraphScope` function had recently been updated to add this permission, but AFAICT the documentation hasn't been updated yet: https://github.com/maester365/maester/pull/178

## Proposed Changes

- Update the documentation to reflect the updated permissions required for the Microsoft Graph app.

I hope this helps!