### PR TITLE
Refactor Invoke-Maester to handle folder paths and validate test files

### DIFF
--- a/powershell/internal/Get-IsNewMaesterVersionAvailable.ps1
+++ b/powershell/internal/Get-IsNewMaesterVersionAvailable.ps1
@@ -29,7 +29,7 @@ Function Get-IsNewMaesterVersionAvailable {
             Write-Host "✨ Update-Module Maester" -NoNewline -ForegroundColor Green
             Write-Host " → Install the latest version of Maester." -ForegroundColor Yellow
             Write-Host "💫 Update-MaesterTests" -NoNewline -ForegroundColor Green
-            Write-Host " → Get the latest tests built by the Maester team." -ForegroundColor Yellow
+            Write-Host " → Get the latest tests built by the Maester team and community." -ForegroundColor Yellow
             return $true
         }
     } catch { Write-Verbose -Message $_}

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -266,17 +266,23 @@ Function Invoke-Maester {
     Write-Verbose "Merged configuration: $($pesterConfig | ConvertTo-Json -Depth 5 -Compress)"
 
     if ( Test-Path -Path $Path -PathType Leaf ) {
-        Write-Error -Message "The path '$Path' is a file. Please provide a folder path."
+        Write-Host "The path '$Path' is a file. Please provide a folder path." -ForegroundColor Red
+        Write-Host "💫 Update-MaesterTests" -NoNewline -ForegroundColor Green
+        Write-Host " → Get the latest tests built by the Maester team and community." -ForegroundColor Yellow
         return
     }
 
     if ( -not ( Test-Path -Path $Path -PathType Container ) ) {
-        Write-Error -Message "The path '$Path' does not exist. Please run Update-MaesterTests to download the tests."
+        Write-Host "The path '$Path' does not exist." -ForegroundColor Red
+        Write-Host "💫 Update-MaesterTests" -NoNewline -ForegroundColor Green
+        Write-Host " → Get the latest tests built by the Maester team and community." -ForegroundColor Yellow
         return
     }
 
     if ( -not ( Get-ChildItem -Path "$Path\*.Tests.ps1" -Recurse ) ) {
-        Write-Error -Message "No test files found in the path '$Path'. Please run Update-MaesterTests to download the tests."
+        Write-Host "No test files found in the path '$Path'." -ForegroundColor Red
+        Write-Host "💫 Update-MaesterTests" -NoNewline -ForegroundColor Green
+        Write-Host " → Get the latest tests built by the Maester team and community." -ForegroundColor Yellow
         return
     }
 

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -262,7 +262,23 @@ Function Invoke-Maester {
     }
 
     $pesterConfig = GetPesterConfiguration -Path $Path -Tag $Tag -ExcludeTag $ExcludeTag -PesterConfiguration $PesterConfiguration
+    $Path = $pesterConfig.Run.Path.value
     Write-Verbose "Merged configuration: $($pesterConfig | ConvertTo-Json -Depth 5 -Compress)"
+
+    if ( Test-Path -Path $Path -PathType Leaf ) {
+        Write-Error -Message "The path '$Path' is a file. Please provide a folder path."
+        return
+    }
+
+    if ( -not ( Test-Path -Path $Path -PathType Container ) ) {
+        Write-Error -Message "The path '$Path' does not exist. Please run Update-MaesterTests to download the tests."
+        return
+    }
+
+    if ( -not ( Get-ChildItem -Path "$Path\*.Tests.ps1" -Recurse ) ) {
+        Write-Error -Message "No test files found in the path '$Path'. Please run Update-MaesterTests to download the tests."
+        return
+    }
 
     $maesterResults = $null
 


### PR DESCRIPTION
This pull request refactors the `Invoke-Maester` function to handle folder paths and validate test files. Previously, the function did not handle folder paths correctly and did not validate if the provided path contained any test files.

This caused errors and incorrect behavior when running the function. With this refactor, the function now properly handles folder paths and validates that the path contains at least one test file before proceeding. This improves the reliability and usability of the `Invoke-Maester` function.