### PR TITLE
Update MT.1006.md

### DIFF
--- a/website/docs/tests/maester/MT.1006.md
+++ b/website/docs/tests/maester/MT.1006.md
@@ -1,20 +1,21 @@
 ---
-title: MT.1006 - At least one Conditional Access policy is configured to require MFA for admins
-description: Checks if the tenant has at least one fallback policy targetting All Apps and All Users.
+title: MT.1006 - At least one Conditional Access policy is configured to require MFA for users with administrator roles
+description: Checks if the tenant has at least one Conditional policy targetting users with administrator roles.
 slug: /tests/MT.1006
 sidebar_class_name: hidden
 ---
 
-# At least one Conditional Access policy is configured to require MFA for admins
+# At least one Conditional Access policy is configured to require MFA user with administrator roles.
 
 ## Description
 
-Checks if the tenant has at least one fallback policy targetting All Apps and All Users.
+Checks if the tenant has at least one Conditional Access policy is configured to require MFA for users with administrator roles.
 
 ## How to fix
 
-Microsoft recommends creating at least one conditional access policy targetting all cloud apps and ideally should be enabled for all users.
+Microsoft recommends creating at least one Conditional Access policy this is configured to require MFA for users with administrator roles.
 
-## Learn more
-
-- [Apply Conditional Access policies to every app](https://learn.microsoft.com/entra/identity/conditional-access/plan-conditional-access#apply-conditional-access-policies-to-every-app)
+## Related links
+- [Entra admin center - Conditional Access | Policies](https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/ConditionalAccessBlade/~/Overview/fromNav/)
+- [Entra admin center - Conditional Access | Policy templates](https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/CaTemplates.ReactView)
+- [Apply Conditional Access policies to require MFA for administrators](https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-admin-mfa)


### PR DESCRIPTION
This was a little bit tricky. There was/is difference between the title and description. I have modified the text in the titel, description and How to fix.

The reason for using the phares "user with administrator roles" is because admins are just users with more permissions after all :)

I hope this is all right and it make sense.

Also added Entra admin center link to CA policies and CA policy templates and renamed "learn more" to "Related links"