### PR TITLE
Skip certain MSFT recommendations when the tenant has no license assigned

### DIFF
--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -1,11 +1,24 @@
 BeforeDiscovery {
-    $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
     $EntraRecommendations = Invoke-MtGraphRequest -DisableCache -ApiVersion beta -RelativeUri 'directory/recommendations?$expand=impactedResources' -OutputType Hashtable
     Write-Verbose "Found $($EntraRecommendations.Count) Entra recommendations"
 }
 
 Describe "Entra Recommendations" -Tag "Maester", "Entra", "Security", "All", "Recommendation" -ForEach $EntraRecommendations {
     It "MT.1024: Entra Recommendation - <displayName>. See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024" {
+        $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
+        $EntraPremiumRecommendations = @(
+            "insiderRiskPolicy",
+            "userRiskPolicy",
+            "signinRiskPolicy"
+        )
+        if ( $EntraIDPlan -ne "P2" ) {
+            $EntraPremiumRecommendations | ForEach-Object {
+                if ( $id -match "$($_)$" ) {
+                    Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP2
+                    return $null
+                }
+            }
+        }
         #region Add detailed test description
         $ActionSteps = $actionSteps | Sort-Object -Property 'stepNumber' | ForEach-Object {
             $_.text + "[$($_.actionUrl.displayName)]($($_.actionUrl.url))."


### PR DESCRIPTION
This pull request addresses the issue of skipping certain Microsoft recommendations when the tenant has no license assigned. It includes changes to the code that check for the EntraIDPlan and skip premium recommendations if the plan is not "P2". This ensures that the recommendations are only applied when the appropriate license is assigned.