### PR TITLE
Support for additional should operators in EIDSCA tests

### DIFF
--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -41,7 +41,7 @@ Function GetVersion($graphUri) {
 }
 
 Function GetRecommendedValue($RecommendedValue) {
-    $compareOperators = @(">",">=","<")
+    $compareOperators = @(">=",">","<")
     foreach ($compareOperator in $compareOperators) {
         if ($RecommendedValue.StartsWith($compareOperator)) {
             $RecommendedValue = $RecommendedValue.Replace($compareOperator, "")
@@ -51,21 +51,20 @@ Function GetRecommendedValue($RecommendedValue) {
 }
 
 Function GetCompareOperator($RecommendedValue) {
-    if ($RecommendedValue.StartsWith(">")) {
-        $compareOperator = [PSCustomObject]@{
-            name       = '>'
-            pester     = 'BeGreaterThan'
-            powershell = 'gt'
-            text       = 'is greater than'
-        }
-    } elseif ($RecommendedValue.StartsWith(">=")) {
+    if ($RecommendedValue.StartsWith(">=")) {
         $compareOperator = [PSCustomObject]@{
             name       = '>='
             pester     = 'BeGreaterOrEqual'
             powershell = 'ge'
             text       = 'is greater than or equal to'
         }
-        $compareOperator = "BeGreaterOrEqual"
+    } elseif ($RecommendedValue.StartsWith(">")) {
+        $compareOperator = [PSCustomObject]@{
+            name       = '>'
+            pester     = 'BeGreaterThan'
+            powershell = 'gt'
+            text       = 'is greater than'
+        }
     } elseif ($RecommendedValue.StartsWith("<")) {
         $compareOperator = [PSCustomObject]@{
             name       = '<'

--- a/powershell/public/eidsca/@template.md
+++ b/powershell/public/eidsca/@template.md
@@ -5,7 +5,7 @@
 #### Test script
 ```
 https://graph.microsoft.com/%ApiVersion%/%RelativeUri%
-.%CurrentValue% = %RecommendedValue%
+.%CurrentValue% %CompareOperator% %RecommendedValue%
 ```
 
 #### Related links

--- a/powershell/public/eidsca/@templateps1.txt
+++ b/powershell/public/eidsca/@templateps1.txt
@@ -8,12 +8,12 @@
 
     Queries %RelativeUri%
     and returns the result of
-     graph/%RelativeUri%.%CurrentValue% -eq %RecommendedValue%
+     graph/%RelativeUri%.%CurrentValue% -%PwshCompareOperator% %RecommendedValue%
 
 .EXAMPLE
     %PSFunctionName%
 
-    Returns the result of graph.microsoft.com/beta/%RelativeUri%.%CurrentValue% -eq %RecommendedValue%
+    Returns the result of graph.microsoft.com/beta/%RelativeUri%.%CurrentValue% -%PwshCompareOperator% %RecommendedValue%
 #>
 
 Function %PSFunctionName% {
@@ -24,12 +24,12 @@ Function %PSFunctionName% {
     $result = Invoke-MtGraphRequest -RelativeUri "%RelativeUri%" -ApiVersion %ApiVersion%
 
     [string]$tenantValue = $result.%CurrentValue%
-    $testResult = $tenantValue -eq %RecommendedValue%
+    $testResult = $tenantValue -%PwshCompareOperator% %RecommendedValue%
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **%RecommendedValue%** for **%RelativeUri%**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value %CompareOperatorText% **%RecommendedValue%** for **%RelativeUri%**"
     } else {
-        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **%RecommendedValue%** for **%RelativeUri%**"
+        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value %CompareOperatorText% **%RecommendedValue%** for **%RelativeUri%**"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/eidsca/Test-MtEidscaAF01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAF01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAF01 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAF02.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAF02.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAF02 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAF03.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAF03.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAF03 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAF04.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAF04.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAF04 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAF05.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAF05.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAF05 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAF06.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAF06.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAF06 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAG01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAG01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAG01 {
     $testResult = $tenantValue -eq 'migrationComplete'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'migrationComplete'** for **policies/authenticationMethodsPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'migrationComplete'** for **policies/authenticationMethodsPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'migrationComplete'** for **policies/authenticationMethodsPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAG02.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAG02.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAG02 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAG03.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAG03.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAG03 {
     $testResult = $tenantValue -eq 'all_users'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'all_users'** for **policies/authenticationMethodsPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'all_users'** for **policies/authenticationMethodsPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM01 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM02.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM02.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM02 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM03.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM03.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM03 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM04.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM04.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM04 {
     $testResult = $tenantValue -eq 'all_users'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM06.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM06.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM06 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM07.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM07.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM07 {
     $testResult = $tenantValue -eq 'all_users'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM09.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM09.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM09 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAM10.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAM10.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAM10 {
     $testResult = $tenantValue -eq 'all_users'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP01 {
     $testResult = $tenantValue -eq 'false'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'false'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP04.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP04.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP04 {
     $testResult = $tenantValue -eq 'adminsAndGuestInviters'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'adminsAndGuestInviters'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'adminsAndGuestInviters'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'adminsAndGuestInviters'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP05.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP05.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP05 {
     $testResult = $tenantValue -eq 'false'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'false'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP06.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP06.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP06 {
     $testResult = $tenantValue -eq 'false'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'false'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP07.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP07.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP07 {
     $testResult = $tenantValue -eq '2af84b1e-32c8-42b7-82bc-daa82404023b'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'2af84b1e-32c8-42b7-82bc-daa82404023b'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'2af84b1e-32c8-42b7-82bc-daa82404023b'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'2af84b1e-32c8-42b7-82bc-daa82404023b'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP08.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP08 {
     $testResult = $tenantValue -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'ManagePermissionGrantsForSelf.microsoft-user-default-low'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'ManagePermissionGrantsForSelf.microsoft-user-default-low'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'ManagePermissionGrantsForSelf.microsoft-user-default-low'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP09.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP09.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP09 {
     $testResult = $tenantValue -eq 'false'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'false'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP10.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP10.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP10 {
     $testResult = $tenantValue -eq 'false'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'false'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAP14.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP14.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAP14 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authorizationPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authorizationPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAT01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAT01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAT01 {
     $testResult = $tenantValue -eq 'enabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAT02.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAT02.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAT02 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaAV01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAV01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaAV01 {
     $testResult = $tenantValue -eq 'disabled'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'disabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'disabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'disabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCP01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCP01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCP01 {
     $testResult = $tenantValue -eq 'False'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'False'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'False'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'False'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCP03.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCP03.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCP03 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCP04.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCP04.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCP04 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCR01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCR01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCR01 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/adminConsentRequestPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/adminConsentRequestPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/adminConsentRequestPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCR02.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCR02.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCR02 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/adminConsentRequestPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/adminConsentRequestPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/adminConsentRequestPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCR03.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCR03.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCR03 {
     $testResult = $tenantValue -eq 'true'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'true'** for **policies/adminConsentRequestPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/adminConsentRequestPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'true'** for **policies/adminConsentRequestPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaCR04.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaCR04.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaCR04 {
     $testResult = $tenantValue -eq '30'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'30'** for **policies/adminConsentRequestPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'30'** for **policies/adminConsentRequestPolicy**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'30'** for **policies/adminConsentRequestPolicy**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaPR01.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaPR01.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaPR01 {
     $testResult = $tenantValue -eq 'Enforce'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'Enforce'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'Enforce'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'Enforce'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaPR02.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaPR02.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaPR02 {
     $testResult = $tenantValue -eq 'True'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'True'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'True'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'True'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaPR03.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaPR03.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaPR03 {
     $testResult = $tenantValue -eq 'True'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'True'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'True'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'True'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaPR05.md
+++ b/powershell/public/eidsca/Test-MtEidscaPR05.md
@@ -5,7 +5,7 @@ The minimum length in seconds of each lockout. If an account locks repeatedly, t
 #### Test script
 ```
 https://graph.microsoft.com/beta/settings
-.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value = '60'
+.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value > '60'
 ```
 
 #### Related links

--- a/powershell/public/eidsca/Test-MtEidscaPR05.md
+++ b/powershell/public/eidsca/Test-MtEidscaPR05.md
@@ -5,7 +5,7 @@ The minimum length in seconds of each lockout. If an account locks repeatedly, t
 #### Test script
 ```
 https://graph.microsoft.com/beta/settings
-.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value > '60'
+.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value >= '60'
 ```
 
 #### Related links

--- a/powershell/public/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaPR05.ps1
@@ -8,12 +8,12 @@
 
     Queries settings
     and returns the result of
-     graph/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -eq '60'
+     graph/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -gt '60'
 
 .EXAMPLE
     Test-MtEidscaPR05
 
-    Returns the result of graph.microsoft.com/beta/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -eq '60'
+    Returns the result of graph.microsoft.com/beta/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -gt '60'
 #>
 
 Function Test-MtEidscaPR05 {
@@ -24,12 +24,12 @@ Function Test-MtEidscaPR05 {
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value
-    $testResult = $tenantValue -eq '60'
+    $testResult = $tenantValue -gt '60'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'60'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is greater than **'60'** for **settings**"
     } else {
-        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'60'** for **settings**"
+        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is greater than **'60'** for **settings**"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaPR05.ps1
@@ -8,12 +8,12 @@
 
     Queries settings
     and returns the result of
-     graph/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -gt '60'
+     graph/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -ge '60'
 
 .EXAMPLE
     Test-MtEidscaPR05
 
-    Returns the result of graph.microsoft.com/beta/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -gt '60'
+    Returns the result of graph.microsoft.com/beta/settings.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -ge '60'
 #>
 
 Function Test-MtEidscaPR05 {
@@ -24,12 +24,12 @@ Function Test-MtEidscaPR05 {
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value
-    $testResult = $tenantValue -gt '60'
+    $testResult = $tenantValue -ge '60'
 
     if($testResult){
-        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is greater than **'60'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is greater than or equal to **'60'** for **settings**"
     } else {
-        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is greater than **'60'** for **settings**"
+        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is greater than or equal to **'60'** for **settings**"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaPR06.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaPR06 {
     $testResult = $tenantValue -eq '10'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'10'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'10'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'10'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaST08.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaST08.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaST08 {
     $testResult = $tenantValue -eq 'false'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'false'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **settings**"
     }

--- a/powershell/public/eidsca/Test-MtEidscaST09.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaST09.ps1
@@ -27,7 +27,7 @@ Function Test-MtEidscaST09 {
     $testResult = $tenantValue -eq 'True'
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant has the recommended value of **'True'** for **settings**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'True'** for **settings**"
     } else {
         $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'True'** for **settings**"
     }

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -145,7 +145,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value = '60'
         #>
-        Test-MtEidscaPR05 | Should -Be '60'
+        Test-MtEidscaPR05 | Should -BeGreaterThan '60'
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR06" {

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -143,7 +143,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
-            .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value = '60'
+            .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value > '60'
         #>
         Test-MtEidscaPR05 | Should -BeGreaterThan '60'
     }

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -143,9 +143,9 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
-            .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value > '60'
+            .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value >= '60'
         #>
-        Test-MtEidscaPR05 | Should -BeGreaterThan '60'
+        Test-MtEidscaPR05 | Should -BeGreaterOrEqual '60'
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR06" {


### PR DESCRIPTION
For some checks, it is not an option to compare a unique value (`Should -be`). Therefore, I've added support for other should operators (e.g., BeGreaterThan). This change requires to change some parts of the code around comparison to allow different operators (e.g., PowerShell operators with hard-coded `-eq` or generated description in the text).

This enhancement will resolve the following issue:
https://github.com/maester365/maester/issues/118