### PR TITLE
Fix#194

### DIFF
--- a/powershell/public/CISA/Entra/Test-MtCisaManagedDevice.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaManagedDevice.ps1
@@ -15,22 +15,34 @@
 Function Test-MtCisaManagedDevice {
     [CmdletBinding()]
     [OutputType([bool])]
-    param()
+    param(
+        [switch]$SkipHybridJoinCheck
+    )
 
     $result = Get-MtConditionalAccessPolicy
 
-    $policies = $result | Where-Object {`
-        $_.state -eq "enabled" -and `
-        $_.conditions.applications.includeApplications -contains "All" -and `
-        $_.conditions.users.includeUsers -contains "All" -and `
-        $_.grantControls.builtInControls -contains "compliantDevice" -and `
-        $_.grantControls.builtInControls -contains "domainJoinedDevice" -and `
-        $_.grantControls.operator -eq "OR" }
+    if($SkipHybridJoinCheck){
+        $policies = $result | Where-Object {`
+            $_.state -eq "enabled" -and `
+            $_.conditions.applications.includeApplications -contains "All" -and `
+            $_.conditions.users.includeUsers -contains "All" -and `
+            $_.grantControls.builtInControls -contains "compliantDevice" }
+    }else{
+        $policies = $result | Where-Object {`
+            $_.state -eq "enabled" -and `
+            $_.conditions.applications.includeApplications -contains "All" -and `
+            $_.conditions.users.includeUsers -contains "All" -and `
+            $_.grantControls.builtInControls -contains "compliantDevice" -and `
+            $_.grantControls.builtInControls -contains "domainJoinedDevice" -and `
+            $_.grantControls.operator -eq "OR" }
+    }
 
     $testResult = $policies.Count -ge 1
 
-    if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require managed devices:`n`n%TestResult%"
+    if ($testResult -and $SkipHybridJoinCheck) {
+        $testResultMarkdown = "Well done, your security posture is more than CISA's control. Your tenant has one or more policies that require a compliant device:`n`n%TestResult%"
+    } elseif ($testResult) {
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device:`n`n%TestResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that require managed devices."
     }

--- a/powershell/public/CISA/Entra/Test-MtCisaManagedDevice.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaManagedDevice.ps1
@@ -40,7 +40,7 @@ Function Test-MtCisaManagedDevice {
     $testResult = $policies.Count -ge 1
 
     if ($testResult -and $SkipHybridJoinCheck) {
-        $testResultMarkdown = "Well done, your security posture is more than CISA's control. Your tenant has one or more policies that require a compliant device:`n`n%TestResult%"
+        $testResultMarkdown = "Well done, your security posture is more than CISA's recommended control. Your tenant has one or more policies that require a compliant device:`n`n%TestResult%"
     } elseif ($testResult) {
         $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device:`n`n%TestResult%"
     } else {

--- a/powershell/public/CISA/Entra/Test-MtCisaManagedDeviceRegistration.ps1
+++ b/powershell/public/CISA/Entra/Test-MtCisaManagedDeviceRegistration.ps1
@@ -15,24 +15,36 @@
 Function Test-MtCisaManagedDeviceRegistration {
     [CmdletBinding()]
     [OutputType([bool])]
-    param()
+    param(
+        [switch]$SkipHybridJoinCheck
+    )
 
     $result = Get-MtConditionalAccessPolicy
 
-    $policies = $result | Where-Object {`
-        $_.state -eq "enabled" -and `
-        $_.conditions.users.includeUsers -contains "All" -and `
-        $_.conditions.applications.includeUserActions -contains "urn:user:registersecurityinfo" -and `
-        $_.grantControls.builtInControls -contains "compliantDevice" -and `
-        $_.grantControls.builtInControls -contains "domainJoinedDevice" -and `
-        $_.grantControls.operator -eq "OR" }
+    if($SkipHybridJoinCheck){
+        $policies = $result | Where-Object {`
+            $_.state -eq "enabled" -and `
+            $_.conditions.applications.includeUserActions -contains "urn:user:registersecurityinfo" -and `
+            $_.conditions.users.includeUsers -contains "All" -and `
+            $_.grantControls.builtInControls -contains "compliantDevice" }
+    }else{
+        $policies = $result | Where-Object {`
+            $_.state -eq "enabled" -and `
+            $_.conditions.applications.includeUserActions -contains "urn:user:registersecurityinfo" -and `
+            $_.conditions.users.includeUsers -contains "All" -and `
+            $_.grantControls.builtInControls -contains "compliantDevice" -and `
+            $_.grantControls.builtInControls -contains "domainJoinedDevice" -and `
+            $_.grantControls.operator -eq "OR" }
+    }
 
     $testResult = $policies.Count -ge 1
 
-    if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require managed devices for registration:`n`n%TestResult%"
+    if ($testResult -and $SkipHybridJoinCheck) {
+        $testResultMarkdown = "Well done, your security posture is more than CISA's recommended control. Your tenant has one or more policies that require a compliant device for registration:`n`n%TestResult%"
+    } elseif ($testResult) {
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device for registration:`n`n%TestResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have any conditional access policies that requires managed devices for registration."
+        $testResultMarkdown = "Your tenant does not have any conditional access policies that require managed devices for registration."
     }
     Add-MtTestResultDetail -Result $testResultMarkdown -GraphObjectType ConditionalAccess -GraphObjects $policies
 

--- a/tests/CISA/Entra/Test-MtCisaManagedDevice.Tests.ps1
+++ b/tests/CISA/Entra/Test-MtCisaManagedDevice.Tests.ps1
@@ -4,6 +4,11 @@ BeforeDiscovery {
 
 Describe "CISA SCuBA" -Tag "MS.AAD", "MS.AAD.3.7", "CISA", "Security", "All" -Skip:( $EntraIDPlan -eq "Free" ) {
     It "MS.AAD.3.7: Managed devices SHOULD be required for authentication." {
-        Test-MtCisaManagedDevice | Should -Be $true -Because "a policy requires managed devices."
+        $result = Test-MtCisaManagedDevice
+        if($result){
+            $result | Should -Be $true -Because "a policy requires compliant or domain joined devices."
+        }else{
+            Test-MtCisaManagedDevice -SkipHybridJoinCheck | Should -Be $true -Because "a policy requires compliant devices."
+        }
     }
 }

--- a/tests/CISA/Entra/Test-MtCisaManagedDeviceRegistration.Tests.ps1
+++ b/tests/CISA/Entra/Test-MtCisaManagedDeviceRegistration.Tests.ps1
@@ -4,6 +4,11 @@ BeforeDiscovery {
 
 Describe "CISA SCuBA" -Tag "MS.AAD", "MS.AAD.3.8", "CISA", "Security", "All" -Skip:( $EntraIDPlan -eq "Free" ) {
     It "MS.AAD.3.8: Managed Devices SHOULD be required to register MFA." {
-        Test-MtCisaManagedDeviceRegistration | Should -Be $true -Because "a policy requires managed devices for registration."
+        $result = Test-MtCisaManagedDeviceRegistration
+        if($result){
+            $result | Should -Be $true -Because "a policy requires compliant or domain joined devices for registration."
+        }else{
+            Test-MtCisaManagedDeviceRegistration -SkipHybridJoinCheck | Should -Be $true -Because "a policy requires compliant devices for registration."
+        }
     }
 }


### PR DESCRIPTION
This is to add the bypass for a compliant device exclusively rather than requiring compliant device OR hybrid joined referenced in #194.

There may be a better way to handle the Pester logic, but this seemed to work as an initial pass.