### PR TITLE
Migrate MtCisaContactSharing to use Get-MtExo caching

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaContactSharing.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaContactSharing.ps1
@@ -23,7 +23,7 @@ function Test-MtCisaContactSharing {
         return $null
     }
 
-    $policies = Get-MtSharingPolicy
+    $policies = Get-MtExo -Request SharingPolicy
 
     $resultPolicies = $policies | Where-Object {`
         $_.Enabled -and `


### PR DESCRIPTION
MtCisaContactSharing was calling Get-SharingPolicy instead of using the Get-MtExo cached version. Migrated to using the cached version for consistency and speed.