### PR TITLE
fix(MT.1006 and MT.1014): Correctly handle empty includeUsers collection in policy conditions

### DIFF
--- a/powershell/public/Test-MtCaDeviceComplianceAdminsExists.ps1
+++ b/powershell/public/Test-MtCaDeviceComplianceAdminsExists.ps1
@@ -72,7 +72,7 @@ See [Require compliant or Microsoft Entra hybrid joined device for administrator
     $PolicyIncludesAllRoles = $true
     $AdministrativeRolesToCheck | ForEach-Object {
       if ( ( $_ -notin $policy.conditions.users.includeRoles `
-            -and $policy.conditions.users.includeUsers -ne 'All' ) `
+            -and $policy.conditions.users.includeUsers -notcontains 'All' ) `
           -or $_ -in $policy.conditions.users.excludeRoles `
       ) {
         $PolicyIncludesAllRoles = $false

--- a/powershell/public/Test-MtCaMfaForAdmin.ps1
+++ b/powershell/public/Test-MtCaMfaForAdmin.ps1
@@ -49,7 +49,7 @@ function Test-MtCaMfaForAdmin {
         $PolicyIncludesAllRoles = $true
         $AdministrativeRolesToCheck | ForEach-Object {
             if ( ( $_ -notin $policy.conditions.users.includeRoles `
-                        -and $policy.conditions.users.includeUsers -ne 'All' ) `
+                        -and $policy.conditions.users.includeUsers -notcontains 'All' ) `
                     -or $_ -in $policy.conditions.users.excludeRoles `
             ) {
                 $PolicyIncludesAllRoles = $false


### PR DESCRIPTION
**Fix Policy Conditions Bug**

This pull request fixes a bug in the policy conditions logic where an empty `includeUsers` collection would incorrectly return `false` when checking if `'All'` is not included.

The bug was caused by the use of the `-ne` operator, which filters out the [right-hand side of the comparison and returns the rest of the collection](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4#-eq-and--ne). When the collection is empty, this would return an empty collection, [which is always considered `false`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_booleans?view=powershell-7.4#converting-from-collection-types).

By changing the comparison to use the `-notcontains` operator, we ensure that the check always returns a boolean value, correctly handling the case where the `includeUsers` collection is empty.

**Changes:**

* Replaced `-ne` with `-notcontains` in policy conditions logic