### PR TITLE
Added test MT.1035 for checking RMAU-protection of security groups in Conditional Access Policies

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -94,6 +94,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-MtCaExclusionForDirectorySyncAccount',
                'Test-MtCaLicenseUtilization', 'Test-MtCaMfaForAdmin',
                'Test-MtCaMfaForAdminManagement', 'Test-MtCaMfaForAllUsers',
+               "Test-MtCaGroupsRestrictedByRmau",
                'Test-MtCaMfaForGuest', 'Test-MtCaMfaForRiskySignIn',
                'Test-MtCaRequirePasswordChangeForHighUserRisk',
                'Test-MtCaSecureSecurityInfoRegistration', 'Test-MtCisaDiagnosticSettings',

--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -94,7 +94,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-MtCaExclusionForDirectorySyncAccount',
                'Test-MtCaLicenseUtilization', 'Test-MtCaMfaForAdmin',
                'Test-MtCaMfaForAdminManagement', 'Test-MtCaMfaForAllUsers',
-               "Test-MtCaGroupsRestrictedByRmau",
+               "Test-MtCaGroupsRestricted",
                'Test-MtCaMfaForGuest', 'Test-MtCaMfaForRiskySignIn',
                'Test-MtCaRequirePasswordChangeForHighUserRisk',
                'Test-MtCaSecureSecurityInfoRegistration', 'Test-MtCisaDiagnosticSettings',

