### PR TITLE
Improve handling for Entra ID Free Tenants

### DIFF
--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -21,7 +21,12 @@ function Test-MtEidscaAP01 {
     [OutputType([bool])]
     param()
 
-    
+    $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
+    if($EntraIDPlan -eq "Free"){
+        Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
+        return $null
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToUseSSPR

--- a/powershell/internal/eidsca/Test-MtEidscaAP05.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP05.md
@@ -8,6 +8,13 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 .allowedToSignUpEmailBasedSubscriptions = 'false'
 ```
 
+#### How to fix
+
+```powershell
+# Get-MgPolicyAuthorizationPolicy | Select-Object AllowedToSignUpEmailBasedSubscriptions
+Update-MgPolicyAuthorizationPolicy -AllowedToSignupEmailBasedSubscriptions $false
+```
+
 #### Related links
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.md
@@ -12,7 +12,8 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Azure admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
@@ -21,10 +21,18 @@ function Test-MtEidscaPR01 {
     [OutputType([bool])]
     param()
 
+    $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
+    if($EntraIDPlan -eq "Free"){
+        Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
+        return $null
+    }
+
     if ( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
             return $null
     }
+
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'BannedPasswordCheckOnPremisesMode' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.md
@@ -12,7 +12,8 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Azure admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -21,7 +21,17 @@ function Test-MtEidscaPR05 {
     [OutputType([bool])]
     param()
 
-    
+    $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
+    if($EntraIDPlan -eq "Free"){
+        Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
+        return $null
+    }
+
+    if ( $SettingsApiAvailable -notcontains 'LockoutDurationInSeconds' ) {
+        Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+        return $null
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.md
@@ -12,7 +12,8 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Azure admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
@@ -21,7 +21,17 @@ function Test-MtEidscaPR06 {
     [OutputType([bool])]
     param()
 
-    
+    $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
+    if($EntraIDPlan -eq "Free"){
+        Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
+        return $null
+    }
+
+    if ( $SettingsApiAvailable -notcontains 'LockoutThreshold' ) {
+        Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+        return $null
+    }
+
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutThreshold' | select-object -expand value

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR05" {
-    It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" {
+    It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value >= '60'
@@ -150,7 +150,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR06" {
-    It "EIDSCA.PR06: Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. See https://maester.dev/docs/tests/EIDSCA.PR06" {
+    It "EIDSCA.PR06: Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. See https://maester.dev/docs/tests/EIDSCA.PR06" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutThreshold' | select-object -expand value = '10'

--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -5,12 +5,13 @@ BeforeDiscovery {
 
 Describe "Entra Recommendations" -Tag "Maester", "Entra", "Security", "All", "Recommendation" -ForEach $EntraRecommendations {
     It "MT.1024: Entra Recommendation - <displayName>. See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024" {
-        $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
+
         $EntraPremiumRecommendations = @(
             "insiderRiskPolicy",
             "userRiskPolicy",
             "signinRiskPolicy"
         )
+        $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
         if ( $EntraIDPlan -ne "P2" ) {
             $EntraPremiumRecommendations | ForEach-Object {
                 if ( $id -match "$($_)$" ) {
@@ -19,6 +20,12 @@ Describe "Entra Recommendations" -Tag "Maester", "Entra", "Security", "All", "Re
                 }
             }
         }
+
+        if ( $status -match "dismissed" ) {
+            Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Status:Dismissed for '$($id)'"
+            return $null
+        }
+
         #region Add detailed test description
         $ActionSteps = $actionSteps | Sort-Object -Property 'stepNumber' | ForEach-Object {
             $_.text + "[$($_.actionUrl.displayName)]($($_.actionUrl.url))."


### PR DESCRIPTION
**List of Changes:**
- Edit features which are failing for Entra ID Free licensed Tenants
- Add implementation in documentation for AllowedToSignupEmailBasedSubscriptions
- Update Links in documentation from "portal.azure.com" to "entra.microsoft.com"
- Skip dismissed Entra Recommendations (Example: 'passwordHashSync' was never enabled in Tenant) > Moved to https://github.com/maester365/maester/pull/564
