### PR TITLE
Migrate core tests to Pester v5 syntax

### DIFF
--- a/powershell/public/Clear-MtDnsCache.ps1
+++ b/powershell/public/Clear-MtDnsCache.ps1
@@ -14,6 +14,7 @@
 #>
 function Clear-MtDnsCache {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification='Setting module level variable')]
+    [CmdletBinding()]
     param()
 
     Write-Verbose -Message "Clearing the results cached from DNS lookups in this session"

--- a/powershell/public/Clear-MtGraphCache.ps1
+++ b/powershell/public/Clear-MtGraphCache.ps1
@@ -19,6 +19,7 @@
 #>
 function Clear-MtGraphCache {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification='Setting module level variable')]
+    [CmdletBinding()]
     param()
 
     Write-Verbose -Message "Clearing the results cached from Graph API calls in this session"

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -61,7 +61,7 @@ Shows results of tests as they are run including details on failed tests.
 
 .EXAMPLE
 ```
-$configuration = [PesterConfiguration]::Default
+$configuration = New-PesterConfiguration
 $configuration.Run.Path = './tests/Maester'
 $configuration.Filter.Tag = 'CA'
 $configuration.Filter.ExcludeTag = 'App'

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -75,6 +75,7 @@ Runs all the Pester tests in the EIDSCA folder.
 Function Invoke-Maester {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
     [Alias("Invoke-MtMaester")]
+    [CmdletBinding()]
     param (
         # Specifies one or more paths to files containing tests. The value is a path\file name or name pattern. Wildcards are permitted.
         [Parameter(Position = 0)]

--- a/powershell/tests/functions/Help.Tests.ps1
+++ b/powershell/tests/functions/Help.Tests.ps1
@@ -1,74 +1,67 @@
-﻿BeforeAll {
+﻿BeforeDiscovery {
     $module = 'Maester'
-    $moduleRoot = (Resolve-Path "$global:testroot/..").Path
-}
-
-BeforeDiscovery {
-
-    $moduleRoot = (Resolve-Path "$global:testroot/..").Path
+    $moduleRoot = "$PSScriptRoot/../.."
     # Get all the functions in the /public folder
     $functions = Get-ChildItem -Path "$moduleRoot/public" -Filter '*.ps1' | ForEach-Object { $_.BaseName }
 
     # Eventually this should include all functions in the /public folder
     # For now, just the ones that we have tested and added
-    $functionsWithTests = ('Invoke-MtMaester'
-    )
+    $functionsWithTests = @('Invoke-MtMaester')
 }
 
-Describe -Tags ('Unit', 'Acceptance') "$module Module Tests" {
-
-    Context "Test Function" -ForEach $functions {
-
-        It "$_.ps1 should exist" {
-            "$moduleRoot/public/$_.ps1" | Should -Exist
+Describe "$module Help Tests" -Tags ('Unit', 'Acceptance') -ForEach @{ moduleRoot = $moduleRoot } {
+    Context 'Function <_>' -ForEach $functions {
+        BeforeAll {
+            $function = $_
+            $functionPath = Join-Path -Path $moduleRoot -ChildPath "/public/$function.ps1"
         }
 
-        It "$_.ps1 should have help block" {
-            "$moduleRoot/public/$_.ps1" | Should -FileContentMatch '<#'
-            "$moduleRoot/public/$_.ps1" | Should -FileContentMatch '#>'
+        It "<function>.ps1 should exist" {
+            Join-Path -Path $moduleRoot -ChildPath "/public/$function.ps1"
+            $functionPath | Should -Exist
         }
 
-        It "$_.ps1 should have a SYNOPSIS section in the help block" {
-            "$moduleRoot/public/$_.ps1" | Should -FileContentMatch '.SYNOPSIS'
+        It "<function>.ps1 should have help block" {
+            $functionPath | Should -FileContentMatch '<#'
+            $functionPath | Should -FileContentMatch '#>'
         }
 
-        It "$_.ps1 should have a DESCRIPTION section in the help block" {
-            "$moduleRoot/public/$_.ps1" | Should -FileContentMatch '.DESCRIPTION'
+        It "<function>.ps1 should have a SYNOPSIS section in the help block" {
+            $functionPath | Should -FileContentMatch '.SYNOPSIS'
         }
 
-        It "$_.ps1 should have a EXAMPLE section in the help block" {
-            "$moduleRoot/public/$_.ps1" | Should -FileContentMatch '.EXAMPLE'
+        It "<function>.ps1 should have a DESCRIPTION section in the help block" {
+            $functionPath | Should -FileContentMatch '.DESCRIPTION'
         }
 
-        It "$_.ps1 should be an advanced function" {
-            foreach ($_ in $_s) {
-                "$moduleRoot/public/$_.ps1" | Should -FileContentMatch 'function'
-                "$moduleRoot/public/$_.ps1" | Should -FileContentMatch 'cmdletbinding'
-                "$moduleRoot/public/$_.ps1" | Should -FileContentMatch 'param'
-            }
-
+        It "<function>.ps1 should have a EXAMPLE section in the help block" {
+            $functionPath | Should -FileContentMatch '.EXAMPLE'
         }
 
-        It "$_.ps1 should contain Write-Verbose blocks" {
-            "$moduleRoot/public/$_.ps1" | Should -FileContentMatch 'Write-Verbose'
+        It "<function>.ps1 should be an advanced function" {
+            $functionPath | Should -FileContentMatch 'function'
+            $functionPath | Should -FileContentMatch 'cmdletbinding'
+            $functionPath | Should -FileContentMatch 'param'
         }
 
-        It "$_.ps1 is valid PowerShell code" {
-            $psFile = Get-Content -Path "$moduleRoot/public/$_.ps1" `
-                -ErrorAction Stop
+        It "<function>.ps1 should contain Write-Verbose blocks" {
+            $functionPath | Should -FileContentMatch 'Write-Verbose'
+        }
+
+        It "<function>.ps1 is valid PowerShell code" {
+            $psFile = Get-Content -Path $functionPath -ErrorAction Stop
             $errors = $null
             $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
             $errors.Count | Should -Be 0
         }
 
