### PR TITLE
Fixed MS-EXO.2.1

### DIFF
--- a/tests/cisa/exchange/Test-MtCisaAntiSpamSafeList.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaAntiSpamSafeList.Tests.ps1
@@ -3,7 +3,7 @@ Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.12.2", "CISA", "Security", "All" {
 
         $cisaAntiSpamSafeList = Test-MtCisaAntiSpamSafeList
 
-        if($null -eq $cisaAntiSpamSafeList) {
+        if($null -ne $cisaAntiSpamSafeList) {
             $cisaAntiSpamSafeList | Should -Be $true -Because "Safe Lists should be disabled."
         }
     }


### PR DESCRIPTION
This check was not working as expected. It would state that the check passed, and that the safe list is enabled in your tenant. However if the safe list is enabled, the check should fail.

Image showing the issue (prior to changes):
<img width="872" alt="Screenshot 2024-07-17 at 9 51 20 AM" src="https://github.com/user-attachments/assets/566ccf73-917e-4308-a352-5e3ed6fbad4f">

Looking at the other CISA checks, the $null -eq value should actually be -ne.
