### PR TITLE
Fix exclusion path filter in CI

### DIFF
--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -28,6 +28,8 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # This requires all patterns to match so exclusion works
+          predicate-quantifier: 'every'
           filters: |
             pwshmodule:
               - 'powershell/**'


### PR DESCRIPTION
PowerShell steps in CI are currently executed on all PRs because `path-filter` only requires one filter to match. As a result the manifest exclusion matches any file in the repo and triggers the PowerShell steps. E.g. the PowerShell tests should not have been executed in #368

PR fixes this by adding the missing `predicate-quantifier: 'every'` parameter to require all filters to match.

**Note**: Workflow and VSCode will warn about the `predicate-quantifier` not being a parameter. This is being fixed in https://github.com/dorny/paths-filter/pull/226