-        It "$_ should run without exceptions" {
-            $scriptBlock = [scriptblock]::Create((Get-Content "$moduleRoot/public/$_.ps1" -Raw))
+        It '<function>.ps1 should run without exceptions' {
+            $scriptBlock = [scriptblock]::Create((Get-Content $functionPath -Raw))
             { & $scriptBlock } | Should -Not -Throw
         }
-    }
 
-    Context "Test Function" -ForEach $functionsWithTests {
-        It "($_.Tests.ps1) should exist" {
+        # Intentionally using skip so the output will remind us of the missing test files :)
+        It 'Matching test file file should exist' -Skip:$($_ -notin $functionsWithTests) {
             "$moduleRoot/tests/functions/$($_).Tests.ps1" | Should -Exist
         }
     }

--- a/powershell/tests/functions/Invoke-Maester.Tests.ps1
+++ b/powershell/tests/functions/Invoke-Maester.Tests.ps1
@@ -1,7 +1,7 @@
-﻿Describe 'Invoke-MtMaester' {
+﻿Describe 'Invoke-Maester' {
     It 'Not connected to graph should return error' {
         if (Get-MgContext) { Disconnect-Graph } # Ensure we are disconnected
-        { Invoke-MtMaester } | Should -Throw 'Not connected to Microsoft Graph.*'
+        { Invoke-Maester } | Should -Throw 'Not connected to Microsoft Graph.*'
     }
 }
 

--- a/powershell/tests/functions/Invoke-MtMaester.Tests.ps1
+++ b/powershell/tests/functions/Invoke-MtMaester.Tests.ps1
@@ -1,9 +1,7 @@
 ﻿Describe 'Invoke-MtMaester' {
     It 'Not connected to graph should return error' {
-
         if (Get-MgContext) { Disconnect-Graph } # Ensure we are disconnected
-
-        { Invoke-MtMaester } | Should -Throw "Not connected to Microsoft Graph.*"
+        { Invoke-MtMaester } | Should -Throw 'Not connected to Microsoft Graph.*'
     }
 }
 

--- a/powershell/tests/general/Help.Tests.ps1
+++ b/powershell/tests/general/Help.Tests.ps1
@@ -36,13 +36,13 @@ Param (
 	$SkipTest,
 
 	[string[]]
-	$CommandPath = @("$global:testroot\..\public", "$global:testroot\..\internal"),
+	$CommandPath = @("$PSScriptRoot\..\..\public", "$PSScriptRoot\..\..\internal"),
 
 	[string]
 	$ModuleName = "PSFramework",
 
 	[string]
-	$ExceptionsFile = "$global:testroot\general\Help.Exceptions.ps1"
+	$ExceptionsFile = "$PSScriptRoot\..\general\Help.Exceptions.ps1"
 )
 if ($SkipTest) { return }
 . $ExceptionsFile

--- a/powershell/tests/general/Manifest.Tests.ps1
+++ b/powershell/tests/general/Manifest.Tests.ps1
@@ -1,48 +1,56 @@
-Describe "Validating the module manifest" {
-	$moduleRoot = (Resolve-Path "$global:testroot\..").Path
-	$manifest = ((Get-Content "$moduleRoot\Maester.psd1") -join "`n") | Invoke-Expression
-	Context "Basic resources validation" {
-		$files = Get-ChildItem "$moduleRoot\public" -Recurse -File | Where-Object Name -like "*.ps1"
-		It "Exports all functions in the public folder" -TestCases @{ files = $files; manifest = $manifest } {
+BeforeDiscovery {
+    $moduleRoot = "$PSScriptRoot/../.."
+    # Using Import-PowerShellDataFile over Test-ModuleManifest as it's easier to navigate
+    $manifest = Import-PowerShellDataFile -Path (Join-Path -Path $moduleRoot -ChildPath 'Maester.psd1')
+}
 
-			$functions = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport | Where-Object SideIndicator -Like '<=').InputObject
-			$functions | Should -BeNullOrEmpty
-		}
-		It "Exports no function that isn't also present in the public folder" -TestCases @{ files = $files; manifest = $manifest } {
-			$functions = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport | Where-Object SideIndicator -Like '=>').InputObject
-			$functions | Should -BeNullOrEmpty
-		}
+Describe 'Validating the module manifest' -ForEach @{ moduleRoot = $moduleRoot; manifest = $manifest } {
+    Context 'Basic resources validation' {
+        BeforeAll {
+            $files = Get-ChildItem -Path "$moduleRoot/public" -Recurse -File -Filter '*.ps1'
+        }
 
-		It "Exports none of its internal functions" -TestCases @{ moduleRoot = $moduleRoot; manifest = $manifest } {
-			$files = Get-ChildItem "$moduleRoot/internal" -Recurse -File -Filter "*.ps1"
-			$files | Where-Object BaseName -In $manifest.FunctionsToExport | Should -BeNullOrEmpty
-		}
-	}
+        It 'Manifest is valid' {
+            Test-ModuleManifest -Path (Join-Path -Path $moduleRoot -ChildPath 'Maester.psd1')
+            # Throws if not valid = failure. Success if not.
+        }
 
-	Context "Individual file validation" {
-		It "The root module file exists" -TestCases @{ moduleRoot = $moduleRoot; manifest = $manifest } {
-			Test-Path "$moduleRoot\$($manifest.RootModule)" | Should -Be $true
-		}
+        It 'Exports all functions in the public folder' {
+            $functions = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport | Where-Object SideIndicator -Like '<=').InputObject
+            $functions | Should -BeNullOrEmpty
+        }
+        It "Exports no function that isn't also present in the public folder" {
+            $functions = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport | Where-Object SideIndicator -Like '=>').InputObject
+            $functions | Should -BeNullOrEmpty
+        }
 
-		foreach ($format in $manifest.FormatsToProcess)
-		{
-			It "The file $format should exist" -TestCases @{ moduleRoot = $moduleRoot; format = $format } {
-				Test-Path "$moduleRoot\$format" | Should -Be $true
-			}
-		}
+        It 'Exports none of its internal functions' {
+            $files = Get-ChildItem "$moduleRoot/internal" -Recurse -File -Filter '*.ps1'
+            $files | Where-Object BaseName -In $manifest.FunctionsToExport | Should -BeNullOrEmpty
+        }
+    }
 
-		foreach ($type in $manifest.TypesToProcess)
-		{
-			It "The file $type should exist" -TestCases @{ moduleRoot = $moduleRoot; type = $type } {
-				Test-Path "$moduleRoot\$type" | Should -Be $true
-			}
-		}
+    Context 'Testing tags' {
+        It "Tag '<_>' should not include whitespace" -ForEach @($manifest.PrivateData.PSData.Tags) {
+            $_ | Should -Not -Match '\s'
+        }
+    }
 
-		foreach ($tag in $manifest.PrivateData.PSData.Tags)
-		{
-			It "Tags should have no spaces in name" -TestCases @{ tag = $tag } {
-				$tag -match " " | Should -Be $false
-			}
-		}
-	}
+    Context 'Individual file validation' {
+        It 'The root module file exists' {
+            Join-Path -Path $moduleRoot -ChildPath $manifest.RootModule | Should -Exist
+        }
+
+        Context 'Testing format files' -Skip:$(-not $manifest.ContainsKey('FormatsToProcess')) {
+            It 'The file <_> should exist' -ForEach $manifest.FormatsToProcess {
+                Join-Path -Path $moduleRoot -ChildPath $_ | Should -Exist
+            }
+        }
+        
+        Context 'Testing types files' -Skip:$(-not $manifest.ContainsKey('TypesToProcess')) {
+            It 'The file <_> should exist' -ForEach $manifest.TypesToProcess {
+                Join-Path -Path $moduleRoot -ChildPath $_ | Should -Exist
+            }
+        }
+    }
 }

