### PR TITLE
Update actions/checkout and action/upload-artifact to node v20 versions

### DIFF
--- a/.github/workflows/build-validation-report.yaml
+++ b/.github/workflows/build-validation-report.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: test-results
+        artifact: test-results-Windows
         name: Maester Test Results
         path: '*.xml'
         reporter: java-junit

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -65,8 +65,8 @@ jobs:
           # Run Pester tests on Windows PowerShell
           ./powershell/tests/pester.ps1
 
-      - uses: actions/upload-artifact@v3  # upload test results
+      - uses: actions/upload-artifact@v4  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:
-          name: test-results
+          name: test-results-${{ runner.os }}
           path: TestResults/*.xml

--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Package ./tests to PowerShell module
         id: package-tests

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Package ./tests to PowerShell module
         id: package-tests

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Package ./tests to PowerShell module
         id: package-tests

--- a/.github/workflows/publish-tests.yaml
+++ b/.github/workflows/publish-tests.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Publish to maester-tests
         id: push_directory
         uses: cpina/github-action-push-to-another-repository@target-branch

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -41,12 +41,10 @@
 
    Connects to Microsoft Graph with the ChannelMessage.Send scope.
 
-
 .EXAMPLE
    Connect-Maester -Privileged
 
    Connects to Microsoft Graph with additional privileged scopes such as **RoleEligibilitySchedule.ReadWrite.Directory** that are required for querying global admin roles in Privileged Identity Management.
-
 #>
 
 Function Connect-Maester {


### PR DESCRIPTION
Fixes the node v16 and artifact v3 deprecation warnings in workflows.

Hardcodes Maester Test Results report in CI to use Windows-run as `actions/upload-artifacts@v4` doesn't allow overwriting artifacts by default and report should always use the same OS. Windows results are currently used (slow runner so always last upload) and has more PSSA rules, so picked that one.

Fix #339

Only tested build-validation workflows, but checkout-action does not have known breaking changes AFAIK.