### PR TITLE
#545 Refine documentation for Invoke-Maester to clarify Path parameter usage

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -79,7 +79,7 @@ function Invoke-Maester {
     [Alias("Invoke-MtMaester")]
     [CmdletBinding()]
     param (
-        # Specifies one or more paths to files containing tests. The value is a path\file name or name pattern. Wildcards are permitted.
+        # Specifies path to files containing tests. The value is a path\file name or name pattern. Wildcards are permitted.
         [Parameter(Position = 0)]
         [string] $Path,
 

--- a/website/docs/commands/Invoke-Maester.mdx
+++ b/website/docs/commands/Invoke-Maester.mdx
@@ -129,7 +129,7 @@ Invoke-Maester -PesterConfiguration $configuration
 
 ### -Path
 
-Specifies one or more paths to files containing tests.
+Specifies path to files containing tests.
 The value is a path\file name or name pattern.
 Wildcards are permitted.
 


### PR DESCRIPTION
Closes #545 

Updates the `Invoke-Maester` documentation for `Path` parameter usage. It turns out that you can't pass multiple paths with the parameter so modifying the documentation to reflect that user can pass one path value only.