### PR TITLE
Added support for 'RoleManagement.ReadWrite.Directory' as privileged …

### DIFF
--- a/powershell/public/Get-MtRoleMember.ps1
+++ b/powershell/public/Get-MtRoleMember.ps1
@@ -79,7 +79,7 @@ function Get-MtRoleMember {
     if ($Active) {
       $types += @{active = "roleManagement/directory/roleAssignments" }
     }
-    if ($Eligible -and "RoleEligibilitySchedule.ReadWrite.Directory" -in $scopes) {
+    if ($Eligible -and ("RoleEligibilitySchedule.ReadWrite.Directory" -in $scopes -or "RoleManagement.ReadWrite.Directory" -in $scopes)) {
       $types += @{eligible = "roleManagement/directory/roleEligibilityScheduleRequests" }
     } elseif ($Eligible) {
       Write-Warning "Skipping eligible roles as required Graph permission 'RoleEligibilitySchedule.ReadWrite.Directory' was not present."

--- a/powershell/public/cis/Test-MtCisGlobalAdminCount.ps1
+++ b/powershell/public/cis/Test-MtCisGlobalAdminCount.ps1
@@ -25,7 +25,7 @@ function Test-MtCisGlobalAdminCount {
     }
 
     $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes
+    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes -and "RoleManagement.ReadWrite.Directory" -notin $scopes
     if ($permissionMissing) {
         Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
         return $null

--- a/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.ps1
@@ -24,7 +24,7 @@ function Test-MtCisaCloudGlobalAdmin {
     }
 
     $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes
+    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes -and "RoleManagement.ReadWrite.Directory" -notin $scopes
     if($permissionMissing){
         Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
         return $null

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
@@ -24,7 +24,7 @@ function Test-MtCisaGlobalAdminCount {
     }
 
     $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes
+    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes -and "RoleManagement.ReadWrite.Directory" -notin $scopes
     if($permissionMissing){
         Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
         return $null

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminRatio.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminRatio.ps1
@@ -24,7 +24,7 @@ function Test-MtCisaGlobalAdminRatio {
     }
 
     $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes
+    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes -and "RoleManagement.ReadWrite.Directory" -notin $scopes
     if($permissionMissing){
         Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
         return $null


### PR DESCRIPTION
…role. #537  for more information.

Change is based on the documentation from Microsoft ([Link](https://learn.microsoft.com/en-us/graph/api/rbacapplication-list-roleeligibilityschedulerequests?view=graph-rest-1.0&tabs=http)).
Also tested that this privilege works when calling:
`Invoke-MgGraphRequest -Method GET -Uri 'https://graph.microsoft.com/v1.0/roleManagement/directory/roleEligibilityScheduleRequests?$expand=principal'`