### PR TITLE
Fixed CIS Policy Checks

### DIFF
--- a/powershell/public/cis/Test-MtCisAttachmentFilter.md
+++ b/powershell/public/cis/Test-MtCisAttachmentFilter.md
@@ -1,12 +1,9 @@
 2.1.2 (L1) Ensure the Common Attachment Types Filter is enabled
 
 **Rationale:**
-
 Blocking known malicious file types can help prevent malware-infested files from infecting a host.
 
 #### Remediation action:
-
-
 
 To enable the Common Attachment Types Filter:
 1. Navigate to Microsoft 365 Defender [https://security.microsoft.com](https://security.microsoft.com).

--- a/powershell/public/cis/Test-MtCisAttachmentFilter.ps1
+++ b/powershell/public/cis/Test-MtCisAttachmentFilter.ps1
@@ -1,9 +1,9 @@
 ﻿<#
 .SYNOPSIS
-    Checks if the default common attadchment types filter is enabled
+    Checks if the default common attachment types filter is enabled
 
 .DESCRIPTION
-    The common attachment types fileter should be enabled
+    The common attachment types filter should be enabled
 
 .EXAMPLE
     Test-MtCisAttachmentFilter
@@ -32,7 +32,10 @@ function Test-MtCisAttachmentFilter {
     }
 
     Write-Verbose "Getting Malware Filter Policy..."
-    $policy = Get-MtExo -Request MalwareFilterPolicy
+    $policies = Get-MtExo -Request MalwareFilterPolicy
+
+    # We grab the default policy as that is what CIS checks
+    $policy = $policies | Where-Object { $_.Name -eq 'Default' }
 
     Write-Verbose "Executing checks"
     $fileFilter = $policy | Where-Object {
@@ -44,10 +47,10 @@ function Test-MtCisAttachmentFilter {
     $portalLink = "https://security.microsoft.com/presetSecurityPolicies"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has the common attachment file filter enabled ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenants default malware filter policy has the common attachment file filter enabled ($portalLink).`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "Your tenant does not have the common attachment file filter enabled ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenants default malware filter policy does not have the common attachment file filter enabled ($portalLink).`n`n%TestResult%"
     }
 
     $resultMd = "| Policy | Result |`n"

--- a/powershell/public/cis/Test-MtCisInternalMalwareNotification.ps1
+++ b/powershell/public/cis/Test-MtCisInternalMalwareNotification.ps1
@@ -32,7 +32,10 @@ function Test-MtCisInternalMalwareNotification {
     }
 
     Write-Verbose "Getting Malware Filter Policy..."
-    $policy = Get-MtExo -Request MalwareFilterPolicy
+    $policies = Get-MtExo -Request MalwareFilterPolicy
+
+    # We grab the default policy as that is what CIS checks
+    $policy = $policies | Where-Object { $_.Name -eq 'Default' }
 
     Write-Verbose "Executing checks"
     $enableInternalSenderAdminNotification = $policy | Where-Object {
@@ -48,10 +51,10 @@ function Test-MtCisInternalMalwareNotification {
     $portalLink = "https://security.microsoft.com/antimalwarev2"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has the recommended internal malware notifications configured ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenants default anti malware policy has recommended internal malware notifications configured ($portalLink).`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "Your tenant does not have the recommended internal malware notifications configured ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenants default anti malware policy does not have the recommended internal malware notifications configured ($portalLink).`n`n%TestResult%"
     }
 
     $resultMd = "| Policy | Result |`n"

--- a/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.ps1
@@ -32,7 +32,10 @@ function Test-MtCisOutboundSpamFilterPolicy {
     }
 
     Write-Verbose "Getting Outbound Spam Filter Policy..."
-    $policy = Get-MtExo -Request HostedOutboundSpamFilterPolicy
+    $policies = Get-MtExo -Request HostedOutboundSpamFilterPolicy
+
+    # We grab the default policy as that is what CIS checks
+    $policy = $policies | Where-Object { $_.Name -eq 'Default' }
 
     $OutboundSpamFilterPolicyCheckList = @()
 
@@ -67,10 +70,10 @@ function Test-MtCisOutboundSpamFilterPolicy {
     $portalLink = "https://security.microsoft.com/antispam"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has Exchange Online Spam Policies set to notify administrators ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenants default Exchange Online Spam policy set to notify administrators ($portalLink).`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "Your tenant does not have Exchange Online Spam Policies set to notify administrators ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenants default Exchange Online Spam policy is not set to notify administrators ($portalLink).`n`n%TestResult%"
     }
 
 

--- a/powershell/public/cis/Test-MtCisSafeAttachment.ps1
+++ b/powershell/public/cis/Test-MtCisSafeAttachment.ps1
@@ -32,7 +32,10 @@ function Test-MtCisSafeAttachment {
     }
 
     Write-Verbose "Getting Safe Attachment Policy..."
-    $policy = Get-MtExo -Request SafeAttachmentPolicy
+    $policies = Get-MtExo -Request SafeAttachmentPolicy
+
+    # We grab the default policy as that is what CIS checks
+    $policy = $policies | Where-Object { $_.Name -eq 'Built-In Protection Policy' }
 
     $safeAttachmentCheckList = @()
 
@@ -72,10 +75,10 @@ function Test-MtCisSafeAttachment {
     $portalLink = "https://security.microsoft.com/safeattachmentv2"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has the safe attachment policy enabled ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenants default safe attachments policy matches CIS recommendations ($portalLink).`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "Your tenant does not have the safe attachment policy enabled ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenants default safe attachments policy does not match CIS recommendations ($portalLink).`n`n%TestResult%"
     }
 
 

--- a/powershell/public/cis/Test-MtCisSafeLink.ps1
+++ b/powershell/public/cis/Test-MtCisSafeLink.ps1
@@ -32,7 +32,10 @@ function Test-MtCisSafeLink {
     }
 
     Write-Verbose "Getting Safe Links Policy..."
-    $policy = Get-MtExo -Request SafeLinksPolicy
+    $policies = Get-MtExo -Request SafeLinksPolicy
+
+    # We grab the default policy as that is what CIS checks
+    $policy = $policies | Where-Object { $_.Name -eq 'Built-In Protection Policy' }
 
     $safeLinkCheckList = @()
 
@@ -108,10 +111,10 @@ function Test-MtCisSafeLink {
     $portalLink = "https://security.microsoft.com/presetSecurityPolicies"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has the recommended safelink settings configured ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenants default safe link policy matches CIS recommendations ($portalLink).`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "Your tenant does not have the recommended safelink settings configured ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenants default safe link policy does not match CIS recommendations ($portalLink).`n`n%TestResult%"
     }
 
 

--- a/tests/cis/Test-MtCisAttachmentFilter.Tests.ps1
+++ b/tests/cis/Test-MtCisAttachmentFilter.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "CIS" -Tag "CIS 2.1.2", "L1", "CIS E3 Level 1", "CIS E3", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "CIS 2.1.2 (L1) Ensure the Common Attachment Types Filter is enabled" {
+    It "CIS 2.1.2 (L1) Ensure the Common Attachment Types Filter is enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisAttachmentFilter
 
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "the common attachment file filter is enabled."
+            $result | Should -Be $true -Because "the default malware filter policy has the common attachment file filter is enabled."
         }
     }
 }

--- a/tests/cis/Test-MtCisInternalMalwareNotification.Tests.ps1
+++ b/tests/cis/Test-MtCisInternalMalwareNotification.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "CIS" -Tag "CIS 2.1.3", "L1", "CIS E3 Level 1", "CIS E3", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.3 (L1) Ensure notifications for internal users sending malware is Enabled" {
+    It "2.1.3 (L1) Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisInternalMalwareNotification
 
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "internal malware notifications are enabled."
+            $result | Should -Be $true -Because "the default malware filter policy has malware notifications enabled."
         }
     }
 }

--- a/tests/cis/Test-MtCisOutboundSpamFilterPolicy.Tests.ps1
+++ b/tests/cis/Test-MtCisOutboundSpamFilterPolicy.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "CIS" -Tag "CIS 2.1.6", "L1", "CIS E3 Level 1", "CIS E3", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.6 (L1) Ensure Exchange Online Spam Policies are set to notify administrators" {
+    It "2.1.6 (L1) Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy)" {
 
         $result = Test-MtCisOutboundSpamFilterPolicy
 
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "the Exchange Online Spam Policies are set to notify administrators."
+            $result | Should -Be $true -Because "the default Exchange Online Spam policy is set to notify administrators."
         }
     }
 }

--- a/tests/cis/Test-MtCisSafeAttachment.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeAttachment.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "CIS" -Tag "CIS 2.1.4", "L2", "CIS E5 Level 2", "CIS E5", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.4 (L2) Ensure Safe Attachments policy is enabled" {
+    It "2.1.4 (L2) Ensure Safe Attachments policy is enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisSafeAttachment
 
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "the Safe Attachement policy is enabled."
+            $result | Should -Be $true -Because "the default Safe Attachement policy matches CIS recommendations."
         }
     }
 }

--- a/tests/cis/Test-MtCisSafeLink.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeLink.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "CIS" -Tag "CIS 2.1.1", "L2", "CIS E5 Level 2", "CIS E5", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.1 (L2) Ensure Safe Links for Office Applications is Enabled" {
+    It "2.1.1 (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisSafeLink
 
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "safe links office applications are Enabled"
+            $result | Should -Be $true -Because "the default safe link policy matches CIS recommendations"
         }
     }
 }

--- a/website/docs/tests/cis/readme.md
+++ b/website/docs/tests/cis/readme.md
@@ -21,6 +21,8 @@ See the [Installation guide](/docs/installation#optional-modules-and-permissions
 
 ## Tests
 
+It is important to note that a number of the policy checks ONLY check the default policy, and not every policy. CIS 2.1.7 `Test-MtCisSafeAntiPhishingPolicy` is one example.
+
 | Cmdlet Name | CIS Recommendation ID |
 | - | - |
 | Test-MtCisCloudAdmin | 1.1.1 (L1) Ensure Administrative accounts are separate and cloud-only |


### PR DESCRIPTION
Reconfigured the CIS based policy checks to specifically check the default policy. Prior to this I am not 100% what the outcome of the existing logic would have been which is an oversight. It likely only considered the first policy listed.

Checking the default policy is typically how CIS provides automated guidance. Where only the default policy is checked, it states this in the title of the output for clarity.

In the future we can probably make this better and check all policies for the desired outcome, but for now I think the clarity of the check is more important.