### PR TITLE
Adjust RoleEligibilitySchedule scope

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.ps1
@@ -24,9 +24,9 @@ function Test-MtCisaCloudGlobalAdmin {
     }
 
     $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes
+    $permissionMissing = "RoleEligibilitySchedule.Read.Directory" -notin $scopes
     if($permissionMissing){
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
+        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.Read.Directory"
         return $null
     }
 

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
@@ -24,9 +24,9 @@ function Test-MtCisaGlobalAdminCount {
     }
 
     $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes
+    $permissionMissing = "RoleEligibilitySchedule.Read.Directory" -notin $scopes
     if($permissionMissing){
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
+        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.Read.Directory"
         return $null
     }
 


### PR DESCRIPTION
I have been doing some work around the CIS checks and came across this. These two tests seem like they might be over scoped, or at least that is what my testing seemed to indicate. Caveat I have an less than ideal test environment at the moment so I want a second opinion.

The original scope was `RoleEligibilitySchedule.ReadWrite.Directory` but in testing `RoleEligibilitySchedule.Read.Directory` seemed to work fine.

Could someone else test and confirm this for me? This would allow us to run these tests without the -Privileged flag