### PR TITLE
Improvements to error handling

### DIFF
--- a/powershell/internal/Get-MtSkippedReason.ps1
+++ b/powershell/internal/Get-MtSkippedReason.ps1
@@ -17,6 +17,7 @@ function Get-MtSkippedReason {
         "NotLicensedEntraIDGovernance" { "This test is for tenants that are licensed for Entra ID Governance. See [Entra ID Governance licensing](https://learn.microsoft.com/entra/fundamentals/licensing#microsoft-entra-id-governance)"; break}
         "NotLicensedEntraWorkloadID" { "This test is for tenants that are licensed for Entra Workload ID. See [Entra Workload ID licensing](https://learn.microsoft.com/entra/workload-id/workload-identities-faqs)"; break}
         "LicensedEntraIDPremium" { "This test is for tenants that are not licensed for any Entra ID Premium license. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)"; break}
+        "NotSupported" { "This test relies on capabilities not currently available (e.g., cmdlets that are not available on all platforms, Resolve-DnsName)"; break}
         default { $SkippedBecause; break}
     }
 }

--- a/powershell/public/Add-MtTestResultDetail.ps1
+++ b/powershell/public/Add-MtTestResultDetail.ps1
@@ -63,7 +63,7 @@ Function Add-MtTestResultDetail {
         [string] $TestName = $____Pester.CurrentTest.ExpandedName,
 
         [ValidateSet('NotConnectedAzure', 'NotConnectedExchange', 'NotDotGovDomain', 'NotLicensedEntraIDP1',
-            'NotLicensedEntraIDP2', 'NotLicensedEntraIDGovernance', 'NotLicensedEntraWorkloadID', "LicensedEntraIDPremium"
+            'NotLicensedEntraIDP2', 'NotLicensedEntraIDGovernance', 'NotLicensedEntraWorkloadID', "LicensedEntraIDPremium", "NotSupported"
         )]
         [string] $SkippedBecause
     )

