### PR TITLE
fix: bump checkout to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,13 @@ runs:
 
     - name: Checkout latest public tests
       if: ${{ inputs.include_public_tests == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: maester365/maester-tests
         path: public-tests
 
     - name: Checkout latest private tests
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: private-tests
 


### PR DESCRIPTION
Minor change, the GitHub Action (which is great btw) uses actions/checkout@v3 which uses Node 16, bumping to v4 uses Node 20 which fixes this deprecation.
