### PR TITLE
Make PowershellGet optional

### DIFF
--- a/powershell/internal/ConvertTo-MtMaesterResults.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResults.ps1
@@ -40,8 +40,13 @@ function ConvertTo-MtMaesterResult {
     $tenantName = GetTenantName
     $account = $mgContext.Account
 
-    $currentVersion = ((Get-Module -Name Maester).Version | Select-Object -Last 1).ToString()
-    $latestVersion = (Find-Module -Name Maester).Version
+    if (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
+        $currentVersion = ((Get-Module -Name Maester).Version | Select-Object -Last 1).ToString()
+        $latestVersion = (Find-Module -Name Maester).Version
+    } else {
+        $currentVersion = 'Unknown'
+        $latestVersion = 'Unknown'
+    }
 
     $mtTests = @()
     $sortedTests = GetTestsSorted

--- a/powershell/internal/ConvertTo-MtMaesterResults.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResults.ps1
@@ -34,19 +34,22 @@ function ConvertTo-MtMaesterResult {
         }
     }
 
+    function GetMaesterLatestVersion() {
+        if (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
+            return (Find-Module -Name Maester).Version
+        }
+
+        return 'Unknown'
+    }
+
     $mgContext = Get-MgContext
 
     $tenantId = $mgContext.TenantId
     $tenantName = GetTenantName
     $account = $mgContext.Account
 
-    if (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
-        $currentVersion = ((Get-Module -Name Maester).Version | Select-Object -Last 1).ToString()
-        $latestVersion = (Find-Module -Name Maester).Version
-    } else {
-        $currentVersion = 'Unknown'
-        $latestVersion = 'Unknown'
-    }
+    $currentVersion = ((Get-Module -Name Maester).Version | Select-Object -Last 1).ToString()
+    $latestVersion = GetMaesterLatestVersion
 
     $mtTests = @()
     $sortedTests = GetTestsSorted


### PR DESCRIPTION
The version `0.1.0` didn't make use of any code that requires the `PowershellGet` module to be installed. When trying out version `0.2.0` I started facing issues due to the use of `Find-Module` not being available.

The use-case I have is the ability to run Maester standard tests + Maester custom tests (user-defined) where we want to avoid users providing unsafe scripts. The environment is stripped down and `PowershellGet` is not installed.