--- a/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordDkim.ps1
+++ b/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordDkim.ps1
@@ -94,10 +94,10 @@ Function ConvertFrom-MailAuthenticationRecordDkim {
                 Where-Object {$_.Type -eq "TXT"} | `
                 Where-Object {$_.Strings -match $matchRecord}).Strings)
         }catch [System.Management.Automation.CommandNotFoundException]{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Unsupported platform, Resolve-DnsName not available"
         }catch{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordDmarc.ps1
+++ b/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordDmarc.ps1
@@ -225,10 +225,10 @@ Function ConvertFrom-MailAuthenticationRecordDmarc {
                 Where-Object {$_.Type -eq "TXT"} | `
                 Where-Object {$_.Strings -match $matchRecord}).Strings)
         }catch [System.Management.Automation.CommandNotFoundException]{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Unsupported platform, Resolve-DnsName not available"
         }catch{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordMx.ps1
+++ b/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordMx.ps1
@@ -40,10 +40,10 @@ Function ConvertFrom-MailAuthenticationRecordMx {
         try{
             $mxRecords = Resolve-DnsName @mxSplat | Where-Object {$_.Type -eq "MX"}
         }catch [System.Management.Automation.CommandNotFoundException]{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Unsupported platform, Resolve-DnsName not available"
         }catch{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordSpf.ps1
+++ b/powershell/public/CISA/exchange/ConvertFrom-MailAuthenticationRecordSpf.ps1
@@ -127,10 +127,10 @@ Function ConvertFrom-MailAuthenticationRecordSpf {
                 Where-Object {$_.Type -eq "TXT"} | `
                 Where-Object {$_.Strings -imatch $matchRecord}).Strings)
         }catch [System.Management.Automation.CommandNotFoundException]{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Unsupported platform, Resolve-DnsName not available"
         }catch{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/CISA/exchange/Get-MailAuthenticationRecord.ps1
+++ b/powershell/public/CISA/exchange/Get-MailAuthenticationRecord.ps1
@@ -89,14 +89,15 @@ Function Get-MailAuthenticationRecord {
                 $recordSet.spfLookups = $mtDnsCache.spfLookups
             }else{
                 $recordSet.spfRecord = ConvertFrom-MailAuthenticationRecordSpf @splat
-                if($recordSet.spfRecord.terms.modifier -contains "redirect"){
-                    Write-Verbose "SPF redirect modifier found, recursing"
-                    $redirect = ($recordSet.spfRecord.terms|Where-Object {`
-                        $_.modifier -eq "redirect"
-                    }).modifierTarget
-                    Get-MailAuthenticationRecord -DomainName $redirect
-                }
-                if($recordSet.spfRecord -ne "Failure to obtain record"){
+                if($recordSet.spfRecord.GetType() -ne "SPFRecord"){
+                    if($recordSet.spfRecord.terms.modifier -contains "redirect"){
+                        Write-Verbose "SPF redirect modifier found, recursing"
+                        $redirect = ($recordSet.spfRecord.terms|Where-Object {`
+                            $_.modifier -eq "redirect"
+                        }).modifierTarget
+                        Get-MailAuthenticationRecord -DomainName $redirect
+                    }
+
                     Write-Verbose "SPF record resolved, checking lookups"
                     if($null -ne $mtDnsCache.spfLookups){
                         Write-Verbose "SPF Lookups records exist in cache - Use Clear-MtDnsCache to reset"

--- a/powershell/public/CISA/exchange/Resolve-SPFRecord.ps1
+++ b/powershell/public/CISA/exchange/Resolve-SPFRecord.ps1
@@ -69,10 +69,10 @@ function Resolve-SPFRecord {
         try{
             $DNSRecords = Resolve-DnsName -Server $Server -Name $Name -Type TXT
         }catch [System.Management.Automation.CommandNotFoundException]{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Unsupported platform, Resolve-DnsName not available"
         }catch{
-            Write-Error $Error[0]
+            Write-Error $_
             return "Failure to obtain record"
         }
         # Check SPF record

--- a/powershell/public/CISA/exchange/Test-MtCisaDmarcAggregateCisa.ps1
+++ b/powershell/public/CISA/exchange/Test-MtCisaDmarcAggregateCisa.ps1
@@ -69,6 +69,9 @@ Function Test-MtCisaDmarcAggregateCisa {
             $dmarcRecord.pass = "Passed"
         }elseif($checkType -and -not $checkTarget){
             $dmarcRecord.reason = "Missing CISA report target"
+        }elseif($dmarcRecord.dmarcRecord -eq "Unsupported platform, Resolve-DnsName not available"){
+            $dmarcRecord.pass = "Skipped"
+            $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }else{
             $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }
@@ -78,6 +81,9 @@ Function Test-MtCisaDmarcAggregateCisa {
 
     if("Failed" -in $dmarcRecords.pass){
         $testResult = $false
+    }elseif("Failed" -notin $dmarcRecords.pass -and "Passed" -notin $dmarcRecords.pass){
+        Add-MtTestResultDetail -SkippedBecause NotSupported
+        return $null
     }else{
         $testResult = $true
     }

--- a/powershell/public/CISA/exchange/Test-MtCisaDmarcRecordExist.ps1
+++ b/powershell/public/CISA/exchange/Test-MtCisaDmarcRecordExist.ps1
@@ -47,6 +47,9 @@ Function Test-MtCisaDmarcRecordExist {
 
         if($dmarcRecord.dmarcRecord.GetType().Name -eq "DMARCRecord"){
             $dmarcRecord.pass = "Passed"
+        }elseif($dmarcRecord.dmarcRecord -eq "Unsupported platform, Resolve-DnsName not available"){
+            $dmarcRecord.pass = "Skipped"
+            $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }else{
             $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }
@@ -56,6 +59,9 @@ Function Test-MtCisaDmarcRecordExist {
 
     if("Failed" -in $dmarcRecords.pass){
         $testResult = $false
+    }elseif("Failed" -notin $dmarcRecords.pass -and "Passed" -notin $dmarcRecords.pass){
+        Add-MtTestResultDetail -SkippedBecause NotSupported
+        return $null
     }else{
         $testResult = $true
     }

--- a/powershell/public/CISA/exchange/Test-MtCisaDmarcRecordReject.ps1
+++ b/powershell/public/CISA/exchange/Test-MtCisaDmarcRecordReject.ps1
@@ -58,6 +58,9 @@ Function Test-MtCisaDmarcRecordReject {
             $dmarcRecord.reason = "Policy is not reject"
         }elseif($checkType -and $dmarcRecord.dmarcRecord.policySubdomain -in @("none","quarantine")){
             $dmarcRecord.reason = "Subdomain policy is not reject"
+        }elseif($dmarcRecord.dmarcRecord -eq "Unsupported platform, Resolve-DnsName not available"){
+            $dmarcRecord.pass = "Skipped"
+            $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }else{
             $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }
@@ -67,6 +70,9 @@ Function Test-MtCisaDmarcRecordReject {
 
     if("Failed" -in $dmarcRecords.pass){
         $testResult = $false
+    }elseif("Failed" -notin $dmarcRecords.pass -and "Passed" -notin $dmarcRecords.pass){
+        Add-MtTestResultDetail -SkippedBecause NotSupported
+        return $null
     }else{
         $testResult = $true
     }

--- a/powershell/public/CISA/exchange/Test-MtCisaDmarcReport.ps1
+++ b/powershell/public/CISA/exchange/Test-MtCisaDmarcReport.ps1
@@ -58,6 +58,9 @@ Function Test-MtCisaDmarcReport {
             $dmarcRecord.pass = "Passed"
         }elseif($checkType){
             $dmarcRecord.reason = "No target in domain"
+        }elseif($dmarcRecord.dmarcRecord -eq "Unsupported platform, Resolve-DnsName not available"){
+            $dmarcRecord.pass = "Skipped"
+            $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }else{
             $dmarcRecord.reason = $dmarcRecord.dmarcRecord
         }
@@ -67,6 +70,9 @@ Function Test-MtCisaDmarcReport {
 
     if("Failed" -in $dmarcRecords.pass){
         $testResult = $false
+    }elseif("Failed" -notin $dmarcRecords.pass -and "Passed" -notin $dmarcRecords.pass){
+        Add-MtTestResultDetail -SkippedBecause NotSupported
+        return $null
     }else{
         $testResult = $true
     }

--- a/powershell/public/CISA/exchange/Test-MtCisaSpfDirective.ps1
+++ b/powershell/public/CISA/exchange/Test-MtCisaSpfDirective.ps1
@@ -44,9 +44,14 @@ Function Test-MtCisaSpfDirective {
             $spfRecord.reason = "1+ mechanism targets"
         }elseif(($directives|Measure-Object).Count -ge 1 -and -not $check){
             $spfRecord.reason = "No EXO directive"
-        }elseif($spfRecord.spfRecord.terms[-1].modifier -eq "redirect"){
+        }elseif($spfRecord.spfRecord -eq "Unsupported platform, Resolve-DnsName not available"){
             $spfRecord.pass = "Skipped"
-            $spfRecord.reason = "Redirect modifier"
+            $spfRecord.reason = $spfRecord.spfRecord
+        }elseif($spfRecord.spfRecord.GetType().Name -eq "SPFRecord"){
+            if($spfRecord.spfRecord.terms[-1].modifier -eq "redirect"){
+                $spfRecord.pass = "Skipped"
+                $spfRecord.reason = "Redirect modifier"
+            }
         }else{
             $spfRecord.reason = "No mechanism targets"
         }
@@ -62,6 +67,9 @@ Function Test-MtCisaSpfDirective {
 
     if("Failed" -in $spfRecords.pass){
         $testResult = $false
+    }elseif("Failed" -notin $spfRecords.pass -and "Passed" -notin $spfRecords.pass){
+        Add-MtTestResultDetail -SkippedBecause NotSupported
+        return $null
     }else{
         $testResult = $true
     }

--- a/powershell/public/CISA/exchange/Test-MtCisaSpfRestriction.ps1
+++ b/powershell/public/CISA/exchange/Test-MtCisaSpfRestriction.ps1
@@ -12,7 +12,7 @@
     Returns true if SPF record exists and has a fail all modifier for all exo domains
 #>
 
-Function Test-MtCisaSpfRestriction2 {
+Function Test-MtCisaSpfRestriction {
     [CmdletBinding()]
     [OutputType([bool])]
     param()
@@ -35,12 +35,17 @@ Function Test-MtCisaSpfRestriction2 {
         $spfRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $spfRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 
-        if($spfRecord.spfRecord.terms[-1].directive -eq "-all"){
-            $spfRecord.pass = "Passed"
-            $spfRecord.reason = "Last directive is '-all'"
-        }elseif($spfRecord.spfRecord.terms[-1].modifier -eq "redirect"){
+        if($spfRecord.spfRecord.GetType().Name -eq "SPFRecord"){
+            if($spfRecord.spfRecord.terms[-1].directive -eq "-all"){
+                $spfRecord.pass = "Passed"
+                $spfRecord.reason = "Last directive is '-all'"
+            }elseif($spfRecord.spfRecord.terms[-1].modifier -eq "redirect"){
+                $spfRecord.pass = "Skipped"
+                $spfRecord.reason = "Redirect modifier"
+            }
+        }elseif($spfRecord.spfRecord -eq "Unsupported platform, Resolve-DnsName not available"){
             $spfRecord.pass = "Skipped"
-            $spfRecord.reason = "Redirect modifier"
+            $spfRecord.reason = $spfRecord.spfRecord
         }else{
             $spfRecord.reason = "Last directive is not '-all'"
         }


### PR DESCRIPTION
Added a few improvements to error handling.

Skipping of tests if Resolve-DnsName is not available, using $_ in place of $Error[0], and some type checking for non-indexed variable errors.