### PR TITLE
Do not exit shell when cancelling Update-MaesterTests

### DIFF
--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -45,7 +45,7 @@ Function Update-MtMaesterTests {
                 }
             } else {
                 Write-Host "Maester tests not $installOrUpdate." -ForegroundColor Red
-                exit
+                return
             }
         }
     }


### PR DESCRIPTION
Replace `exit` with `return` so the function returns to the prompt instead of closing the shell completely. Resolves #160.