### PR TITLE
Improve Tag handling and Prerelease & Telemetry in actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,11 +27,11 @@ inputs:
     required: false
     default: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
   include_tags:
-    description: "A list of tags to include in the test run. Please separate multiple tags with a comma."
+    description: "A list of tags to include in the test run. Please separate multiple tags with a comma (without space)."
     required: false
     default: ""
   exclude_tags:
-    description: "A list of tags to exclude from the test run. Please separate multiple tags with a comma."
+    description: "A list of tags to exclude from the test run. Please separate multiple tags with a comma (without space)."
     required: false
     default: ""
   pester_verbosity:
@@ -48,6 +48,11 @@ inputs:
     description: "Define whether the results are uploaded as Artifacts."
     required: false
     default: true
+  install_prerelease:
+    type: boolean
+    description: "Installs the Preview version, allowing access to new cmdlets"
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -87,7 +92,11 @@ runs:
           Connect-MgGraph -AccessToken $accessToken -NoWelcome
 
           # Install Maester
-          Install-Module Maester -Force
+          if(!$install_prerelease){
+            Install-Module Maester -Force
+          } else {
+            Install-Module Maester -AllowPrerelease -Force
+          }
 
           # Configure test results
           $PesterConfiguration = New-PesterConfiguration

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,12 @@ inputs:
     default: true
   install_prerelease:
     type: boolean
-    description: "Installs the Preview version, allowing access to new cmdlets"
+    description: "Installs the preview version, allowing access to new cmdlets."
+    required: false
+    default: false
+  disable_telemetry:
+    type: boolean
+    description: "If set, telemetry information will not be logged."
     required: false
     default: false
 
@@ -92,10 +97,10 @@ runs:
           Connect-MgGraph -AccessToken $accessToken -NoWelcome
 
           # Install Maester
-          if(!$install_prerelease){
-            Install-Module Maester -Force
-          } else {
+          if ( [string]::IsNullOrWhiteSpace( '${{ inputs.install_prerelease}}' ) -eq $true ){
             Install-Module Maester -AllowPrerelease -Force
+          } else {
+            Install-Module Maester -Force
           }
 
           # Configure test results
@@ -137,6 +142,11 @@ runs:
               } else {
                   Write-Warning "Mail recipients are not provided. Skipping mail notification."
               }
