### PR TITLE
Update action.yml to fix artifact not being uploaded

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
 
     - name: Archive Maester Html Report
       uses: actions/upload-artifact@v4
-      if: ${{ inputs.artifact_upload == true }}
+      if: ${{ inputs.artifact_upload == 'true' }}
       with:
         name: maester-test-results-${{ env.NOW }}
         path: test-results


### PR DESCRIPTION
true != 'true'

This causes artifact upload to not be executed.

From the debug logs.
##[debug]Evaluating: (success() && (inputs.artifact_upload == true)) ##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating Equal:
##[debug]....Evaluating Index:
##[debug]......Evaluating inputs:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'artifact_upload'
##[debug]....=> 'true'
##[debug]....Evaluating Boolean:
##[debug]....=> true
##[debug]..=> false
##[debug]=> false
##[debug]Expanded: (true && ('true' == true))
##[debug]Result: false


actions.yml line 145 in the section regarding "Archive Maester Html Report"
      if: ${{ inputs.artifact_upload == true }}
      
example of working example from  "Checkout latest public tests"
line 67
      if: ${{ inputs.include_public_tests == 'true' }}