### PR TITLE
New cmdlet to get a local cache of known license SKUs and their nesti…

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -123,7 +123,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-MtCisaDlp',
                'Test-MtConditionalAccessWhatIf',
                'Test-MtConnection',
-               'Test-MtEidscaControl',
+               'Test-MtEidscaControl', 'Update-MtLicenseCache',
                'Test-MtPimAlertsExists', 'Test-MtPrivPermanentDirectoryRole',
                'Update-MaesterTests', 'Compare-MtTestResult',  'Get-MailAuthenticationRecord',
                'ConvertFrom-MailAuthenticationRecordSpf', 'ConvertFrom-MailAuthenticationRecordMx',

--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -123,7 +123,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-MtCisaDlp',
                'Test-MtConditionalAccessWhatIf',
                'Test-MtConnection',
-               'Test-MtEidscaControl', 'Update-MtLicenseCache',
+               'Test-MtEidscaControl', 'Update-MtLicenseCache', 'Get-MtLicenseRelationship',
                'Test-MtPimAlertsExists', 'Test-MtPrivPermanentDirectoryRole',
                'Update-MaesterTests', 'Compare-MtTestResult',  'Get-MailAuthenticationRecord',
                'ConvertFrom-MailAuthenticationRecordSpf', 'ConvertFrom-MailAuthenticationRecordMx',

--- a/powershell/public/Get-MtLicenseRelationship.ps1
+++ b/powershell/public/Get-MtLicenseRelationship.ps1
@@ -5,8 +5,20 @@
 .DESCRIPTION
     This function retrieves the license relationships for a Microsoft 365 product from Microsoft's documentation
 
-.PARAMETER Product
-    The Microsoft 365 product for which to retrieve the license information.
+.PARAMETER regexSearchString
+    Provide a regex search string that will be used against the license display names and part names.
+
+.PARAMETER servicePlanId
+    Provide a GUID for a specific subscription. For bundle only SKUs that are not a la carte products use skuId.
+
+.PARAMETER servicePlanName
+    Provide a string for a specific subscription part name. Same as servicePlanName.
+
+.PARAMETER skuPartNumber
+    Provide a string for a specific subscription part name. Same as skuPartNumber. Matches Graph property, https://learn.microsoft.com/en-us/graph/api/resources/subscribedsku#properties
+
+.PARAMETER skuId
+    Provide a GUID for a specific subscription.
 
 .EXAMPLE
     Get-MtLicenseRelationship -regexSearchString "^.*Entra.*$"
@@ -26,7 +38,7 @@
 .EXAMPLE
     Get-MtLicenseRelationship -skuId cf6b0d46-4093-4546-a0ab-0b1546dcc10e
 
-    Returns all subscriptions that include the Entra Identity Governance subscription. Matches Graph property, https://learn.microsoft.com/en-us/graph/api/resources/subscribedsku#properties
+    Returns all subscriptions that include the Entra Identity Governance subscription.
 
 .EXAMPLE
     Get-MtLicenseRelationship -skuPartNumber Microsoft_Entra_ID_Governance
@@ -34,7 +46,7 @@
     Returns all subscriptions that include the Entra Identity Governance subscription. Matches Graph property, https://learn.microsoft.com/en-us/graph/api/resources/subscribedsku#properties
 
 .LINK
