### PR TITLE
Refactor ConvertTo-MtMaesterResults.ps1 to use ExpandedName for Block property

### DIFF
--- a/powershell/internal/ConvertTo-MtMaesterResults.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResults.ps1
@@ -73,7 +73,7 @@ function ConvertTo-MtMaesterResult {
             ScriptBlock     = $test.ScriptBlock.ToString()
             ScriptBlockFile = $test.ScriptBlock.File
             ErrorRecord     = $test.ErrorRecord
-            Block           = $test.Block.Name
+            Block           = $test.Block.ExpandedName
             ResultDetail    = $__MtSession.TestResultDetail[$test.ExpandedName]
         }
         $mtTests += $mtTestInfo


### PR DESCRIPTION
Refactored the `ConvertTo-MtMaesterResults.ps1` script to use the `ExpandedName` property instead of the `Name` property for the `Block` property. 