### PR TITLE
Update Azure AD diagnostic settings API calls to use GET method

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaDiagnosticSettings.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaDiagnosticSettings.ps1
@@ -24,7 +24,7 @@ function Test-MtCisaDiagnosticSettings {
         return $null
     }
 
-    $logs = Invoke-AzRestMethod -Path "/providers/microsoft.aadiam/diagnosticSettingsCategories?api-version=2017-04-01-preview"
+    $logs = Invoke-AzRestMethod -Method GET -Path "/providers/microsoft.aadiam/diagnosticSettingsCategories?api-version=2017-04-01-preview"
     $logs = ($logs.Content|ConvertFrom-Json).value
     $logs = ($logs | Where-Object { `
         $_.properties.categoryType -eq "Logs"
@@ -32,7 +32,7 @@ function Test-MtCisaDiagnosticSettings {
 
     $configs = @()
 
-    $settings = Invoke-AzRestMethod -Path "/providers/microsoft.aadiam/diagnosticSettings?api-version=2017-04-01-preview"
+    $settings = Invoke-AzRestMethod -Method GET -Path "/providers/microsoft.aadiam/diagnosticSettings?api-version=2017-04-01-preview"
     $settings = ($settings.Content|ConvertFrom-Json).value
 
     $settings | ForEach-Object { `

--- a/powershell/public/core/Test-MtConnection.ps1
+++ b/powershell/public/core/Test-MtConnection.ps1
@@ -33,7 +33,10 @@ function Test-MtConnection {
         $isConnected = $false
         try {
             $isConnected = $null -ne (Get-AzContext -ErrorAction SilentlyContinue)
+            # Validate that the credentials are still valid
+            Invoke-AzRestMethod -Method GET -Path "subscriptions" -ErrorAction Stop | Out-Null
         } catch {
+            $isConnected = $false
             Write-Debug "Azure: $false"
         }
         Write-Verbose "Azure: $isConnected"


### PR DESCRIPTION
This pull request updates the Azure AD diagnostic settings API calls to use the GET method instead of the default method. 

Additionally, a dummy Invoke function has been added to verify the validity of the credentials.