### PR TITLE
Proposal(Test-MtCaGroupsRestricted): Inconsistent Case in $UnrestrictedGroups

### DIFF
--- a/powershell/public/Test-MtCaGroupsRestricted.ps1
+++ b/powershell/public/Test-MtCaGroupsRestricted.ps1
@@ -52,7 +52,7 @@ Function Test-MtCaGroupsRestricted {
     -not $_.isManagementRestricted -and -not $_.isAssignableToRole
 }
 
-  $result = ($unrestrictedGroups | Measure-Object).Count -eq 0
+  $result = ($UnrestrictedGroups | Measure-Object).Count -eq 0
 
   if ( $result ) {
     $ResultDescription = "Well done! All security groups with assignment in Conditional Access are protected!"


### PR DESCRIPTION
**Inconsistent Case in $UnrestrictedGroups**

This pull request resolves an inconsistency the case of the `$UnrestrictedGroups` variable.

**Changes:**

- Updated the variable name to use the correct case, replacing `$unrestrictedGroups` with `$UnrestrictedGroups`