### PR TITLE
Add Maester tag to native Maester tests

### DIFF
--- a/tests/Maester/Entra/Test-AppManagementPolicies.Tests.ps1
+++ b/tests/Maester/Entra/Test-AppManagementPolicies.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "App Management Policies" -Tag "App", "Security", "All" {
+Describe "App Management Policies" -Tag "Maester", "App", "Security", "All" {
     It "MT.1002: App management restrictions on applications and service principals is configured and enabled. See https://maester.dev/docs/tests/MT.1002" -Tag "MT.1002" {
 
         Test-MtAppManagementPolicyEnabled | Should -Be $true -Because "an app policy for workload identities should be defined to enforce strong credentials instead of passwords and a maximum expiry period (e.g. credential should be renewed every six months)"

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe "Conditional Access Baseline Policies" -Tag "CA", "Security", "All" {
+﻿Describe "Conditional Access Baseline Policies" -Tag "Maester", "CA", "Security", "All" {
     It "MT.1001: At least one Conditional Access policy is configured with device compliance. See https://maester.dev/docs/tests/MT.1001" -Tag "MT.1001" {
         Test-MtCaDeviceComplianceExists | Should -Be $true -Because "there is no policy which requires device compliances"
     }

--- a/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
@@ -13,7 +13,7 @@ BeforeDiscovery {
 }
 
 
-Describe "Conditional Access WhatIf" -Tag "CA", "CAWhatIf", "Security", "All" -Skip:( $EntraIDPlan -eq "Free" ) {
+Describe "Conditional Access WhatIf" -Tag "Maester", "CA", "CAWhatIf", "Security", "All" -Skip:( $EntraIDPlan -eq "Free" ) {
 
     Context "Regular users" -ForEach @( $RegularUsers ) {
 

--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -4,7 +4,7 @@ BeforeDiscovery {
     Write-Verbose "Found $($EntraRecommendations.Count) Entra recommendations"
 }
 
-Describe "Entra Recommendations" -Tag "Entra", "Security", "All", "Recommendation" -ForEach $EntraRecommendations {
+Describe "Entra Recommendations" -Tag "Maester", "Entra", "Security", "All", "Recommendation" -ForEach $EntraRecommendations {
     It "MT.1024: Entra Recommendation - <displayName>. See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024" {
         #region Add detailed test description
         $ActionSteps = $actionSteps | Sort-Object -Property 'stepNumber' | ForEach-Object {

--- a/tests/Maester/Entra/Test-PrivilegedAssignments.Tests.ps1
+++ b/tests/Maester/Entra/Test-PrivilegedAssignments.Tests.ps1
@@ -2,7 +2,7 @@
     $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
 }
 
-Describe "Directory Roles - Permanent assignments" -Tag "Privileged", "Security", "All" {
+Describe "Directory Roles - Permanent assignments" -Tag "Maester", "Privileged", "Security", "All" {
     It "MT.1025: No external user with permanent role assignment on Control Plane. See https://maester.dev/docs/tests/MT.1025" -Tag "MT.1025" {
         $Check = Test-MtPrivPermanentDirectoryRole -FilteredAccessLevel "ControlPlane" -FilterPrincipal "ExternalUser"
         $Check | Should -Be $false -Because "External user shouldn't have high-privileged roles"


### PR DESCRIPTION
This pull request adds the "Maester" tag to the native Maester tests. This ensures that the tests are properly categorized and can be easily filtered and searched for.