--- a/powershell/tests/general/Manifest.Tests.ps1
+++ b/powershell/tests/general/Manifest.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Validating the module manifest' -ForEach @{ moduleRoot = $moduleRoot; 
                 Join-Path -Path $moduleRoot -ChildPath $_ | Should -Exist
             }
         }
-        
+
         Context 'Testing types files' -Skip:$(-not $manifest.ContainsKey('TypesToProcess')) {
             It 'The file <_> should exist' -ForEach $manifest.TypesToProcess {
                 Join-Path -Path $moduleRoot -ChildPath $_ | Should -Exist

--- a/powershell/tests/general/Module.Tests.ps1
+++ b/powershell/tests/general/Module.Tests.ps1
@@ -3,7 +3,7 @@
     $moduleRoot = "$PSScriptRoot/../.."
 }
 
-Describe "$module Module Tests" -Tags ('Unit', 'Acceptance') {
+Describe "<module> Module Tests" -Tags ('Unit', 'Acceptance') {
 
     Context 'Module Setup' {
         It "has the root module $module.psm1" {
@@ -15,11 +15,11 @@ Describe "$module Module Tests" -Tags ('Unit', 'Acceptance') {
             Join-Path -Path $moduleRoot -ChildPath "$module.psd1" | Should -FileContentMatch "$module.psm1"
         }
 
-        It "$module folder has functions" {
+        It '<module> folder has functions' {
             Join-Path -Path $moduleRoot -ChildPath "public/*.ps1" | Should -Exist
         }
 
-        It "$module is valid PowerShell code" {
+        It '<module> is valid PowerShell code' {
             $psFile = Get-Content -Path (Join-Path -Path $moduleRoot -ChildPath "$module.psm1") -ErrorAction Stop
             $errors = $null
             $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)

--- a/powershell/tests/general/Module.Tests.ps1
+++ b/powershell/tests/general/Module.Tests.ps1
@@ -4,7 +4,6 @@
 }
 
 Describe "<module> Module Tests" -Tags ('Unit', 'Acceptance') {
-
     Context 'Module Setup' {
         It "has the root module $module.psm1" {
             Join-Path -Path $moduleRoot -ChildPath "$module.psm1" | Should -Exist

--- a/powershell/tests/general/Module.Tests.ps1
+++ b/powershell/tests/general/Module.Tests.ps1
@@ -1,27 +1,26 @@
 ﻿BeforeAll {
     $module = 'Maester'
-    $moduleRoot = (Resolve-Path "$global:testroot/..").Path
+    $moduleRoot = "$PSScriptRoot/../.."
 }
 
-Describe -Tags ('Unit', 'Acceptance') "$module Module Tests" {
+Describe "$module Module Tests" -Tags ('Unit', 'Acceptance') {
 
     Context 'Module Setup' {
         It "has the root module $module.psm1" {
-            "$moduleRoot/$module.psm1" | Should -Exist
+            Join-Path -Path $moduleRoot -ChildPath "$module.psm1" | Should -Exist
         }
 
         It "has the a manifest file of $module.psd1" {
-            "$moduleRoot/$module.psd1" | Should -Exist
-            "$moduleRoot/$module.psd1" | Should -FileContentMatch "$module.psm1"
+            Join-Path -Path $moduleRoot -ChildPath "$module.psd1" | Should -Exist
+            Join-Path -Path $moduleRoot -ChildPath "$module.psd1" | Should -FileContentMatch "$module.psm1"
         }
 
         It "$module folder has functions" {
-            "$moduleRoot/public/*.ps1" | Should -Exist
+            Join-Path -Path $moduleRoot -ChildPath "public/*.ps1" | Should -Exist
         }
 
         It "$module is valid PowerShell code" {
-            $psFile = Get-Content -Path "$moduleRoot\$module.psm1" `
-                -ErrorAction Stop
+            $psFile = Get-Content -Path (Join-Path -Path $moduleRoot -ChildPath "$module.psm1") -ErrorAction Stop
             $errors = $null
             $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
             $errors.Count | Should -Be 0

--- a/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -1,5 +1,4 @@
-﻿[CmdletBinding()]
-Param (
+﻿Param (
     [switch]
     $SkipTest,
 

--- a/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -1,10 +1,10 @@
 ﻿[CmdletBinding()]
 Param (
-	[switch]
-	$SkipTest,
+    [switch]
+    $SkipTest,
 
-	[string[]]
-	$CommandPath = @("$global:testroot\..\public", "$global:testroot\..\internal")
+    [string[]]
+    $CommandPath = @("$PSScriptRoot/../../public/", "$PSScriptRoot/../../internal/")
 )
 
 if ($SkipTest) { return }
@@ -12,29 +12,22 @@ if ($SkipTest) { return }
 $global:__pester_data.ScriptAnalyzer = New-Object System.Collections.ArrayList
 
 Describe 'Invoking PSScriptAnalyzer against commandbase' {
-	$commandFiles = foreach ($path in $CommandPath) { Get-ChildItem -Path $path -Recurse | Where-Object Name -like "*.ps1" }
-	$scriptAnalyzerRules = Get-ScriptAnalyzerRule
+    BeforeDiscovery {
+        $commandFiles = Get-ChildItem -Path $CommandPath -Recurse -File -Filter '*.ps1'
+        $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+    }
 
-	foreach ($file in $commandFiles)
-	{
-		Context "Analyzing $($file.BaseName)" {
-			$analysis = Invoke-ScriptAnalyzer -Path $file.FullName -ExcludeRule PSAvoidTrailingWhitespace, PSShouldProcess
-
-			forEach ($rule in $scriptAnalyzerRules)
-			{
-				It "Should pass $rule" -TestCases @{ analysis = $analysis; rule = $rule } {
-					If ($analysis.RuleName -contains $rule)
-					{
-						$analysis | Where-Object RuleName -EQ $rule -outvariable failures | ForEach-Object { $null = $global:__pester_data.ScriptAnalyzer.Add($_) }
-
-						1 | Should -Be 0
-					}
-					else
-					{
-						0 | Should -Be 0
-					}
-				}
-			}
-		}
-	}
+    Context 'Analyzing <_.BaseName>' -ForEach $commandFiles {
+        BeforeAll {
+            $file = $_
+            $analysis = Invoke-ScriptAnalyzer -Path $file.FullName -ExcludeRule PSAvoidTrailingWhitespace, PSShouldProcess
+        }
+        It "Should pass '<_.RuleName>'" -ForEach $scriptAnalyzerRules {
+            $rule = $_
+            If ($analysis.RuleName -contains $rule.RuleName) {
+                $analysis | Where-Object RuleName -EQ $rule -OutVariable failures | ForEach-Object { $null = $global:__pester_data.ScriptAnalyzer.Add($_) }
+                1 | Should -Be 0
+            }
+        }
+    }
 }

--- a/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'Invoking PSScriptAnalyzer against commandbase' -ForEach @{ commandFile
 
     # The next Context blocks are kinda duplicate, but helps us document both
     # which files and which rules where evaluated without running every rule for every file 
-    Context 'Analyzing <_.RuleName>' -ForEach $scriptAnalyzerRules {
+    Context 'Analyzing rule <_.RuleName>' -ForEach $scriptAnalyzerRules {
         BeforeAll {
             $rule = $_
         }
@@ -35,18 +35,18 @@ Describe 'Invoking PSScriptAnalyzer against commandbase' -ForEach @{ commandFile
         }
     }
 
-    Context 'Analyzing <_.BaseName>' -ForEach $commandFiles {
+    Context 'Analyzing file <_.BaseName>' -ForEach $commandFiles {
         BeforeAll {
             $file = $_
         }
         It "Should pass all rules" -Tag 'ScriptAnalyzerRule' {
             $failedRules = foreach ($failure in $analysis) {
                 if ($failure.ScriptPath -eq $file.FullName) {
-                    $failure.RuleName
+                    $failure
                 }
             }
             $failedRules # Intentional output so we can get it from StandardOutput-property in pester.ps1
-            $failedRules | Should -BeNullOrEmpty
+            @($failedRules).RuleName | Should -BeNullOrEmpty
         }
     }
 }

--- a/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -9,8 +9,6 @@ Param (
 
 if ($SkipTest) { return }
 
-$global:__pester_data.ScriptAnalyzer = New-Object System.Collections.ArrayList
-
 Describe 'Invoking PSScriptAnalyzer against commandbase' {
     BeforeDiscovery {
         $commandFiles = Get-ChildItem -Path $CommandPath -Recurse -File -Filter '*.ps1'
@@ -22,11 +20,13 @@ Describe 'Invoking PSScriptAnalyzer against commandbase' {
             $file = $_
             $analysis = Invoke-ScriptAnalyzer -Path $file.FullName -ExcludeRule PSAvoidTrailingWhitespace, PSShouldProcess
         }
-        It "Should pass '<_.RuleName>'" -ForEach $scriptAnalyzerRules {
+        It "Should pass '<_.RuleName>'" -Tag 'ScriptAnalyzerRule' -ForEach $scriptAnalyzerRules {
             $rule = $_
             If ($analysis.RuleName -contains $rule.RuleName) {
-                $analysis | Where-Object RuleName -EQ $rule -OutVariable failures | ForEach-Object { $null = $global:__pester_data.ScriptAnalyzer.Add($_) }
-                1 | Should -Be 0
+                $failedRule = $analysis | Where-Object RuleName -EQ $rule.RuleName
+                $failedRule # Intentional output so we can get it from StandardOutput-property in pester.ps1
+
+                $failedRule | Should -BeNullOrEmpty
             }
         }
     }

--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -68,7 +68,6 @@ if ($TestGeneral)
             }
 
             if ($test.Result -eq 'Failed' -and $test.Tag -contains 'ScriptAnalyzerRule' -and $test.StandardOutput) {
-                # Print ScriptAnalyzer findings
                 $null = $scriptAnalyzerFailures.Add($test.StandardOutput)
             }
         }
@@ -76,7 +75,7 @@ if ($TestGeneral)
 }
 #endregion Run General Tests
 
-# Print any ScriptAnalyzer findings
+# Print any ScriptAnalyzer output
 $scriptAnalyzerFailures | Out-Host
 
 #region Test Commands
@@ -94,7 +93,7 @@ if ($TestFunctions)
         $config.Run.PassThru = $true
         $config.Output.Verbosity = $Output
         $result = Invoke-Pester -Configuration $config
-        
+
         foreach ($test in $result.Tests) {
             if ($test.Result -notin 'Passed','Skipped') {
                 $failedTest = [pscustomobject]@{

--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -20,7 +20,6 @@ Write-Host "Importing Module"
 
 Remove-Module Maester -ErrorAction Ignore
 Import-Module "$PSScriptRoot\..\Maester.psd1"
-Import-Module "$PSScriptRoot\..\Maester.psm1" -Force
 
 Import-Module PSModuleDevelopment
 Import-Module Pester

--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -20,10 +20,9 @@ Write-Host "Importing Module"
 
 Remove-Module Maester -ErrorAction Ignore
 Import-Module "$PSScriptRoot\..\Maester.psd1"
-Import-Module PSModuleDevelopment
 Import-Module "$PSScriptRoot\..\Maester.psm1" -Force
 
-# Need to import explicitly so we can use the configuration class
+Import-Module PSModuleDevelopment
 Import-Module Pester
 
 Write-PSFMessage -Level Important -Message "Creating test result folder"
@@ -34,7 +33,7 @@ $totalRun = 0
 
 $testresults = [System.Collections.Generic.List[object]]::new()
 $scriptAnalyzerFailures = [System.Collections.Generic.List[object]]::new()
-$config = [PesterConfiguration]::Default
+$config = New-PesterConfiguration
 $config.TestResult.Enabled = $true
 
 #region Run General Tests

--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -16,10 +16,8 @@
 )
 
 Write-Host "Starting Tests"
-
 Write-Host "Importing Module"
 
-$global:testroot = $PSScriptRoot
 $global:__pester_data = @{ }
 
 Remove-Module Maester -ErrorAction Ignore
@@ -94,7 +92,7 @@ if ($TestFunctions)
 		{
 			$totalRun += $result.TotalCount
 			$totalFailed += $result.FailedCount
-			$result.Tests | Where-Object Result -ne 'Passed' | ForEach-Object {
+			$result.Tests | Where-Object Result -notin 'Passed','Skipped' | ForEach-Object {
 				$testresults += [pscustomobject]@{
 					Block    = $_.Block
 					Name	 = "It $($_.Name)"


### PR DESCRIPTION
Updates core tests to:
- Use Pester v5 syntax, e.g. no loose code and foreach-loops
- Not depend on global variables. Bad practice and blocks debugging single file in VSCode without running `pester.ps1` once
- Minor improvements
- Rewrites PSScriptAnalyzer.Tests.ps1 to summarize by rule and file. Provides the same visibility in reports, but removes 98% (11k) tests and reduced PSSA-runs to cut time from 20s -> 1s.

Also adds Cmdletbinding-attribute to a few functions missing it. The test validating it was fixed as part of the PR.

Related #98 . Not marking as fixed due to remaining duplicate help-tests