### PR TITLE
Switch cmdlet to use count of Measure-Object rather than PSCustomObject

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.ps1
@@ -26,7 +26,7 @@ Function Test-MtCisaBlockLegacyAuth {
             $_.conditions.clientAppTypes -contains "other" -and `
             $_.conditions.users.includeUsers -contains "All" }
 
-    $testResult = $blockPolicies.Count -ge 1
+    $testResult = ($blockPolicies|Measure-Object).Count -ge 1
 
     if ($testResult) {
         $testResultMarkdown = "Your tenant has one or more policies that block legacy authentication:`n`n%TestResult%"


### PR DESCRIPTION
This is a potential fix to #212. If this does resolve the issue then refactoring the other cmdlets will be necessary for backwards compatibility.