--- a/powershell/internal/Get-GraphObjectMarkdown.ps1
+++ b/powershell/internal/Get-GraphObjectMarkdown.ps1
@@ -25,7 +25,10 @@ Function Get-GraphObjectMarkdown {
         [ValidateSet('AuthenticationMethod', 'AuthorizationPolicy', 'ConditionalAccess', 'ConsentPolicy',
             'Devices', 'Domains', 'Groups', 'IdentityProtection', 'Users', 'UserRole'
             )]
-        [string] $GraphObjectType
+        [string] $GraphObjectType,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $AsPlainTextLink
     )
 
     $markdownLinkTemplate = @{
@@ -45,7 +48,11 @@ Function Get-GraphObjectMarkdown {
     $result = ""
     foreach ($item in $GraphObjects) {
         $link = $markdownLinkTemplate[$GraphObjectType] -f $item.id
-        $result += "  - [$($item.displayName)]($link)`n"
+        if ($AsPlainTextLink) {
+            $result += "[$($item.displayName)]($link)"
+        } else {
+            $result += "  - [$($item.displayName)]($link)`n"
+        }
     }
 
     return $result

--- a/powershell/public/Test-MtCaGroupsRestricted.ps1
+++ b/powershell/public/Test-MtCaGroupsRestricted.ps1
@@ -13,13 +13,13 @@
   https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management
 
   .Example
-  Test-MtCaGroupsRestrictedByRmau
+  Test-MtCaGroupsRestricted
 
   .LINK
-  https://maester.dev/docs/commands/Test-MtCaGroupsRestrictedByRmau
+  https://maester.dev/docs/commands/Test-MtCaGroupsRestricted
 #>
 
-Function Test-MtCaGroupsRestrictedByRmau {
+Function Test-MtCaGroupsRestricted {
   [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Exists is not a plural.')]
   [CmdletBinding()]
   [OutputType([bool])]

--- a/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
+++ b/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
@@ -1,0 +1,67 @@
+﻿<#
+  .Synopsis
+  Checks if the tenant has at least one fallback policy targetting All Apps and All Users.
+
+  .Description
+  Microsoft recommends creating at least one conditional access policy targetting all cloud apps
+  and ideally should be enabled for all users.
+
+  Learn more:
+  https://learn.microsoft.com/entra/identity/conditional-access/plan-conditional-access#apply-conditional-access-policies-to-every-app
+
+  .Example
+  Test-MtCaAllAppsExists
+
+  Returns true if at least one conditional access policy exists that targets all cloud apps and all users.
+
+  .Example
+  Test-MtCaAllAppsExists -SkipCheckAllUsers
+
+  Returns true if at least one conditional access policy exists that targets all cloud apps and all users, but skips the check for all users.
+#>
+
+Function Test-MtCaGroupsRestrictedByRmau {
+
+  if ( ( Get-MtLicenseInformation EntraID ) -eq "Free" ) {
+    Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
+    return $null
+  }
+
+  $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq "enabled" }
+  $Groups = $policies.conditions.users | Where-Object {$_.includeGroups -ne ""} | Select-Object -ExpandProperty includeGroups | Select-Object -unique
+  $GroupsDetail = foreach ($Group in $Groups) {
+    Invoke-MtGraphRequest -RelativeUri "groups/$($Group)" -ApiVersion beta | Select-Object displayName, isManagementRestricted, id
+  }
+  $UnrestrictedGroups = $GroupsDetail | Where-Object {$_.isManagementRestricted -eq $true} # Filtering out groups that are created as role assignable group
+  $result = ($unrestrictedGroup | Measure-Object).Count -eq 0
+
+  if ( $result ) {
+    $ResultDescription = "All security groups with assignment in Conditional Access are protected."
+  } else {
+    $ResultDescription = "These security groups with assignments in Conditional Access are not protected by RMAU."
+    $ImpactedCaGroups = "`n`n#### Impacted Conditional Access Policies`n`n | Security Group | Condition | Policy name | `n"
+    $ImpactedCaGroups += "| --- | --- | --- |`n"
+  }
+
+  foreach ($UnrestrictedGroup in $UnrestrictedGroups) {
+    $ImpactedPolicies = Get-MtConditionalAccessPolicy | Where-Object { $_.conditions.users.includeGroups -contains $UnrestrictedGroup.id -or $_.conditions.users.excludeGroups -contains $UnrestrictedGroup.id }
+    foreach ($ImpactedPolicy in $ImpactedPolicies) {
+      if ($ImpactedPolicy.conditions.users.includeGroups -contains $UnrestrictedGroup.id) {
+        $Condition = "include"
+      } elseif ($ImpactedPolicy.conditions.users.excludeGroups -contains $UnrestrictedGroup.id) {
+        $Condition = "exclude"
+      } else {
+        Write-Warning
+        $Condition = "Unknown"
+      }
+      $Policy = (Get-GraphObjectMarkdown -GraphObjects $ImpactedPolicy -GraphObjectType ConditionalAccess -AsPlainTextLink)
+      $Group = (Get-GraphObjectMarkdown -GraphObjects $UnrestrictedGroup -GraphObjectType Groups -AsPlainTextLink)
+      $ImpactedCaGroups += "| $($Group) | $($Condition) | $($Policy) | `n"
+    }
+  }
+
+  $resultMarkdown = $ResultDescription + $ImpactedCaGroups
+  Add-MtTestResultDetail -Description $testDescription -Result $resultMarkdown
+
+  return $result
+}

--- a/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
+++ b/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
@@ -14,16 +14,17 @@
 
   .Example
   Test-MtCaGroupsRestrictedByRmau
-
-  Returns true if all Conditional Access groups are protected.
-
 #>
 
 Function Test-MtCaGroupsRestrictedByRmau {
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Exists is not a plural.')]
+  [CmdletBinding()]
+  [OutputType([bool])]
+  param ()
 
   if ( ( Get-MtLicenseInformation EntraID ) -eq "Free" ) {
-    Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
-    return $null
+      Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
+      return $null
   }
 
   $Policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq "enabled" }

--- a/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
+++ b/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
@@ -40,7 +40,7 @@ Function Test-MtCaGroupsRestrictedByRmau {
       Invoke-MtGraphRequest -RelativeUri "groups/$($Group)" -ApiVersion beta | Select-Object displayName, isManagementRestricted, isAssignableToRole, id
     }
     catch {
-      Write-Warning "Group $Group not found"
+      Write-Verbose "Group $Group not found"
     }
   }
 
@@ -66,7 +66,6 @@ Function Test-MtCaGroupsRestrictedByRmau {
       } elseif ($ImpactedPolicy.conditions.users.excludeGroups -contains $UnrestrictedGroup.id) {
         $Condition = "exclude"
       } else {
-        Write-Warning
         $Condition = "Unknown"
       }
       $Policy = (Get-GraphObjectMarkdown -GraphObjects $ImpactedPolicy -GraphObjectType ConditionalAccess -AsPlainTextLink)

--- a/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
+++ b/powershell/public/Test-MtCaGroupsRestrictedByRmau.ps1
@@ -14,6 +14,9 @@
 
   .Example
   Test-MtCaGroupsRestrictedByRmau
+
+  .LINK
+  https://maester.dev/docs/commands/Test-MtCaGroupsRestrictedByRmau
 #>
 
 Function Test-MtCaGroupsRestrictedByRmau {

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -56,8 +56,8 @@
     It "MT.1020: All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. See https://maester.dev/docs/tests/MT.1020" -Tag "MT.1020" {
         Test-MtCaExclusionForDirectorySyncAccount | Should -Be $true -Because "there is no policy that excludes directory synchronization accounts"
     }
-    It "MT.1021: All security groups assigned to Conditional Access Policies should be protected by RMAU. See https://maester.dev/docs/tests/MT.1021" -Tag "MT.1021" {
-        Test-MtCaGroupsRestrictedByRmau | Should -Be $true -Because "there is no policy that excludes directory synchronization accounts"
+    It "MT.1035: All security groups assigned to Conditional Access Policies should be protected by RMAU. See https://maester.dev/docs/tests/MT.1035" -Tag "MT.1035" {
+        Test-MtCaGroupsRestrictedByRmau | Should -Be $true -Because "there is one or more policy without protection of included or excluded groups"
     }
     Context "License utilization" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -56,6 +56,9 @@
     It "MT.1020: All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. See https://maester.dev/docs/tests/MT.1020" -Tag "MT.1020" {
         Test-MtCaExclusionForDirectorySyncAccount | Should -Be $true -Because "there is no policy that excludes directory synchronization accounts"
     }
+    It "MT.1021: All security groups assigned to Conditional Access Policies should be protected by RMAU. See https://maester.dev/docs/tests/MT.1021" -Tag "MT.1021" {
+        Test-MtCaGroupsRestrictedByRmau | Should -Be $true -Because "there is no policy that excludes directory synchronization accounts"
+    }
     Context "License utilization" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {
             $LicenseReport = Test-MtCaLicenseUtilization -License "P1"

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -57,7 +57,7 @@
         Test-MtCaExclusionForDirectorySyncAccount | Should -Be $true -Because "there is no policy that excludes directory synchronization accounts"
     }
     It "MT.1035: All security groups assigned to Conditional Access Policies should be protected by RMAU. See https://maester.dev/docs/tests/MT.1035" -Tag "MT.1035" {
-        Test-MtCaGroupsRestrictedByRmau | Should -Be $true -Because "there is one or more policy without protection of included or excluded groups"
+        Test-MtCaGroupsRestricted | Should -Be $true -Because "there is one or more policy without protection of included or excluded groups"
     }
     Context "License utilization" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {

--- a/website/docs/tests/maester/MT.1035.md
+++ b/website/docs/tests/maester/MT.1035.md
@@ -1,0 +1,22 @@
+---
+title: MT.1034 - All security groups assigned to Conditional Access Policies should be protected by RMAU
+description: Checks if groups used in Conditional Access are protected by either Restricted Management Administrative Units or Role Assignable Groups
+slug: /tests/MT.1035
+sidebar_class_name: hidden
+---
+
+# All security groups assigned to Conditional Access Policies should be protected by RMAU
+
+## Description
+
+Security Groups will be used to exclude and include users from Conditional Access Policies.
+Modify group membership outside of Conditional Access Administrator or other privileged roles can lead to bypassing Conditional Access Policies. To prevent this, you can protect these groups by using Restricted Management Administrative Units or Role Assignable Groups. Role Assignable Group should be used in combination of assignments to Entra ID roles. Restricted Management Administrative Units should be used to protect groups by restricting management to specific users or groups. This test checks if all groups used in Conditional Access Policies are protected.
+
+## How to fix
+
+Assign security groups to Restricted Management Administrative Unit (RMAU).
+
+## Learn more
+  - [Microsoft Learn | Restricted management administrative units in Microsoft Entra ID (Preview)](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management)
+  - [janbakker.tech | Prevent Conditional Access bypass with Restricted Management Administrative Units in Entra ID](https://janbakker.tech/prevent-conditional-access-bypass-with-restricted-management-administrative-units-in-entra-id/)
+  - [Cloud-Architekt.net | Protection of privileged users and groups by Azure AD Restricted Management Administrative Units](https://www.cloud-architekt.net/restricted-management-administrative-unit/)

--- a/website/docs/tests/maester/MT.1035.md
+++ b/website/docs/tests/maester/MT.1035.md
@@ -16,6 +16,6 @@ Modify group membership outside of Conditional Access Administrator or other pri
 Assign security groups to Restricted Management Administrative Unit (RMAU).
 
 ## Learn more
-  - [Microsoft Learn | Restricted management administrative units in Microsoft Entra ID (Preview)](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management)
-  - [janbakker.tech | Prevent Conditional Access bypass with Restricted Management Administrative Units in Entra ID](https://janbakker.tech/prevent-conditional-access-bypass-with-restricted-management-administrative-units-in-entra-id/)
-  - [Cloud-Architekt.net | Protection of privileged users and groups by Azure AD Restricted Management Administrative Units](https://www.cloud-architekt.net/restricted-management-administrative-unit/)
+- [Microsoft Learn | Restricted management administrative units in Microsoft Entra ID (Preview)](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management)
+- [janbakker.tech | Prevent Conditional Access bypass with Restricted Management Administrative Units in Entra ID](https://janbakker.tech/prevent-conditional-access-bypass-with-restricted-management-administrative-units-in-entra-id/)
+- [Cloud-Architekt.net | Protection of privileged users and groups by Azure AD Restricted Management Administrative Units](https://www.cloud-architekt.net/restricted-management-administrative-unit/)

--- a/website/docs/tests/maester/MT.1035.md
+++ b/website/docs/tests/maester/MT.1035.md
@@ -1,5 +1,6 @@
 ---
-title: MT.1035 - All security groups assigned to Conditional Access Policies should be protected by RMAUdescription: Checks if groups used in Conditional Access are protected by either Restricted Management Administrative Units or Role Assignable Groups
+title: MT.1035 - All security groups assigned to Conditional Access Policies should be protected by RMAU
+description: Checks if groups used in Conditional Access are protected by either Restricted Management Administrative Units or Role Assignable Groups
 slug: /tests/MT.1035
 sidebar_class_name: hidden
 ---
@@ -16,6 +17,6 @@ Modify group membership outside of Conditional Access Administrator or other pri
 Assign security groups to Restricted Management Administrative Unit (RMAU).
 
 ## Learn more
-- [Microsoft Learn | Restricted management administrative units in Microsoft Entra ID (Preview)](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management)
-- [janbakker.tech | Prevent Conditional Access bypass with Restricted Management Administrative Units in Entra ID](https://janbakker.tech/prevent-conditional-access-bypass-with-restricted-management-administrative-units-in-entra-id/)
-- [Cloud-Architekt.net | Protection of privileged users and groups by Azure AD Restricted Management Administrative Units](https://www.cloud-architekt.net/restricted-management-administrative-unit/)
+  - [Microsoft Learn | Restricted management administrative units in Microsoft Entra ID (Preview)](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management)
+  - [janbakker.tech | Prevent Conditional Access bypass with Restricted Management Administrative Units in Entra ID](https://janbakker.tech/prevent-conditional-access-bypass-with-restricted-management-administrative-units-in-entra-id/)
+  - [Cloud-Architekt.net | Protection of privileged users and groups by Azure AD Restricted Management Administrative Units](https://www.cloud-architekt.net/restricted-management-administrative-unit/)

--- a/website/docs/tests/maester/MT.1035.md
+++ b/website/docs/tests/maester/MT.1035.md
@@ -1,6 +1,5 @@
 ---
-title: MT.1034 - All security groups assigned to Conditional Access Policies should be protected by RMAU
-description: Checks if groups used in Conditional Access are protected by either Restricted Management Administrative Units or Role Assignable Groups
+title: MT.1035 - All security groups assigned to Conditional Access Policies should be protected by RMAUdescription: Checks if groups used in Conditional Access are protected by either Restricted Management Administrative Units or Role Assignable Groups
 slug: /tests/MT.1035
 sidebar_class_name: hidden
 ---


### PR DESCRIPTION
- [Added Test] "MT.1035" - All security groups assigned to Conditional Access Policies should be protected by RMAU
- [Enhancement] Added support for receiving result of `Get-GraphObjectMarkdown` as plaintext without format and paragraph 