### PR TITLE
Add tag filter to HTML report

### DIFF
--- a/powershell/assets/ReportTemplate.html
+++ b/powershell/assets/ReportTemplate.html
@@ -58000,20 +58000,31 @@ function ResultInfoDialog(props) {
 function TestResultsTable(props) {
   const [selectedStatus, setSelectedStatus] = reactExports.useState(["Passed", "Failed", "Skipped"]);
   const [selectedBlock, setSelectedBlock] = reactExports.useState([]);
+  const [selectedTag, setSelectedTag] = reactExports.useState([]);
   const testResults2 = props.TestResults;
   const isStatusSelected = (item) => {
-    return (selectedStatus.includes(item.Result) || selectedStatus.length === 0) && (selectedBlock.includes(item.Block) || selectedBlock.length === 0);
+    return (selectedStatus.length === 0 || selectedStatus.includes(item.Result)) && (selectedBlock.length === 0 || selectedBlock.includes(item.Block)) && (selectedTag.length === 0 || item.Tag.some((tag) => selectedTag.includes(tag)));
   };
   const status = ["Passed", "Failed", "NotRun", "Skipped"];
+  const uniqueTags = [...new Set(testResults2.Tests.flatMap((t3) => t3.Tag))];
   return /* @__PURE__ */ jsxRuntimeExports$1.jsxs(c$6, { children: [
-    /* @__PURE__ */ jsxRuntimeExports$1.jsxs(a$m, { justifyContent: "start", children: [
+    /* @__PURE__ */ jsxRuntimeExports$1.jsxs(a$m, { justifyContent: "start", className: "flex-wrap gap-2", children: [
       /* @__PURE__ */ jsxRuntimeExports$1.jsx(
         h$2,
         {
           onValueChange: setSelectedBlock,
           placeholder: "Select category...",
-          className: "max-w-lg mr-6",
+          className: "max-w-lg",
           children: testResults2.Blocks.sort((a4, b3) => a4.Name > b3.Name ? 1 : -1).map((item) => /* @__PURE__ */ jsxRuntimeExports$1.jsx(i$d, { value: item.Name, children: item.Name }, item.Name))
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports$1.jsx(
+        h$2,
+        {
+          onValueChange: setSelectedTag,
+          placeholder: "Select tag...",
+          className: "max-w-fit",
+          children: uniqueTags.sort((a4, b3) => a4 > b3 ? 1 : -1).map((tag) => /* @__PURE__ */ jsxRuntimeExports$1.jsx(i$d, { value: tag, children: tag }, tag))
         }
       ),
       /* @__PURE__ */ jsxRuntimeExports$1.jsx(
@@ -58802,6 +58813,21 @@ const testResults = {
         "All"
       ],
       "Result": "Skipped",
+      "ScriptBlock": '\n        Test-MtAppManagementPolicyEnabled | Should -Be $true -Because "an app policy for workload identities should be defined to enforce strong credentials instead of passwords and a maximum expiry period (e.g. credential should be renewed every six months)"\n    ',
+      "ScriptBlockFile": "/Users/merill/GitHub/maester/tests/Maester/Entra/Test-AppManagementPolicies.Tests.ps1",
+      "ErrorRecord": [],
+      "Block": "App Management Policies",
+      "ResultDetail": null
+    },
+    {
+      "Name": "MT.1003: App management restrictions on applications and service principals is configured and enabled.",
+      "HelpUrl": "https://maester.dev/docs/tests/MT.1002",
+      "Tag": [
+        "App",
+        "Security",
+        "Some"
+      ],
+      "Result": "Passed",
       "ScriptBlock": '\n        Test-MtAppManagementPolicyEnabled | Should -Be $true -Because "an app policy for workload identities should be defined to enforce strong credentials instead of passwords and a maximum expiry period (e.g. credential should be renewed every six months)"\n    ',
       "ScriptBlockFile": "/Users/merill/GitHub/maester/tests/Maester/Entra/Test-AppManagementPolicies.Tests.ps1",
       "ErrorRecord": [],
@@ -59995,9 +60021,6 @@ video {
 .mr-5 {
   margin-right: 1.25rem;
 }
-.mr-6 {
-  margin-right: 1.5rem;
-}
 .mr-8 {
   margin-right: 2rem;
 }
@@ -60381,6 +60404,9 @@ video {
 }
 .gap-12 {
   gap: 3rem;
+}
+.gap-2 {
+  gap: 0.5rem;
 }
 .gap-3 {
   gap: 0.75rem;

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -11,9 +11,9 @@ export default function TestResultsTable(props) {
   const testResults = props.TestResults;
 
   const isStatusSelected = (item) => {
-    return (selectedStatus.includes(item.Result) || selectedStatus.length === 0) &&
-      (selectedBlock.includes(item.Block) || selectedBlock.length === 0) &&
-      (item.Tag.some((tag) => selectedTag.includes(tag)) || selectedTag.length === 0);
+    return (selectedStatus.length === 0 || selectedStatus.includes(item.Result)) &&
+      (selectedBlock.length === 0 || selectedBlock.includes(item.Block)) &&
+      (selectedTag.length === 0 || item.Tag.some(tag => selectedTag.includes(tag)));
   }
 
   const status = ['Passed', 'Failed', 'NotRun', 'Skipped'];

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -7,13 +7,17 @@ import StatusLabel from "./StatusLabel";
 export default function TestResultsTable(props) {
   const [selectedStatus, setSelectedStatus] = useState(['Passed', 'Failed', 'Skipped']);
   const [selectedBlock, setSelectedBlock] = useState([]);
+  const [selectedTag, setSelectedTag] = useState([]);
   const testResults = props.TestResults;
 
   const isStatusSelected = (item) => {
-    return (selectedStatus.includes(item.Result) || selectedStatus.length === 0) && (selectedBlock.includes(item.Block) || selectedBlock.length === 0);
+    return (selectedStatus.includes(item.Result) || selectedStatus.length === 0) &&
+      (selectedBlock.includes(item.Block) || selectedBlock.length === 0) &&
+      (item.Tag.some((tag) => selectedTag.includes(tag)) || selectedTag.length === 0);
   }
 
   const status = ['Passed', 'Failed', 'NotRun', 'Skipped'];
+  const uniqueTags = [...new Set(testResults.Tests.flatMap((t) => t.Tag))];
 
   return (
     <Card>
@@ -28,6 +32,19 @@ export default function TestResultsTable(props) {
             .map((item) => (
               <MultiSelectItem key={item.Name} value={item.Name}>
                 {item.Name}
+              </MultiSelectItem>
+            ))}
+        </MultiSelect>
+        <MultiSelect
+          onValueChange={setSelectedTag}
+          placeholder="Select tag..."
+          className="max-w-fit mr-6"
+        >
+          {uniqueTags
+            .sort((a, b) => a > b ? 1 : -1)
+            .map((tag) => (
+              <MultiSelectItem key={tag} value={tag}>
+                {tag}
               </MultiSelectItem>
             ))}
         </MultiSelect>

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -21,11 +21,11 @@ export default function TestResultsTable(props) {
 
   return (
     <Card>
-      <Flex justifyContent="start">
+      <Flex justifyContent="start" className="flex-wrap gap-2">
         <MultiSelect
           onValueChange={setSelectedBlock}
           placeholder="Select category..."
-          className="max-w-lg mr-6"
+          className="max-w-lg"
         >
           {testResults.Blocks
             .sort((a, b) => a.Name > b.Name ? 1 : -1)
@@ -38,7 +38,7 @@ export default function TestResultsTable(props) {
         <MultiSelect
           onValueChange={setSelectedTag}
           placeholder="Select tag..."
-          className="max-w-fit mr-6"
+          className="max-w-fit"
         >
           {uniqueTags
             .sort((a, b) => a > b ? 1 : -1)


### PR DESCRIPTION
Adds a multiselect filter for test tag in the result table.

Updates styling to wrap filters on smaller screens.

Fix #185