### PR TITLE
Added support for SkippedCustomReason and TestCases in EIDSCA

### DIFF
--- a/powershell/internal/eidsca/@templateps1.txt
+++ b/powershell/internal/eidsca/@templateps1.txt
@@ -21,6 +21,7 @@ Function %PSFunctionName% {
     [OutputType([bool])]
     param()
 
+    %SkipCheck%
     $result = Invoke-MtGraphRequest -RelativeUri "%RelativeUri%" -ApiVersion %ApiVersion%
 
     [string]$tenantValue = $result.%CurrentValue%

--- a/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAF01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAF02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF02.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAF02 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'Fido2' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of FIDO2 security keys is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.isSelfServiceRegistrationAllowed

--- a/powershell/internal/eidsca/Test-MtEidscaAF03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF03.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAF03 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'Fido2' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of FIDO2 security keys is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.isAttestationEnforced

--- a/powershell/internal/eidsca/Test-MtEidscaAF04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF04.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAF04 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'Fido2' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of FIDO2 security keys is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.keyRestrictions.isEnforced

--- a/powershell/internal/eidsca/Test-MtEidscaAF05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF05.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAF05 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'Fido2' -or (Test-MtEidscaAF04) -eq $false ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of FIDO2 security keys is not enabled and key restriction not enforced.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.keyRestrictions.aaGuids -notcontains $null

--- a/powershell/internal/eidsca/Test-MtEidscaAF06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF06.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAF06 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'Fido2' -or (Test-MtEidscaAF04) -eq $false ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of FIDO2 security keys is not enabled and key restriction not enforced.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.keyRestrictions.aaGuids -notcontains $null -and ($result.keyRestrictions.enforcementType -eq 'allow' -or $result.keyRestrictions.enforcementType -eq 'block')

--- a/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAG01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.policyMigrationState

--- a/powershell/internal/eidsca/Test-MtEidscaAG02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG02.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAG02 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.reportSuspiciousActivitySettings.state

--- a/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAG03 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.reportSuspiciousActivitySettings.includeTarget.id

--- a/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAM01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAM02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM02.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM02 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAM03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM03.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM03 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.featureSettings.numberMatchingRequiredState.state

--- a/powershell/internal/eidsca/Test-MtEidscaAM04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM04.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM04 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.featureSettings.numberMatchingRequiredState.includeTarget.id

--- a/powershell/internal/eidsca/Test-MtEidscaAM06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM06.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM06 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.featureSettings.displayAppInformationRequiredState.state

--- a/powershell/internal/eidsca/Test-MtEidscaAM07.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM07.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM07 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.featureSettings.displayAppInformationRequiredState.includeTarget.id

--- a/powershell/internal/eidsca/Test-MtEidscaAM09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM09.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM09 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.featureSettings.displayLocationInformationRequiredState.state

--- a/powershell/internal/eidsca/Test-MtEidscaAM10.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM10.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAM10 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Microsoft Authenticator is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.featureSettings.displayLocationInformationRequiredState.includeTarget.id

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToUseSSPR

--- a/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP04 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowInvitesFrom

--- a/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP05 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToSignUpEmailBasedSubscriptions

--- a/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP06 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowEmailVerifiedUsersToJoinOrganization

--- a/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP07 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.guestUserRoleId

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP08 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1

--- a/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP09 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowUserConsentForRiskyApps

--- a/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP10 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToCreateApps

--- a/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAP14 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToReadOtherUsers

--- a/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAT01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAT02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAT02.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaAT02 {
     [OutputType([bool])]
     param()
 
+    if ( $EnabledAuthMethods -notcontains 'TemporaryAccessPass' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Authentication method of Temporary Access Pass is not enabled.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')" -ApiVersion beta
 
     [string]$tenantValue = $result.isUsableOnce

--- a/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaAV01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaCP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCP01.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaCP01 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'EnableGroupSpecificConsent' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableGroupSpecificConsent' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaCP03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCP03.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaCP03 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'BlockUserConsentForRiskyApps' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'BlockUserConsentForRiskyApps' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaCP04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCP04.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaCP04 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'EnableAdminConsentRequests' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableAdminConsentRequests' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaCR01 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.isEnabled

--- a/powershell/internal/eidsca/Test-MtEidscaCR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR02.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaCR02 {
     [OutputType([bool])]
     param()
 
+    if ( ($EnabledAdminConsentWorkflow) -eq $false ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Admin Consent Workflow is not enabled'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.notifyReviewers

--- a/powershell/internal/eidsca/Test-MtEidscaCR03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR03.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaCR03 {
     [OutputType([bool])]
     param()
 
+    if ( ($EnabledAdminConsentWorkflow) -eq $false ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Admin Consent Workflow is not enabled'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.notifyReviewers

--- a/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaCR04 {
     [OutputType([bool])]
     param()
 
+    if ( ($EnabledAdminConsentWorkflow) -eq $false ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Admin Consent Workflow is not enabled'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.requestDurationInDays

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaPR01 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'BannedPasswordCheckOnPremisesMode' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaPR02 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableBannedPasswordCheckOnPremises' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR03.ps1
@@ -21,6 +21,11 @@ Function Test-MtEidscaPR03 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'EnableBannedPasswordCheck' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            return $null 
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableBannedPasswordCheck' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaPR05 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaPR06 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'LockoutThreshold' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaST08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST08.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaST08 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToBeGroupOwner' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaST09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST09.ps1
@@ -21,6 +21,8 @@ Function Test-MtEidscaST09 {
     [OutputType([bool])]
     param()
 
+    
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToAccessGroups' | select-object -expand value

--- a/powershell/public/Add-MtTestResultDetail.ps1
+++ b/powershell/public/Add-MtTestResultDetail.ps1
@@ -62,16 +62,27 @@ Function Add-MtTestResultDetail {
         [Parameter(Mandatory = $false)]
         [string] $TestName = $____Pester.CurrentTest.ExpandedName,
 
-        [ValidateSet('NotConnectedAzure', 'NotConnectedExchange', 'NotConnectedGraph', 'NotDotGovDomain', 'NotLicensedEntraIDP1', 'NotConnectedSecurityCompliance',
-            'NotLicensedEntraIDP2', 'NotLicensedEntraIDGovernance', 'NotLicensedEntraWorkloadID', "LicensedEntraIDPremium", 'NotSupported'
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('NotConnectedAzure', 'NotConnectedExchange', 'NotDotGovDomain', 'NotLicensedEntraIDP1', 'NotConnectedSecurityCompliance',
+            'NotLicensedEntraIDP2', 'NotLicensedEntraIDGovernance', 'NotLicensedEntraWorkloadID', "LicensedEntraIDPremium", 'NotSupported', 'Custom'
         )]
-        [string] $SkippedBecause
+        [string] $SkippedBecause,
+
+        [Parameter(Mandatory = $false)]
+        [string] $SkippedCustomReason
     )
 
     $hasGraphResults = $GraphObjects -and $GraphObjectType
 
     if ($SkippedBecause) {
-        $SkippedReason = Get-MtSkippedReason $SkippedBecause
+        if ($SkippedBecause -eq 'Custom') {
+            if ([string]::IsNullOrEmpty($SkippedCustomReason)) {
+                throw "SkippedBecause is set to 'Custom' but no SkippedCustomReason was provided."
+            }
+            $SkippedReason = $SkippedCustomReason
+        } else {
+            $SkippedReason = Get-MtSkippedReason $SkippedBecause
+        }
 
         if ([string]::IsNullOrEmpty($Result)) {
             $Result = "Skipped. $SkippedReason"

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeDiscovery {
-New-Variable -Name 'SettingsApiAvailable' -Value (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name -Scope Script -Force
-New-Variable -Name 'EnabledAuthMethods' -Value (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id -Scope Script -Force
-New-Variable -Name 'EnabledAdminConsentWorkflow' -Value (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled -Scope Script -Force
+$SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
+$EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
+$EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
 }
 Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AP01" {
     It "EIDSCA.AP01: Default Authorization Settings - Enabled Self service password reset for administrators. See https://maester.dev/docs/tests/EIDSCA.AP01" {
@@ -85,8 +85,8 @@ Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EID
     }
 }
 
-Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP01" -Skip:( $SettingsApiAvailable -notcontains 'EnableGroupSpecificConsent' ) {
-    It "EIDSCA.CP01: Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. See https://maester.dev/docs/tests/EIDSCA.CP01" {
+Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP01" {
+    It "EIDSCA.CP01: Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. See https://maester.dev/docs/tests/EIDSCA.CP01" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'EnableGroupSpecificConsent' | select-object -expand value = 'False'
@@ -94,8 +94,8 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId CP01 | Should -Be 'False'
     }
 }
-Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP03" -Skip:( $SettingsApiAvailable -notcontains 'BlockUserConsentForRiskyApps' ) {
-    It "EIDSCA.CP03: Default Settings - Consent Policy Settings - Block user consent for risky apps. See https://maester.dev/docs/tests/EIDSCA.CP03" {
+Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP03" {
+    It "EIDSCA.CP03: Default Settings - Consent Policy Settings - Block user consent for risky apps. See https://maester.dev/docs/tests/EIDSCA.CP03" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'BlockUserConsentForRiskyApps' | select-object -expand value = 'true'
@@ -103,8 +103,8 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId CP03 | Should -Be 'true'
     }
 }
-Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP04" -Skip:( $SettingsApiAvailable -notcontains 'EnableAdminConsentRequests' ) {
-    It "EIDSCA.CP04: Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. See https://maester.dev/docs/tests/EIDSCA.CP04" {
+Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP04" {
+    It "EIDSCA.CP04: Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. See https://maester.dev/docs/tests/EIDSCA.CP04" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'EnableAdminConsentRequests' | select-object -expand value = 'true'
@@ -113,8 +113,8 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
     }
 }
 
-Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR01" -Skip:( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
-    It "EIDSCA.PR01: Default Settings - Password Rule Settings - Password Protection - Mode. See https://maester.dev/docs/tests/EIDSCA.PR01" {
+Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR01" {
+    It "EIDSCA.PR01: Default Settings - Password Rule Settings - Password Protection - Mode. See https://maester.dev/docs/tests/EIDSCA.PR01" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'BannedPasswordCheckOnPremisesMode' | select-object -expand value = 'Enforce'
@@ -131,8 +131,8 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
         Test-MtEidscaControl -CheckId PR02 | Should -Be 'True'
     }
 }
-Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR03" -Skip:( $SettingsApiAvailable -notcontains 'EnableBannedPasswordCheck' ) {
-    It "EIDSCA.PR03: Default Settings - Password Rule Settings - Enforce custom list. See https://maester.dev/docs/tests/EIDSCA.PR03" {
+Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR03" {
+    It "EIDSCA.PR03: Default Settings - Password Rule Settings - Enforce custom list. See https://maester.dev/docs/tests/EIDSCA.PR03" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'EnableBannedPasswordCheck' | select-object -expand value = 'True'
@@ -215,8 +215,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM01 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM02" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM02: Authentication Method - Microsoft Authenticator - Allow use of Microsoft Authenticator OTP. See https://maester.dev/docs/tests/EIDSCA.AM02" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM02" {
+    It "EIDSCA.AM02: Authentication Method - Microsoft Authenticator - Allow use of Microsoft Authenticator OTP. See https://maester.dev/docs/tests/EIDSCA.AM02" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .state = 'enabled'
@@ -224,8 +224,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM02 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM03" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM03: Authentication Method - Microsoft Authenticator - Require number matching for push notifications. See https://maester.dev/docs/tests/EIDSCA.AM03" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM03" {
+    It "EIDSCA.AM03: Authentication Method - Microsoft Authenticator - Require number matching for push notifications. See https://maester.dev/docs/tests/EIDSCA.AM03" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .featureSettings.numberMatchingRequiredState.state = 'enabled'
@@ -233,8 +233,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM03 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM04" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM04: Authentication Method - Microsoft Authenticator - Included users/groups of number matching for push notifications. See https://maester.dev/docs/tests/EIDSCA.AM04" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM04" {
+    It "EIDSCA.AM04: Authentication Method - Microsoft Authenticator - Included users/groups of number matching for push notifications. See https://maester.dev/docs/tests/EIDSCA.AM04" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .featureSettings.numberMatchingRequiredState.includeTarget.id = 'all_users'
@@ -242,8 +242,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM04 | Should -Be 'all_users'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM06" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM06: Authentication Method - Microsoft Authenticator - Show application name in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM06" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM06" {
+    It "EIDSCA.AM06: Authentication Method - Microsoft Authenticator - Show application name in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM06" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .featureSettings.displayAppInformationRequiredState.state = 'enabled'
@@ -251,8 +251,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM06 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM07" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM07: Authentication Method - Microsoft Authenticator - Included users/groups to show application name in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM07" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM07" {
+    It "EIDSCA.AM07: Authentication Method - Microsoft Authenticator - Included users/groups to show application name in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM07" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .featureSettings.displayAppInformationRequiredState.includeTarget.id = 'all_users'
@@ -260,8 +260,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM07 | Should -Be 'all_users'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM09" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM09: Authentication Method - Microsoft Authenticator - Show geographic location in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM09" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM09" {
+    It "EIDSCA.AM09: Authentication Method - Microsoft Authenticator - Show geographic location in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM09" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .featureSettings.displayLocationInformationRequiredState.state = 'enabled'
@@ -269,8 +269,8 @@ Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Secur
         Test-MtEidscaControl -CheckId AM09 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM10" -Skip:( $EnabledAuthMethods -notcontains 'MicrosoftAuthenticator' ) {
-    It "EIDSCA.AM10: Authentication Method - Microsoft Authenticator - Included users/groups to show geographic location in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM10" {
+Describe "Authentication Method - Microsoft Authenticator" -Tag "EIDSCA", "Security", "All", "EIDSCA.AM10" {
+    It "EIDSCA.AM10: Authentication Method - Microsoft Authenticator - Included users/groups to show geographic location in push and passwordless notifications. See https://maester.dev/docs/tests/EIDSCA.AM10" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')"
             .featureSettings.displayLocationInformationRequiredState.includeTarget.id = 'all_users'
@@ -288,8 +288,8 @@ Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId AF01 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF02" -Skip:( $EnabledAuthMethods -notcontains 'Fido2' ) {
-    It "EIDSCA.AF02: Authentication Method - FIDO2 security key - Allow self-service set up. See https://maester.dev/docs/tests/EIDSCA.AF02" {
+Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF02" {
+    It "EIDSCA.AF02: Authentication Method - FIDO2 security key - Allow self-service set up. See https://maester.dev/docs/tests/EIDSCA.AF02" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')"
             .isSelfServiceRegistrationAllowed = 'true'
@@ -297,8 +297,8 @@ Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId AF02 | Should -Be 'true'
     }
 }
-Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF03" -Skip:( $EnabledAuthMethods -notcontains 'Fido2' ) {
-    It "EIDSCA.AF03: Authentication Method - FIDO2 security key - Enforce attestation. See https://maester.dev/docs/tests/EIDSCA.AF03" {
+Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF03" {
+    It "EIDSCA.AF03: Authentication Method - FIDO2 security key - Enforce attestation. See https://maester.dev/docs/tests/EIDSCA.AF03" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')"
             .isAttestationEnforced = 'true'
@@ -306,8 +306,8 @@ Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId AF03 | Should -Be 'true'
     }
 }
-Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF04" -Skip:( $EnabledAuthMethods -notcontains 'Fido2' ) {
-    It "EIDSCA.AF04: Authentication Method - FIDO2 security key - Enforce key restrictions. See https://maester.dev/docs/tests/EIDSCA.AF04" {
+Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF04" {
+    It "EIDSCA.AF04: Authentication Method - FIDO2 security key - Enforce key restrictions. See https://maester.dev/docs/tests/EIDSCA.AF04" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')"
             .keyRestrictions.isEnforced = 'true'
@@ -315,8 +315,8 @@ Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId AF04 | Should -Be 'true'
     }
 }
-Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF05" -Skip:( $EnabledAuthMethods -notcontains 'Fido2' -or (Test-MtEidscaAF04) -eq $false ) {
-    It "EIDSCA.AF05: Authentication Method - FIDO2 security key - Restricted. See https://maester.dev/docs/tests/EIDSCA.AF05" {
+Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF05" {
+    It "EIDSCA.AF05: Authentication Method - FIDO2 security key - Restricted. See https://maester.dev/docs/tests/EIDSCA.AF05" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')"
             .keyRestrictions.aaGuids -notcontains $null = 'true'
@@ -324,8 +324,8 @@ Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security",
         Test-MtEidscaControl -CheckId AF05 | Should -Be 'true'
     }
 }
-Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF06" -Skip:( $EnabledAuthMethods -notcontains 'Fido2' -or (Test-MtEidscaAF04) -eq $false ) {
-    It "EIDSCA.AF06: Authentication Method - FIDO2 security key - Restrict specific keys. See https://maester.dev/docs/tests/EIDSCA.AF06" {
+Describe "Authentication Method - FIDO2 security key" -Tag "EIDSCA", "Security", "All", "EIDSCA.AF06" {
+    It "EIDSCA.AF06: Authentication Method - FIDO2 security key - Restrict specific keys. See https://maester.dev/docs/tests/EIDSCA.AF06" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')"
             .keyRestrictions.aaGuids -notcontains $null -and ($result.keyRestrictions.enforcementType -eq 'allow' -or $result.keyRestrictions.enforcementType -eq 'block') = 'true'
@@ -343,8 +343,8 @@ Describe "Authentication Method - Temporary Access Pass" -Tag "EIDSCA", "Securit
         Test-MtEidscaControl -CheckId AT01 | Should -Be 'enabled'
     }
 }
-Describe "Authentication Method - Temporary Access Pass" -Tag "EIDSCA", "Security", "All", "EIDSCA.AT02" -Skip:( $EnabledAuthMethods -notcontains 'TemporaryAccessPass' ) {
-    It "EIDSCA.AT02: Authentication Method - Temporary Access Pass - One-time. See https://maester.dev/docs/tests/EIDSCA.AT02" {
+Describe "Authentication Method - Temporary Access Pass" -Tag "EIDSCA", "Security", "All", "EIDSCA.AT02" {
+    It "EIDSCA.AT02: Authentication Method - Temporary Access Pass - One-time. See https://maester.dev/docs/tests/EIDSCA.AT02" -TestCases @{ EnabledAuthMethods = $EnabledAuthMethods } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')"
             .isUsableOnce = 'true'
@@ -372,8 +372,8 @@ Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", 
         Test-MtEidscaControl -CheckId CR01 | Should -Be 'true'
     }
 }
-Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR02" -Skip:( ($EnabledAdminConsentWorkflow) -eq $false ) {
-    It "EIDSCA.CR02: Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. See https://maester.dev/docs/tests/EIDSCA.CR02" {
+Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR02" {
+    It "EIDSCA.CR02: Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. See https://maester.dev/docs/tests/EIDSCA.CR02" -TestCases @{ EnabledAdminConsentWorkflow = ($EnabledAdminConsentWorkflow) } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy"
             .notifyReviewers = 'true'
@@ -381,8 +381,8 @@ Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", 
         Test-MtEidscaControl -CheckId CR02 | Should -Be 'true'
     }
 }
-Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR03" -Skip:( ($EnabledAdminConsentWorkflow) -eq $false ) {
-    It "EIDSCA.CR03: Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. See https://maester.dev/docs/tests/EIDSCA.CR03" {
+Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR03" {
+    It "EIDSCA.CR03: Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. See https://maester.dev/docs/tests/EIDSCA.CR03" -TestCases @{ EnabledAdminConsentWorkflow = ($EnabledAdminConsentWorkflow) } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy"
             .notifyReviewers = 'true'
@@ -390,8 +390,8 @@ Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", 
         Test-MtEidscaControl -CheckId CR03 | Should -Be 'true'
     }
 }
-Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR04" -Skip:( ($EnabledAdminConsentWorkflow) -eq $false ) {
-    It "EIDSCA.CR04: Consent Framework - Admin Consent Request - Consent request duration (days). See https://maester.dev/docs/tests/EIDSCA.CR04" {
+Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR04" {
+    It "EIDSCA.CR04: Consent Framework - Admin Consent Request - Consent request duration (days). See https://maester.dev/docs/tests/EIDSCA.CR04" -TestCases @{ EnabledAdminConsentWorkflow = ($EnabledAdminConsentWorkflow) } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy"
             .requestDurationInDays = '30'


### PR DESCRIPTION
- Added support for parameter SkippedCustomReason in `Add-MtTestResultDetail` by @f-bader 
- Added custom text for SkippedCustomReason (also known as SkipReason in EIDSCA JSON
- Added TestCases parameter to EIDSCA pester test if variables of Discovery should be used for skip conditions
- Updated "How to fix" links