### PR TITLE
Moved additional test error/warning details to verbose

### DIFF
--- a/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDkim.ps1
+++ b/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDkim.ps1
@@ -113,16 +113,16 @@ Function ConvertFrom-MailAuthenticationRecordDkim {
                         return "Failure to obtain record"
                     }
                 } else {
-                    Write-Error "`nFor non-Windows platforms, please install DnsClient-PS module."
-                    Write-Host "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
+                    Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."
+                    Write-Verbose "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
                     return "Missing dependency, Resolve-Dns not available"
                 }
             }
         } catch [System.Management.Automation.CommandNotFoundException] {
-            Write-Error $_
+            Write-Verbose $_
             return "Unsupported platform, Resolve-DnsName not available"
         } catch {
-            Write-Error $_
+            Write-Verbose $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDmarc.ps1
+++ b/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDmarc.ps1
@@ -244,16 +244,16 @@ Function ConvertFrom-MailAuthenticationRecordDmarc {
                         return "Failure to obtain record"
                     }
                 } else {
-                    Write-Error "`nFor non-Windows platforms, please install DnsClient-PS module."
-                    Write-Host "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
+                    Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."
+                    Write-Verbose "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
                     return "Missing dependency, Resolve-Dns not available"
                 }
             }
         } catch [System.Management.Automation.CommandNotFoundException] {
-            Write-Error $_
+            Write-Verbose $_
             return "Unsupported platform, Resolve-DnsName not available"
         } catch {
-            Write-Error $_
+            Write-Verbose $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordMx.ps1
+++ b/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordMx.ps1
@@ -64,16 +64,16 @@ Function ConvertFrom-MailAuthenticationRecordMx {
                         }
                     }
                 } else {
-                    Write-Error "`nFor non-Windows platforms, please install DnsClient-PS module."
-                    Write-Host "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
+                    Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."
+                    Write-Verbose "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
                     return "Missing dependency, Resolve-Dns not available"
                 }
             }
         } catch [System.Management.Automation.CommandNotFoundException] {
-            Write-Error $_
+            Write-Verbose $_
             return "Unsupported platform, Resolve-DnsName not available"
         } catch {
-            Write-Error $_
+            Write-Verbose $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordSpf.ps1
+++ b/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordSpf.ps1
@@ -141,16 +141,16 @@ Function ConvertFrom-MailAuthenticationRecordSpf {
                                 Where-Object { $_.RecordType -eq "TXT" } | `
                                 Where-Object { $_.Text -imatch $matchRecord }).Text)
                 } else {
-                    Write-Error "`nFor non-Windows platforms, please install DnsClient-PS module."
-                    Write-Host "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
+                    Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."
+                    Write-Verbose "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
                     return "Missing dependency, Resolve-Dns not available"
                 }
             }
         } catch [System.Management.Automation.CommandNotFoundException] {
-            Write-Error $_
+            Write-Verbose $_
             return "Unsupported platform, Resolve-DnsName not available"
         } catch {
-            Write-Error $_
+            Write-Verbose $_
             return "Failure to obtain record"
         }
 

--- a/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
+++ b/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
@@ -83,16 +83,16 @@ function Resolve-SPFRecord {
                         }
                     }
                 } else {
-                    Write-Error "`nFor non-Windows platforms, please install DnsClient-PS module."
-                    Write-Host "`n    Install-Module DnsClient-PS -Scope CurrentUser`n" -ForegroundColor Yellow
+                    Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."
+                    Write-Verbose "`n    Install-Module DnsClient-PS -Scope CurrentUser`n"
                     return "Missing dependency, Resolve-Dns not available"
                 }
             }
         } catch [System.Management.Automation.CommandNotFoundException] {
-            Write-Error $_
+            Write-Verbose $_
             return "Unsupported platform, Resolve-DnsName not available"
         } catch {
-            Write-Error $_
+            Write-Verbose $_
             return "Failure to obtain record"
         }
         # Check SPF record
@@ -102,11 +102,11 @@ function Resolve-SPFRecord {
 
         if ( $SPFCount -eq 0) {
             # If there is no error show an error
-            Write-Error "No SPF record found for `"$Name`""
+            Write-Verbose "No SPF record found for `"$Name`""
         } elseif ( $SPFCount -ge 2 ) {
             # Multiple DNS Records are not allowed
             # https://tools.ietf.org/html/rfc7208#section-3.2
-            Write-Error "There is more than one SPF for domain `"$Name`""
+            Write-Verbose "There is more than one SPF for domain `"$Name`""
         } else {
             # Multiple Strings in a Single DNS Record
             # https://tools.ietf.org/html/rfc7208#section-3.3
@@ -133,11 +133,11 @@ function Resolve-SPFRecord {
                 $ReturnValues = foreach ($SPFDirective in $SPFDirectives) {
                     switch -Regex ($SPFDirective) {
                         "%[{%-_]" {
-                            Write-Warning "[$_]`tMacros are not supported. For more information, see https://tools.ietf.org/html/rfc7208#section-7"
+                            Write-Verbose "[$_]`tMacros are not supported. For more information, see https://tools.ietf.org/html/rfc7208#section-7"
                             Continue
                         }
                         "^exp:.*$" {
-                            Write-Warning "[$_]`tExplanation is not supported. For more information, see https://tools.ietf.org/html/rfc7208#section-6.2"
+                            Write-Verbose "[$_]`tExplanation is not supported. For more information, see https://tools.ietf.org/html/rfc7208#section-6.2"
                             Continue
                         }
                         '^include:.*$' {
@@ -224,17 +224,17 @@ function Resolve-SPFRecord {
                             }
                         }
                         Default {
-                            Write-Warning "[$_]`t Unknown directive"
+                            Write-Verbose "[$_]`t Unknown directive"
                         }
                     }
                 }
 
                 $DNSQuerySum = $ReturnValues | Select-Object -Unique SPFSourceDomain | Measure-Object | Select-Object -ExpandProperty Count
                 if ( $DNSQuerySum -gt 6) {
-                    Write-Warning "Watch your includes!`nThe maximum number of DNS queries is 10 and you have already $DNSQuerySum.`nCheck https://tools.ietf.org/html/rfc7208#section-4.6.4"
+                    Write-Verbose "Watch your includes!`nThe maximum number of DNS queries is 10 and you have already $DNSQuerySum.`nCheck https://tools.ietf.org/html/rfc7208#section-4.6.4"
                 }
                 if ( $DNSQuerySum -gt 10) {
-                    Write-Error "Too many DNS queries made ($DNSQuerySum).`nMust not exceed 10 DNS queries.`nCheck https://tools.ietf.org/html/rfc7208#section-4.6.4"
+                    Write-Verbose "Too many DNS queries made ($DNSQuerySum).`nMust not exceed 10 DNS queries.`nCheck https://tools.ietf.org/html/rfc7208#section-4.6.4"
                 }
 
                 return $ReturnValues


### PR DESCRIPTION
This limits the amount of details sent back to the shell with Invoke-Maester without the Verbose switch.