### PR TITLE
Only delete known Maester tests with Update-MaesterTests

### DIFF
--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -62,7 +62,6 @@ Function Update-MtMaesterTests {
         }
     }
 
-    $MaesterTestsPath = Get-MtMaesterTestFolderPath
     Copy-Item -Path $MaesterTestsPath\* -Destination $Path -Recurse -Force
 
     $message = "Run `Connect-Maester` to sign in and then run `Invoke-Maester` to start testing."

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -23,12 +23,14 @@ Function Update-MtMaesterTests {
         return
     }
 
+    $MaesterTests = (Get-ChildItem -Path $MaesterTestsPath -Exclude 'Custom').Name
+
     $targetFolderExists = (Test-Path -Path $Path -PathType Container)
 
     $installOrUpdate = if ($Install) { "installed" } else { "updated" }
     if ($targetFolderExists) {
         # Check if the folder already exists and prompt user to confirm overwrite.
-        $itemsToDelete = Get-ChildItem -Path $Path -Exclude "Custom"
+        $itemsToDelete = Get-ChildItem -Path $Path | Where-Object {$_.Name -in $($MaesterTests.Name)}
 
         if ($itemsToDelete.Count -gt 0) {
             $message = "`nThe following items will be deleted when installing the latest Maester tests:`n"

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -27,7 +27,13 @@ Function Update-MtMaesterTests {
     $targetFolderExists = (Test-Path -Path $Path -PathType Container)
     if (-not $targetFolderExists) {
         Write-Verbose "Creating directory $([System.IO.Path]::GetFullPath($Path))"
-        New-Item -Path $Path -ItemType Directory | Out-Null
+        try {
+            New-Item -Path $Path -ItemType Directory | Out-Null
+        } catch {
+            Write-Error "Unable to create directory $([System.IO.Path]::GetFullPath($Path))."
+            Write-Verbose $_
+            return
+        }
     }
 
     $installOrUpdate = if ($Install) { "installed" } else { "updated" }

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -18,12 +18,12 @@ Function Update-MtMaesterTests {
 
     $MaesterTestsPath = Get-MtMaesterTestFolderPath
 
-    if (-not (Test-Path -Path $MaesterTestsPath)) {
+    if (-not (Test-Path -Path $MaesterTestsPath -PathType Container)) {
         Write-Error "Maester tests not found at $MaesterTestsPath"
         return
     }
 
-    $targetFolderExists = (Test-Path -Path $Path)
+    $targetFolderExists = (Test-Path -Path $Path -PathType Container)
 
     $installOrUpdate = if ($Install) { "installed" } else { "updated" }
     if ($targetFolderExists) {

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -40,7 +40,7 @@ Function Update-MtMaesterTests {
 
     if ($targetFolderExists) {
         # Check if the folder already exists and prompt user to confirm overwrite.
-        $itemsToDelete = Get-ChildItem -Path $Path | Where-Object {$_.Name -in $($MaesterTests.Name)}
+        $itemsToDelete = Get-ChildItem -Path $Path | Where-Object {$_.Name -in $($MaesterTests)}
 
         if ($itemsToDelete.Count -gt 0) {
             $message = "`nThe following items will be deleted when installing the latest Maester tests:`n"

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -17,7 +17,6 @@ Function Update-MtMaesterTests {
     )
 
     $MaesterTestsPath = Get-MtMaesterTestFolderPath
-
     if (-not (Test-Path -Path $MaesterTestsPath -PathType Container)) {
         Write-Error "Maester tests not found at $MaesterTestsPath"
         return
@@ -26,8 +25,13 @@ Function Update-MtMaesterTests {
     $MaesterTests = (Get-ChildItem -Path $MaesterTestsPath -Exclude 'Custom').Name
 
     $targetFolderExists = (Test-Path -Path $Path -PathType Container)
+    if (-not $targetFolderExists) {
+        Write-Verbose "Creating directory $Path"
+        New-Item -Path $Path -ItemType Directory | Out-Null
+    }
 
     $installOrUpdate = if ($Install) { "installed" } else { "updated" }
+
     if ($targetFolderExists) {
         # Check if the folder already exists and prompt user to confirm overwrite.
         $itemsToDelete = Get-ChildItem -Path $Path | Where-Object {$_.Name -in $($MaesterTests.Name)}
@@ -50,11 +54,6 @@ Function Update-MtMaesterTests {
                 return
             }
         }
-    }
-
-    if (-not $targetFolderExists) {
-        Write-Verbose "Creating directory $Path"
-        New-Item -Path $Path -ItemType Directory | Out-Null
     }
 
     $MaesterTestsPath = Get-MtMaesterTestFolderPath

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -47,7 +47,7 @@ Function Update-MtMaesterTests {
                 }
             } else {
                 Write-Host "Maester tests not $installOrUpdate." -ForegroundColor Red
-                exit
+                return
             }
         }
     }

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -26,7 +26,7 @@ Function Update-MtMaesterTests {
 
     $targetFolderExists = (Test-Path -Path $Path -PathType Container)
     if (-not $targetFolderExists) {
-        Write-Verbose "Creating directory $Path"
+        Write-Verbose "Creating directory $([System.IO.Path]::GetFullPath($Path))"
         New-Item -Path $Path -ItemType Directory | Out-Null
     }
 

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -30,7 +30,7 @@ Function Update-MtMaesterTests {
         try {
             New-Item -Path $Path -ItemType Directory | Out-Null
         } catch {
-            Write-Error "Unable to create directory $([System.IO.Path]::GetFullPath($Path))."
+            Write-Error "Unable to create directory $([System.IO.Path]::GetFullPath($Path))"
             Write-Verbose $_
             return
         }
@@ -62,7 +62,13 @@ Function Update-MtMaesterTests {
         }
     }
 
-    Copy-Item -Path $MaesterTestsPath\* -Destination $Path -Recurse -Force
+    try {
+        Copy-Item -Path $MaesterTestsPath\* -Destination $Path -Recurse -Force
+    } catch {
+        Write-Error "Unable to copy the Maester tests to $Path."
+        Write-Verbose $_
+        return
+    }
 
     $message = "Run `Connect-Maester` to sign in and then run `Invoke-Maester` to start testing."
     if (Get-MgContext) {

--- a/powershell/public/core/Install-MaesterTests.ps1
+++ b/powershell/public/core/Install-MaesterTests.ps1
@@ -62,7 +62,7 @@ Function Install-MaesterTests {
 
     Write-Verbose "Installing Maester tests to $Path"
 
-    $targetFolderExists = (Test-Path -Path $Path)
+    $targetFolderExists = (Test-Path -Path $Path -PathType Container)
 
 
     # Check if current folder is empty and prompt user to continue if it is not

--- a/powershell/public/core/Update-MaesterTests.ps1
+++ b/powershell/public/core/Update-MaesterTests.ps1
@@ -12,12 +12,12 @@
     The path to install or update the Maester tests in.
 
 .EXAMPLE
-    Update-MaesterTests -Path ./maester-tests
+    Update-MaesterTests -Path .\maester-tests
 
     Installs or updates the latest Maester tests in the specified directory.
 
 .EXAMPLE
-    Update-MaesterTests -Path ./
+    Update-MaesterTests -Path .\
 
     Install the latest set of Maester tests in the current directory.
 
@@ -31,7 +31,7 @@ function Update-MaesterTests {
     param(
         # The path to install or update Maester tests in. Defaults to the current directory.
         [Parameter(Mandatory = $false)]
-        [string] $Path = './'
+        [string] $Path = '.\'
     )
     Get-IsNewMaesterVersionAvailable | Out-Null
 

--- a/powershell/public/core/Update-MaesterTests.ps1
+++ b/powershell/public/core/Update-MaesterTests.ps1
@@ -8,27 +8,30 @@
 
     The tests can be viewed at https://github.com/maester365/maester/tree/main/tests
 
+.PARAMETER Path
+    The path to install or update the Maester tests in.
+
 .EXAMPLE
-    Update-MaesterTests -Path .\maester-tests
+    Update-MaesterTests -Path ./maester-tests
 
     Installs or updates the latest Maester tests in the specified directory.
 
 .EXAMPLE
-    Update-MaesterTests
+    Update-MaesterTests -Path ./
 
     Install the latest set of Maester tests in the current directory.
 
 #>
 
-Function Update-MaesterTests {
+function Update-MaesterTests {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'This command updates multiple tests')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'TODO: Implement ShouldProcess')]
     [CmdletBinding()]
     param(
-        # The path to install the Maester tests to, defaults to the current directory.
+        # The path to install or update Maester tests in. Defaults to the current directory.
         [Parameter(Mandatory = $false)]
-        [string] $Path = ".\"
+        [string] $Path = './'
     )
     Get-IsNewMaesterVersionAvailable | Out-Null
 


### PR DESCRIPTION
Checks the known Maester test names from the installed module path and only deletes those child object names instead of everything in $Path. Provides a resolution for #173.