-    https://maester.dev/docs/commands/Get-MtLicenseInformation
+    https://maester.dev/docs/commands/Get-MtLicenseRelationship
 #>
 function Get-MtLicenseRelationship {
     [OutputType([pscustomobject])]

--- a/powershell/public/Get-MtLicenseRelationship.ps1
+++ b/powershell/public/Get-MtLicenseRelationship.ps1
@@ -66,6 +66,7 @@ function Get-MtLicenseRelationship {
 
     process {
         if(-not (Test-Path $env:TEMP\maesterLicenses.csv)){
+            Write-Verbose "License cache not found, updating"
             Update-MtLicenseCache
         }
 
@@ -74,24 +75,29 @@ function Get-MtLicenseRelationship {
         $relationships = @()
 
         if($skuId){
+            Write-Verbose "Processing as skuId"
             $relationships = $plans | Where-Object {`
                 $_.GUID -eq $skuId
             }
         }elseif($servicePlanId){
+            Write-Verbose "Processing as servicePlanId"
             $relationships = $plans | Where-Object {`
                 $_.Service_Plan_Id -eq $servicePlanId
             }
         }elseif($servicePlanName){
+            Write-Verbose "Processing as servicePlanName"
             $relationships = $plans | Where-Object {`
                 $_.String_Id -eq $servicePlanName -or `
                 $_.Service_Plan_Name -eq $servicePlanName
             }
         }elseif($skuPartNumber){
+            Write-Verbose "Processing as skuPartNumber"
             $relationships = $plans | Where-Object {`
                 $_.String_Id -eq $skuPartNumber -or `
                 $_.Service_Plan_Name -eq $skuPartNumber
             }
         }elseif($regexSearchString){
+            Write-Verbose "Processing as regexSearchString"
             foreach($plan in $plans){
                 $match = $regexSearchString.Match($plan.Product_Display_Name).Success -or `
                     $regexSearchString.Match($plan.String_Id).Success -or `

--- a/powershell/public/Get-MtLicenseRelationship.ps1
+++ b/powershell/public/Get-MtLicenseRelationship.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Get license relationships for a Microsoft 365 product
+
+.DESCRIPTION
+    This function retrieves the license relationships for a Microsoft 365 product from Microsoft's documentation
+
+.PARAMETER Product
+    The Microsoft 365 product for which to retrieve the license information.
+
+.EXAMPLE
+    Get-MtLicenseRelationship -regexSearchString "^.*Entra.*$"
+
+    Returns all subscriptions that match part names and display names with Entra.
+
+.EXAMPLE
+    Get-MtLicenseRelationship -servicePlanId 41781fb2-bc02-4b7c-bd55-b576c07bb09d
+
+    Returns all subscriptions that include the Entra ID Plan 1 subscription. Use skuId for bundle subscriptions.
+
+.EXAMPLE
+    Get-MtLicenseRelationship -servicePlanName AAD_PREMIUM
+
+    Returns all subscriptions that include the Entra ID Plan 1 subscription. Same as skuPartNumber.
+
+.EXAMPLE
+    Get-MtLicenseRelationship -skuId cf6b0d46-4093-4546-a0ab-0b1546dcc10e
+
+    Returns all subscriptions that include the Entra Identity Governance subscription. Matches Graph property, https://learn.microsoft.com/en-us/graph/api/resources/subscribedsku#properties
+
+.EXAMPLE
+    Get-MtLicenseRelationship -skuPartNumber Microsoft_Entra_ID_Governance
+
+    Returns all subscriptions that include the Entra Identity Governance subscription. Matches Graph property, https://learn.microsoft.com/en-us/graph/api/resources/subscribedsku#properties
+
+.LINK
+    https://maester.dev/docs/commands/Get-MtLicenseInformation
+#>
+function Get-MtLicenseRelationship {
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ParameterSetName = "regex")]
+        [regex]$regexSearchString,
+        [Parameter(Mandatory, ParameterSetName = "id")]
+        [guid]$servicePlanId,
+        [Parameter(Mandatory, ParameterSetName = "name")]
+        [string]$servicePlanName,
+        [Parameter(Mandatory, ParameterSetName = "sku")]
+        [guid]$skuId,
+        [Parameter(Mandatory, ParameterSetName = "pn")]
+        [string]$skuPartNumber
+    )
+
+    process {
+        if(-not (Test-Path $env:TEMP\maesterLicenses.csv)){
+            Update-MtLicenseCache
+        }
+
+        $plans = Import-Csv -Path $env:TEMP\maesterLicenses.csv
+
+        $relationships = @()
+
+        if($skuId){
+            $relationships = $plans | Where-Object {`
+                $_.GUID -eq $skuId
+            }
+        }elseif($servicePlanId){
+            $relationships = $plans | Where-Object {`
+                $_.Service_Plan_Id -eq $servicePlanId
+            }
+        }elseif($servicePlanName){
+            $relationships = $plans | Where-Object {`
+                $_.String_Id -eq $servicePlanName -or `
+                $_.Service_Plan_Name -eq $servicePlanName
+            }
+        }elseif($skuPartNumber){
+            $relationships = $plans | Where-Object {`
+                $_.String_Id -eq $skuPartNumber -or `
+                $_.Service_Plan_Name -eq $skuPartNumber
+            }
+        }elseif($regexSearchString){
+            foreach($plan in $plans){
+                $match = $regexSearchString.Match($plan.Product_Display_Name).Success -or `
+                    $regexSearchString.Match($plan.String_Id).Success -or `
+                    $regexSearchString.Match($plan.Service_Plan_Name).Success -or `
+                    $regexSearchString.Match($plan.Service_Plans_Included_Friendly_Names).Success
+
+                if($match){
+                    $relationships += $plan
+                }
+            }
+        }
+
+        return $relationships
+    }
+}

--- a/powershell/public/Update-MtLicenseCache.ps1
+++ b/powershell/public/Update-MtLicenseCache.ps1
@@ -8,6 +8,8 @@
 .EXAMPLE
     Update-MtLicenseCache
 
+.LINK
+    https://maester.dev/docs/commands/Update-MtLicenseCache
 #>
 function Update-MtLicenseCache {
     [OutputType([System.Void])]
@@ -46,5 +48,6 @@ function Update-MtLicenseCache {
         }
 
         Write-Verbose "$(($skus|Measure-Object).Count) SKUs in cache"
+        return $null
     }
 }

--- a/powershell/public/Update-MtLicenseCache.ps1
+++ b/powershell/public/Update-MtLicenseCache.ps1
@@ -13,10 +13,21 @@
 #>
 function Update-MtLicenseCache {
     [OutputType([System.Void])]
-    [CmdletBinding()]
-    param ()
+    [CmdletBinding(
+        SupportsShouldProcess,
+        ConfirmImpact = "Low"
+    )]
+
+    param (
+        [Switch]$Force,
+        [String]$FileName="maesterLicenses.csv"
+    )
 
     process {
+        if ($Force -and -not $Confirm){
+            $ConfirmPreference = "None"
+        }
+
         try{
             Write-Verbose "Attempting License Cache Update"
             $csv = Invoke-RestMethod -Uri "https://download.microsoft.com/download/e/3/e/e3e9faf2-f28b-490a-9ada-c6089a1fc5b0/Product%20names%20and%20service%20plan%20identifiers%20for%20licensing.csv"
@@ -26,16 +37,16 @@ function Update-MtLicenseCache {
             exit
         }
         Write-Verbose "Getting hash of downloaded content"
-        $hashNew = Get-FileHash -InputStream ([IO.MemoryStream]::new([text.encoding]::UTF8.GetBytes($skus2))) -Algorithm SHA256
+        $hashNew = Get-FileHash -InputStream ([IO.MemoryStream]::new([text.encoding]::UTF8.GetBytes($csv))) -Algorithm SHA256
 
-        if(Test-Path -Path $env:TEMP\maesterLicenses.csv){
+        if(Test-Path -Path $env:TEMP\$FileName){
             Write-Verbose "Cache exists"
-            $skus = Get-Content $env:TEMP\maesterLicenses.csv
+            $skus = Get-Content $env:TEMP\$FileName
             Write-Verbose "Getting cache hash"
             $hashOld = Get-FileHash -InputStream ([IO.MemoryStream]::new([text.encoding]::UTF8.GetBytes($skus))) -Algorithm SHA256
-            if($hashNew.Hash -ne $hashOld.Hash){
+            if($hashNew.Hash -ne $hashOld.Hash -and $PSCmdlet.ShouldProcess($FileName)){
                 Write-Verbose "Cache does not match download, overwriting"
-                $csv|Out-File $env:TEMP\maesterLicenses.csv
+                $csv|Out-File $env:TEMP\$FileName -Confirm:$false
                 $skus = $csv|ConvertFrom-Csv
             }else{
                 Write-Verbose "Cache matches"
@@ -43,7 +54,9 @@ function Update-MtLicenseCache {
             }
         }else{
             Write-Verbose "Cache does not exist, setting cache"
-            $csv|Out-File $env:TEMP\maesterLicenses.csv
+            if($PSCmdlet.ShouldProcess($FileName)){
+                $csv|Out-File $env:TEMP\$FileName -Confirm:$false
+            }
             $skus = $csv|ConvertFrom-Csv
         }
 

--- a/powershell/public/Update-MtLicenseCache.ps1
+++ b/powershell/public/Update-MtLicenseCache.ps1
@@ -8,6 +8,12 @@
 .EXAMPLE
     Update-MtLicenseCache
 
+.PARAMETER Force
+    Forces the cmdlet to update the cache file
+
+.PARAMETER FileName
+    Provides the file name for the cache file in the system temp directory
+
 .LINK
     https://maester.dev/docs/commands/Update-MtLicenseCache
 #>

--- a/powershell/public/Update-MtLicenseCache.ps1
+++ b/powershell/public/Update-MtLicenseCache.ps1
@@ -6,7 +6,7 @@
     This function retrieves the license information for known M365 Product SKUs using a list Microsoft maintains.
 
 .EXAMPLE
-    Update-MtLicenseCache
+    Update-MtLicenseCache -Force
 
 .PARAMETER Force
     Forces the cmdlet to update the cache file

--- a/powershell/public/Update-MtLicenseCache.ps1
+++ b/powershell/public/Update-MtLicenseCache.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Get license information for known M365 Products
+
+.DESCRIPTION
+    This function retrieves the license information for known M365 Product SKUs using a list Microsoft maintains.
+
+.EXAMPLE
+    Update-MtLicenseCache
+
+#>
+function Update-MtLicenseCache {
+    [OutputType([System.Void])]
+    [CmdletBinding()]
+    param ()
+
+    process {
+        try{
+            Write-Verbose "Attempting License Cache Update"
+            $csv = Invoke-RestMethod -Uri "https://download.microsoft.com/download/e/3/e/e3e9faf2-f28b-490a-9ada-c6089a1fc5b0/Product%20names%20and%20service%20plan%20identifiers%20for%20licensing.csv"
+        }
+        catch{
+            Write-Error $_
+            exit
+        }
+        Write-Verbose "Getting hash of downloaded content"
+        $hashNew = Get-FileHash -InputStream ([IO.MemoryStream]::new([text.encoding]::UTF8.GetBytes($skus2))) -Algorithm SHA256
+
+        if(Test-Path -Path $env:TEMP\maesterLicenses.csv){
+            Write-Verbose "Cache exists"
+            $skus = Get-Content $env:TEMP\maesterLicenses.csv
+            Write-Verbose "Getting cache hash"
+            $hashOld = Get-FileHash -InputStream ([IO.MemoryStream]::new([text.encoding]::UTF8.GetBytes($skus))) -Algorithm SHA256
+            if($hashNew.Hash -ne $hashOld.Hash){
+                Write-Verbose "Cache does not match download, overwriting"
+                $csv|Out-File $env:TEMP\maesterLicenses.csv
+                $skus = $csv|ConvertFrom-Csv
+            }else{
+                Write-Verbose "Cache matches"
+                $skus = $skus|ConvertFrom-Csv
+            }
+        }else{
+            Write-Verbose "Cache does not exist, setting cache"
+            $csv|Out-File $env:TEMP\maesterLicenses.csv
+            $skus = $csv|ConvertFrom-Csv
+        }
+
+        Write-Verbose "$(($skus|Measure-Object).Count) SKUs in cache"
+    }
+}


### PR DESCRIPTION
…ng relationships

Still trying to figure out how useful this will be. The current idea is to have an ability to check license relationships. `Get-MtLicenseInformation` uses just the base SKU as the bundles show that entitlement, so this isn't needed, but my thought is it may be helpful to get the relationships as well.

My other concern is I am not certain Microsoft will retain that download URL when updating in the future, would be ideal if it would be an aka.ms link instead.