### PR TITLE
Added support for Should "BeIn" function in Pester in EIDSCA

### DIFF
--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -41,17 +41,37 @@ Function GetVersion($graphUri) {
 }
 
 Function GetRecommendedValue($RecommendedValue) {
-    $compareOperators = @(">=",">","<")
-    foreach ($compareOperator in $compareOperators) {
-        if ($RecommendedValue.StartsWith($compareOperator)) {
-            $RecommendedValue = $RecommendedValue.Replace($compareOperator, "")
+    if($RecommendedValue -notlike "@('*,*')") {
+        $compareOperators = @(">=",">","<")
+        foreach ($compareOperator in $compareOperators) {
+            if ($RecommendedValue.StartsWith($compareOperator)) {
+                $RecommendedValue = $RecommendedValue.Replace($compareOperator, "")
+            }
         }
+        return "'$RecommendedValue'"
+    } else {
+        return $RecommendedValue
     }
-    return "'$RecommendedValue'"
+}
+
+Function GetRecommendedValueMarkdown($RecommendedValueMarkdown) {
+    if($RecommendedValueMarkdown -like "@('*,*')") {
+        $RecommendedValueMarkdown = $RecommendedValueMarkdown -replace "@\(", "" -replace "\)", ""
+        return "$RecommendedValueMarkdown"
+    } else {
+        return "'$RecommendedValueMarkdown'"
+    }
 }
 
 Function GetCompareOperator($RecommendedValue) {
-    if ($RecommendedValue.StartsWith(">=")) {
+    if ($RecommendedValue -like "@('*,*')") {
+        $compareOperator = [PSCustomObject]@{
+            name       = 'in'
+            pester     = 'BeIn'
+            powershell = 'in'
+            text       = 'is one of the following values'
+        }
+    } elseif ($RecommendedValue.StartsWith(">=")) {
         $compareOperator = [PSCustomObject]@{
             name       = '>='
             pester     = 'BeGreaterOrEqual'
@@ -72,6 +92,7 @@ Function GetCompareOperator($RecommendedValue) {
             powershell = 'lt'
             text       = 'is less than'
         }
+
     } else {
         $compareOperator = [PSCustomObject]@{
             name       = '='
@@ -259,6 +280,7 @@ Function UpdateTemplate($template, $control, $controlItem, $docName, $isDoc) {
     $apiVersion = GetVersion($control.GraphUri)
 
     $recommendedValue = GetRecommendedValue($controlItem.RecommendedValue)
+    $RecommendedValueMarkdown = GetRecommendedValueMarkdown($controlItem.RecommendedValue)
     $compareOperator = GetCompareOperator($controlItem.RecommendedValue)
     $currentValue = $controlItem.CurrentValue
 
@@ -301,6 +323,7 @@ if ($currentValue -eq '' -or $control.ControlName -eq '') {
     $output = $output -replace '%CompareOperator%', $compareOperator.Name
     $output = $output -replace '%PwshCompareOperator%', $compareOperator.powershell.Replace("'", "")
     $output = $output -replace '%RecommendedValue%', $recommendedValue
+    $output = $output -replace '%RecommendedValueMarkdown%', $recommendedValueMarkdown
     $output = $output -replace '%CurrentValue%', $CurrentValue
     $output = $output -replace '%GraphEndPoint%', $control.GraphEndpoint
     $output = $output -replace '%GraphDocsUrl%', $graphDocsUrl

--- a/powershell/public/eidsca/Test-MtEidscaAP04.md
+++ b/powershell/public/eidsca/Test-MtEidscaAP04.md
@@ -5,7 +5,7 @@ CISA SCuBA 2.18: Only users with the Guest Inviter role SHOULD be able to invite
 #### Test script
 ```
 https://graph.microsoft.com/beta/policies/authorizationPolicy
-.allowInvitesFrom = 'adminsAndGuestInviters'
+.allowInvitesFrom in @('adminsAndGuestInviters','none')
 ```
 
 #### Related links

--- a/powershell/public/eidsca/Test-MtEidscaAP04.ps1
+++ b/powershell/public/eidsca/Test-MtEidscaAP04.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Checks if Default Authorization Settings - Guest invite restrictions is set to 'adminsAndGuestInviters'
+    Checks if Default Authorization Settings - Guest invite restrictions is set to @('adminsAndGuestInviters','none')
 
 .DESCRIPTION
 
@@ -8,12 +8,12 @@
 
     Queries policies/authorizationPolicy
     and returns the result of
-     graph/policies/authorizationPolicy.allowInvitesFrom -eq 'adminsAndGuestInviters'
+     graph/policies/authorizationPolicy.allowInvitesFrom -in @('adminsAndGuestInviters','none')
 
 .EXAMPLE
     Test-MtEidscaAP04
 
-    Returns the result of graph.microsoft.com/beta/policies/authorizationPolicy.allowInvitesFrom -eq 'adminsAndGuestInviters'
+    Returns the result of graph.microsoft.com/beta/policies/authorizationPolicy.allowInvitesFrom -in @('adminsAndGuestInviters','none')
 #>
 
 Function Test-MtEidscaAP04 {
@@ -24,15 +24,15 @@ Function Test-MtEidscaAP04 {
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowInvitesFrom
-    $testResult = $tenantValue -eq 'adminsAndGuestInviters'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'adminsAndGuestInviters' -notlike '*$null*'
+    $testResult = $tenantValue -in @('adminsAndGuestInviters','none')
+    $tenantValueNotSet = $null -eq $tenantValue -and @('adminsAndGuestInviters','none') -notlike '*$null*'
 
     if($testResult){
-        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'adminsAndGuestInviters'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is one of the following values **@('adminsAndGuestInviters','none')** for **policies/authorizationPolicy**"
     } elseif ($tenantValueNotSet) {
-        $testResultMarkdown = "Your tenant is **not configured explicitly**.`n`nThe recommended value is **'adminsAndGuestInviters'** for **policies/authorizationPolicy**. It seems that you are using a default value by Microsoft. We recommend to set the setting value explicitly since non set values could change depending on what Microsoft decides the current default should be."
+        $testResultMarkdown = "Your tenant is **not configured explicitly**.`n`nThe recommended value is **@('adminsAndGuestInviters','none')** for **policies/authorizationPolicy**. It seems that you are using a default value by Microsoft. We recommend to set the setting value explicitly since non set values could change depending on what Microsoft decides the current default should be."
     } else {
-        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'adminsAndGuestInviters'** for **policies/authorizationPolicy**"
+        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is one of the following values **@('adminsAndGuestInviters','none')** for **policies/authorizationPolicy**"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -1,4 +1,5 @@
 BeforeDiscovery {
+$SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
 $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
 $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
 }
@@ -15,9 +16,9 @@ Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EID
     It "EIDSCA.AP04: Default Authorization Settings - Guest invite restrictions. See https://maester.dev/docs/tests/EIDSCA.AP04" {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authorizationPolicy"
-            .allowInvitesFrom = 'adminsAndGuestInviters'
+            .allowInvitesFrom in @('adminsAndGuestInviters','none')
         #>
-        Test-MtEidscaAP04 | Should -Be 'adminsAndGuestInviters'
+        Test-MtEidscaAP04 | Should -BeIn @('adminsAndGuestInviters','none')
     }
 }
 Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AP05" {
@@ -84,7 +85,7 @@ Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EID
     }
 }
 
-Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP01" {
+Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP01" -Skip:( $SettingsApiAvailable -notcontains 'EnableGroupSpecificConsent' ) {
     It "EIDSCA.CP01: Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. See https://maester.dev/docs/tests/EIDSCA.CP01" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
@@ -93,7 +94,7 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
         Test-MtEidscaCP01 | Should -Be 'False'
     }
 }
-Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP03" {
+Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP03" -Skip:( $SettingsApiAvailable -notcontains 'BlockUserConsentForRiskyApps' ) {
     It "EIDSCA.CP03: Default Settings - Consent Policy Settings - Block user consent for risky apps. See https://maester.dev/docs/tests/EIDSCA.CP03" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
@@ -102,7 +103,7 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
         Test-MtEidscaCP03 | Should -Be 'true'
     }
 }
-Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP04" {
+Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP04" -Skip:( $SettingsApiAvailable -notcontains 'EnableAdminConsentRequests' ) {
     It "EIDSCA.CP04: Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. See https://maester.dev/docs/tests/EIDSCA.CP04" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
@@ -112,7 +113,7 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
     }
 }
 
-Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR01" {
+Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR01" -Skip:( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
     It "EIDSCA.PR01: Default Settings - Password Rule Settings - Password Protection - Mode. See https://maester.dev/docs/tests/EIDSCA.PR01" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
@@ -130,7 +131,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
         Test-MtEidscaPR02 | Should -Be 'True'
     }
 }
-Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR03" {
+Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR03" -Skip:( $SettingsApiAvailable -notcontains 'EnableBannedPasswordCheck' ) {
     It "EIDSCA.PR03: Default Settings - Password Rule Settings - Enforce custom list. See https://maester.dev/docs/tests/EIDSCA.PR03" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"

--- a/website/docs/tests/eidsca/@template.txt
+++ b/website/docs/tests/eidsca/@template.txt
@@ -25,7 +25,7 @@ sidebar_class_name: hidden
 | **Recommendation** | %Recommendation% |
 | **Configuration** | %RelativeUri% |
 | **Setting** | `%CurrentValue%` |
-| **Recommended Value** | %RecommendedValue% |
+| **Recommended Value** | %RecommendedValueMarkdown% |
 | **Default Value** | %DefaultValue% |
 | **Graph API Docs** | %GraphDocsUrl% |
 | **Graph Explorer** | %GraphExplorerUrl% |

--- a/website/docs/tests/eidsca/EIDSCA.AP04.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP04.md
@@ -25,7 +25,7 @@ Manages controls who can invite guests to your directory to collaborate on resou
 | **Recommendation** | CISA SCuBA 2.18: Only users with the Guest Inviter role SHOULD be able to invite guest users |
 | **Configuration** | policies/authorizationPolicy |
 | **Setting** | `allowInvitesFrom` |
-| **Recommended Value** | 'adminsAndGuestInviters' |
+| **Recommended Value** | 'adminsAndGuestInviters','none' |
 | **Default Value** | everyone |
 | **Graph API Docs** | [authorizationPolicy resource type - Microsoft Graph v1.0 - Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy) |
 | **Graph Explorer** | [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com) |

--- a/website/docs/tests/eidsca/EIDSCA.PR05.md
+++ b/website/docs/tests/eidsca/EIDSCA.PR05.md
@@ -25,7 +25,7 @@ The minimum length in seconds of each lockout. If an account locks repeatedly, t
 | **Recommendation** | [Prevent attacks using smart lockout - Microsoft Entra ID - Microsoft Learn](https://learn.microsoft.com/en-us/azure/active-directory/authentication/howto-password-smart-lockout) |
 | **Configuration** | settings |
 | **Setting** | `values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value` |
-| **Recommended Value** | '60' |
+| **Recommended Value** | '>=60' |
 | **Default Value** | 60 |
 | **Graph API Docs** | [directorySetting resource type - Microsoft Graph beta - Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting) |
 | **Graph Explorer** | [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com) |


### PR DESCRIPTION
Some checks have more than a single value which can be accepted as "recommended" configuration.
Therefore, I've started to implement support for "BeIn" statements in EIDSCA without a big impact of the existing EIDSCA JSON schema. Defining a value in syntax of a object in the property "RecommendedValue" (string property) will be recognized and seems for me a valid workaround.