+          }
+
+          # Check if disable telemetry is provided
+          if (( [string]::IsNullOrWhiteSpace( '${{ inputs.disable_telemetry}}' ) -eq $true ){
+            $MaesterParameters.Add( 'DisableTelemetry', $true )
           }
 
           # Run Maester tests

--- a/powershell/internal/ConvertTo-MtMaesterResults.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResults.ps1
@@ -68,7 +68,7 @@ function ConvertTo-MtMaesterResult {
         $mtTestInfo = [PSCustomObject]@{
             Name            = $name
             HelpUrl         = $helpUrl
-            Tag             = $test.Block.Tag
+            Tag             = ($test.Block.Tag + $test.Tag | Select-Object -Unique) ?? @()
             Result          = $test.Result
             ScriptBlock     = $test.ScriptBlock.ToString()
             ScriptBlockFile = $test.ScriptBlock.File

--- a/powershell/internal/ConvertTo-MtMaesterResults.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResults.ps1
@@ -68,7 +68,7 @@ function ConvertTo-MtMaesterResult {
         $mtTestInfo = [PSCustomObject]@{
             Name            = $name
             HelpUrl         = $helpUrl
-            Tag             = ($test.Block.Tag + $test.Tag | Select-Object -Unique) ?? @()
+            Tag             = ($test.Block.Tag + $test.Tag | Select-Object -Unique)
             Result          = $test.Result
             ScriptBlock     = $test.ScriptBlock.ToString()
             ScriptBlockFile = $test.ScriptBlock.File

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -62,7 +62,7 @@
     It "MT.1036: All excluded objects should have a fallback include in another policy. See https://maester.dev/docs/tests/MT.1036" -Tag "MT.1036", "Warning" {
         Test-MtCaGap | Should -Be $true -Because "there is one ore more object excluded without an include fallback in another policy."
     }
-    Context "License utilization" {
+    Context "License utilization" -Tag "LicenseUtilization" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {
             $LicenseReport = Test-MtCaLicenseUtilization -License "P1"
             $LicenseReport.TotalLicensesUtilized | Should -BeLessOrEqual $LicenseReport.EntitledLicenseCount -Because "this is the maximium number of user that can utilize a P1 license"
@@ -81,6 +81,15 @@ Describe "Security Defaults" -Tag "CA", "Security", "All" {
             Add-MtTestResultDetail -SkippedBecause LicensedEntraIDPremium
         } else {
             $SecurityDefaults = Invoke-MtGraphRequest -RelativeUri "policies/identitySecurityDefaultsEnforcementPolicy" -ApiVersion beta | Select-Object -ExpandProperty isEnabled
+
+            if ($SecurityDefaults -eq $true) {
+                $testResultMarkdown = "Well done. SecurityDefaults are On `n`n"
+            } else {
+                $testResultMarkdown = "SecurityDefaults are Off '$($SecurityDefaults)' `n`n"
+            }
+            $testDetailsMarkdown = "You should enable SecurityDefaults or configure Conditional Access."
+            Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown
+
             $SecurityDefaults | Should -Be $true -Because "Security Defaults are not enabled"
         }
     }

--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -4,7 +4,7 @@ BeforeDiscovery {
 }
 
 Describe "Entra Recommendations" -Tag "Maester", "Entra", "Security", "All", "Recommendation" -ForEach $EntraRecommendations {
-    It "MT.1024: Entra Recommendation - <displayName>. See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024" {
+    It "MT.1024: Entra Recommendation - <displayName>. See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024", $recommendationType {
         $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
         $EntraPremiumRecommendations = @(
             "insiderRiskPolicy",
@@ -36,7 +36,7 @@ Describe "Entra Recommendations" -Tag "Maester", "Entra", "Security", "All", "Re
                 $impactedResourcesList += "| $($resourceResult) | [$($resource.displayName)]($($resource.portalUrl)) | $($resource.addedDateTime) | `n"
             }
         }
-        $ResultMarkdown = $insights + $impactedResourcesList + "`n`n#### Remediation actions:`n`n" + $ActionSteps
+        $ResultMarkdown = $insights + $impactedResourcesList + "`n`n#### Remediation actions:`n`n" + $ActionSteps + "`n`n ExcludeTag: $($recommendationType)"
         Add-MtTestResultDetail -Description $benefits -Result $ResultMarkdown
         #endregion
         # Actual test

--- a/website/docs/commands/Invoke-Maester.mdx
+++ b/website/docs/commands/Invoke-Maester.mdx
@@ -125,6 +125,21 @@ Invoke-Maester -PesterConfiguration $configuration
 
 ```
 
+### EXAMPLE 12
+
+```powershell
+$exclude_tags1 = @('CA', 'App') # System.Array
+$exclude_tags2 = @('MT.1028', 'MT.1024') # System.Array
+
+$exclude_tags_combined = $exclude_tags1 + $exclude_tags2
+
+#Invoke-Maester -ExcludeTag $exclude_tags_combined -Verbose
+Invoke-Maester -ExcludeTag $exclude_tags_combined
+```
+
+This combines two arrays of exclusion tags and runs the tests, excluding any tests with those tags.
+
+
 ## PARAMETERS
 
 ### -Path


### PR DESCRIPTION
**Improve Tag handling**
Include all tags from configuration files in the report. Previously, tags were only excluded (hard to know which ones)

- Related to: https://github.com/maester365/maester/issues/411

**Prerelease in Actions**
The attribute "exclude_tags" is currently ineffective for cmdlets missing in the module.
Underlying issue: The tests are newer than the PowerShell module version.
Workaround: Add possibility switch to the preview modules until this issue is looked at.

```
# The term 'Test-Mt*' is not recognized as a name of a cmdlet, function, script file, or executable program.
# Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

Indirect related to:
1. https://github.com/maester365/maester/issues/193
2. https://github.com/maester365/maester/issues/365
3. https://github.com/maester365/maester/issues/466
