### PR TITLE
Enhance mt.1024 entra recommendations

### DIFF
--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeDiscovery {
     $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
-    $EntraRecommendations = Invoke-MtGraphRequest -DisableCache -ApiVersion beta -RelativeUri 'directory/recommendations' -OutputType Hashtable
+    $EntraRecommendations = Invoke-MtGraphRequest -DisableCache -ApiVersion beta -RelativeUri 'directory/recommendations?$expand=impactedResources' -OutputType Hashtable
     Write-Verbose "Found $($EntraRecommendations.Count) Entra recommendations"
 }
 
@@ -9,7 +9,19 @@ Describe "Entra Recommendations" -Tag "Entra", "Security", "All", "Recommendatio
         #region Add detailed test description
         $ActionSteps = $actionSteps | Sort-Object -Property 'stepNumber' | Select-Object -ExpandProperty text -EA SilentlyContinue
         $ActionSteps = $ActionSteps -join "`n`n"
-        $ResultMarkdown = $insights + "`n`nRemediation actions:`n`n" + $ActionSteps
+        if ($status -ne 'completedBySystem' -and $impactedResources) {
+            $impactedResourcesList = "`n`n#### Impacted resources`n`n | Status | Name | First detected| `n"
+            $impactedResourcesList += "| --- | --- | --- |`n"
+            foreach ($resource in $impactedResources) {
+                if ($resource.status -eq 'completedBySystem') {
+                    $resourceResult = "✅ Pass"
+                } else {
+                    $resourceResult = "❌ Fail"
+                }
+                $impactedResourcesList += "| $($resourceResult) | [$($resource.displayName)]($($resource.portalUrl)) | $($resource.addedDateTime) | `n"
+            }
+        }
+        $ResultMarkdown = $insights + $impactedResourcesList + "`n`n#### Remediation actions:`n`n" + $ActionSteps
         Add-MtTestResultDetail -Description $benefits -Result $ResultMarkdown
         #endregion
         # Actual test

--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -7,7 +7,9 @@ BeforeDiscovery {
 Describe "Entra Recommendations" -Tag "Entra", "Security", "All", "Recommendation" -ForEach $EntraRecommendations {
     It "MT.1024: Entra Recommendation - <displayName>. See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024" {
         #region Add detailed test description
-        $ActionSteps = $actionSteps | Sort-Object -Property 'stepNumber' | Select-Object -ExpandProperty text -EA SilentlyContinue
+        $ActionSteps = $actionSteps | Sort-Object -Property 'stepNumber' | ForEach-Object {
+            $_.text + "[$($_.actionUrl.displayName)]($($_.actionUrl.url))."
+        }
         $ActionSteps = $ActionSteps -join "`n`n"
         if ($status -ne 'completedBySystem' -and $impactedResources) {
             $impactedResourcesList = "`n`n#### Impacted resources`n`n | Status | Name | First detected| `n"


### PR DESCRIPTION
Partly fixes #189 where Entra Recommendations include impacted resources, however it would seem that user related recommendations does not include users.

This PR includes action URLs into the remediation steps. Some steps ended abruptly because the URL was part of the sentence. It also enhances many other remediation steps with relevant URLs.