### PR TITLE
Fix handling of `Invoke-Maester` `Output*` params

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -142,7 +142,7 @@ Function Invoke-Maester {
     function ValidateAndSetOutputFiles($out) {
         $result = $null
         if (![string]::IsNullOrEmpty($out.OutputHtmlFile)) {
-            if ($out.OutputFile.EndsWith(".html") -eq $false) {
+            if ($out.OutputHtmlFile.EndsWith(".html") -eq $false) {
                 $result = "The OutputHtmlFile parameter must have an .html extension."
             }
         }
@@ -156,9 +156,11 @@ Function Invoke-Maester {
                 $result = "The OutputJsonFile parameter must have a .json extension."
             }
         }
-        if ([string]::IsNullOrEmpty($out.OutputFolder) -or `
-            (!$PassThru -and [string]::IsNullOrEmpty($out.OutputFolder) -and [string]::IsNullOrEmpty($out.OutputHtmlFile) `
-                    -and [string]::IsNullOrEmpty($out.OutputMarkdownFile) -and [string]::IsNullOrEmpty($out.OutputJsonFile))) {
+
+        $someOutputFileHasValue = ![string]::IsNullOrEmpty($out.OutputHtmlFile) -or `
+            ![string]::IsNullOrEmpty($out.OutputMarkdownFile) -or ![string]::IsNullOrEmpty($out.OutputJsonFile)
+
+        if ([string]::IsNullOrEmpty($out.OutputFolder) -and !$someOutputFileHasValue) {
             # No outputs specified. Set default folder.
             $out.OutputFolder = "./test-results"
         }


### PR DESCRIPTION
This pull request fixes the handling of `Output*` parameters in the `Invoke-Maester` function. There were 2 issues identified:

1. The `$out.OutputHtmlFile` property, was incorrectly referenced in `ValidateAndSetOutputFiles`. Prior to this change, the script referenced an invalid member `$out.OutputFile`. It was updated to the correct member reference of `$out.OutputHtmlFile` 

2. The conditional logic in `ValidateAndSetOutputFiles` now checks that _if and only if_ all the following are true:

   1. `OutputFolder` is null or empty
   2. `OutputJsonFile`, `OutputHtmlFile` and `OutputMarkdownFile` are all null or empty

   then the value of `OutputFolder` will be set to `./test-results`, in accordance with the docs: https://maester.dev/docs/commands/Invoke-Maester#-outputfolder. Checking `$PassThru` is inconsequential and was removed from the conditional logic because either way, files will be output to the file system.
   
Resolves #278 