### PR TITLE
Update MS.AAD.8.2 test to allow "none"

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaGuestInvitation.md
+++ b/powershell/public/cisa/entra/Test-MtCisaGuestInvitation.md
@@ -5,7 +5,8 @@ Rationale: By only allowing an authorized group of individuals to invite externa
 #### Remediation action:
 
 1. In **Entra ID** and **External Identities**, select **[External collaboration settings](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/CompanyRelationshipsMenuBlade/~/Settings/menuId/Settings)**.
-2. Under **Guest invite settings**, select **Only users assigned to specific admin roles can invite guest users**.
+2. Under **Guest invite settings**, select **Only users assigned to specific admin roles can invite guest users** or **No one in the organization can invite guest users including admins (most restrictive)**.
+
 3. Click **Save**.
 
 #### Related links

--- a/powershell/public/cisa/entra/Test-MtCisaGuestInvitation.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGuestInvitation.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-    Checks if guest invitiations are restricted to admins
+    Checks if guest invitations are restricted to admins
 
 .DESCRIPTION
     Only users with the Guest Inviter role SHOULD be able to invite guest users.
@@ -8,7 +8,7 @@
 .EXAMPLE
     Test-MtCisaGuestInvitation
 
-    Returns true if guest invitiations are restricted to admins
+    Returns true if guest invitations are restricted to admins
 
 .LINK
     https://maester.dev/docs/commands/Test-MtCisaGuestInvitation
@@ -25,12 +25,12 @@ function Test-MtCisaGuestInvitation {
 
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion v1.0
 
-    $testResult = $result.allowInvitesFrom -eq "adminsAndGuestInviters"
+    $testResult = ($result.allowInvitesFrom -eq "adminsAndGuestInviters") -or ($result.allowInvitesFrom -eq "none")
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant restricts who can invite guests:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant restricts who can invite guests:`n`nallowInvitesFrom : $($result.allowInvitesFrom)"
     } else {
-        $testResultMarkdown = "Your tenant allows anyone to invite guests."
+        $testResultMarkdown = "Your tenant allows anyone to invite guests.`n`nallowInvitesFrom : $($result.allowInvitesFrom)"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
     return $testResult


### PR DESCRIPTION
Fix for https://github.com/maester365/maester/issues/453, "MS.AAD.8.2 will fail if allowInvitesFrom is set to none"

