### PR TITLE
Cleanup in Prep for v1

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -152,7 +152,8 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Update-MaesterTests', 'Compare-MtTestResult',  'Get-MailAuthenticationRecord',
                'ConvertFrom-MailAuthenticationRecordSpf', 'ConvertFrom-MailAuthenticationRecordMx',
                'ConvertFrom-MailAuthenticationRecordDmarc', 'ConvertFrom-MailAuthenticationRecordDkim',
-               'Resolve-SpfRecord', 'Clear-MtDnsCache'
+               'Resolve-SpfRecord', 'Clear-MtDnsCache',
+               'Test-MtTeamsRestrictParticipantGiveRequestControl'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/powershell/internal/Get-MtSkippedReason.ps1
+++ b/powershell/internal/Get-MtSkippedReason.ps1
@@ -9,10 +9,10 @@ function Get-MtSkippedReason {
     )
 
     switch($SkippedBecause){
-        "NotConnectedAzure" { "Not connected to Azure. See [Connecting to Azure](https://maester.dev/docs/installation#optional-modules-and-permissions)"; break}
-        "NotConnectedExchange" { "Not connected to Exchange Online. See [Connecting to Exchange Online](https://maester.dev/docs/installation#optional-modules-and-permissions)"; break}
-        "NotConnectedSecurityCompliance" { "Not connected to Security & Compliance. See [Connecting to Security & Compliance](https://maester.dev/docs/installation#optional-modules-and-permissions)"; break}
-        "NotConnectedTeams" { "Not connected to Teams. See [Connecting to Teams](https://maester.dev/docs/installation#optional-modules-and-permissions)"; break} # Docs?
+        "NotConnectedAzure" { "Not connected to Azure. See [Connecting to Azure](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
+        "NotConnectedExchange" { "Not connected to Exchange Online. See [Connecting to Exchange Online](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
+        "NotConnectedSecurityCompliance" { "Not connected to Security & Compliance. See [Connecting to Security & Compliance](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
+        "NotConnectedTeams" { "Not connected to Teams. See [Connecting to Teams](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
         "NotConnectedGraph" { "Not connected to Graph. See [Connect-Maester](https://maester.dev/docs/commands/Connect-Maester#examples)"; break}
         "NotDotGovDomain" { "This test is only for federal, executive branch, departments and agencies. To override use [Test-MtCisaDmarcAggregateCisa -Force](https://maester.dev/docs/commands/Test-MtCisaDmarcAggregateCisa)"; break}
         "NotLicensedEntraIDP1" { "This test is for tenants that are licensed for Entra ID P1. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)"; break}

--- a/powershell/public/Get-MtGroupMember.ps1
+++ b/powershell/public/Get-MtGroupMember.ps1
@@ -21,6 +21,13 @@ function Get-MtGroupMember {
     [switch]$Recursive
   )
 
+  try{
+    Invoke-MtGraphRequest -RelativeUri "groups/$GroupId/" -ApiVersion v1.0|Out-Null
+  }catch{
+    Write-Error "Error obtaining group ($GroupId) from Microsoft Graph. Confirm the group exists in your tenant."
+    return $null
+  }
+
   Write-Verbose -Message "Getting group members."
 
   $members = @()

--- a/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.md
+++ b/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.md
@@ -1,0 +1,23 @@
+This test checks the Org-wide default meeting policy is configured to only allow users in the **Presenter** role to request control and share content during meetings.
+
+Restricting who can present limits meeting disruptions and reduces the risk of unwanted or inappropriate content being shared.
+
+#### Remediation action:
+
+To prevent standard attendees from sharing content during Teams meetings:
+
+1. Click here to open [**Org-wide default settings > Meetings**](https://admin.teams.microsoft.com/one-policy/settings/meeting)
+   * Or navigate to [Teams Admin Center](https://admin.teams.microsoft.com).
+   * Click **Settings & policies > Org-wide default settings > Meetings**.
+1. Scroll to the **Content sharing** section.
+1. Set **Participants can give or request control** to **Off**.
+1. Click Save.
+
+#### Related links
+
+* [Manage meeting policies for content sharing](https://learn.microsoft.com/en-us/microsoftteams/meeting-policies-content-sharing)
+* [7 tips for safe online meetings and collaboration with Microsoft Teams - Tip 3: Determine who can present content or share their screen in your Teams meeting](https://techcommunity.microsoft.com/blog/microsoftteamsblog/7-tips-for-safe-online-meetings-and-collaboration-with-microsoft-teams/2072303)
+
+<!--- Results --->
+
+%TestResult%

--- a/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.ps1
+++ b/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.ps1
@@ -1,0 +1,45 @@
+﻿<#
+ .Synopsis
+  Checks if Teams is configured to only allow users with presenter rights to share content during meetings.
+
+ .Description
+  Restricting who can present limits meeting disruptions and reduces the risk of unwanted or inappropriate content being shared.
+
+  Learn more:
+  https://techcommunity.microsoft.com/blog/microsoftteamsblog/7-tips-for-safe-online-meetings-and-collaboration-with-microsoft-teams/2072303
+  https://learn.microsoft.com/en-us/microsoftteams/meeting-policies-content-sharing
+
+ .Example
+  Test-MtTeamsRestrictParticipantGiveRequestControl
+
+.LINK
+    https://maester.dev/docs/commands/Test-MtTeamsBlockParticipantGiveRequestControl
+#>
+function Test-MtTeamsRestrictParticipantGiveRequestControl {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+        # The TeamsMeetingPolicy object to check
+        # Run `Get-CsTeamsMeetingPolicy` to get the policy
+        $TeamsMeetingPolicy
+    )
+
+    if (!(Test-MtConnection Teams)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedTeams
+        return $null
+    }
+
+    $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
+
+    $result = -not $TeamsMeetingPolicyGlobal.AllowParticipantGiveRequestControl
+
+    if ($result) {
+        $testResultMarkdown = "Well done. Only users in the **Presenter** role are configured to share content during Teams meetings.`n`n"
+    } else {
+        $testResultMarkdown = "Standard attendees who are not in the **Presenter** role are allowed to share content during Teams meetings.`n`n"
+    }
+
+    Add-MtTestResultDetail -Result $testResultMarkdown
+
+    return $result
+}

--- a/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.ps1
+++ b/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.ps1
@@ -13,7 +13,7 @@
   Test-MtTeamsRestrictParticipantGiveRequestControl
 
 .LINK
-    https://maester.dev/docs/commands/Test-MtTeamsBlockParticipantGiveRequestControl
+    https://maester.dev/docs/commands/Test-MtTeamsRestrictParticipantGiveRequestControl
 #>
 function Test-MtTeamsRestrictParticipantGiveRequestControl {
     [CmdletBinding()]
@@ -32,6 +32,8 @@ function Test-MtTeamsRestrictParticipantGiveRequestControl {
     $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
 
     $result = -not $TeamsMeetingPolicyGlobal.AllowParticipantGiveRequestControl
+
+    Write-Verbose "Test-MtTeamsRestrictParticipantGiveRequestControl: $result"
 
     if ($result) {
         $testResultMarkdown = "Well done. Only users in the **Presenter** role are configured to share content during Teams meetings.`n`n"

--- a/tests/Maester/Teams/Test-TeamsMeeting.Tests.ps1
+++ b/tests/Maester/Teams/Test-TeamsMeeting.Tests.ps1
@@ -3,42 +3,23 @@ BeforeDiscovery {
 
         $TeamsMeetingPolicy = Get-CsTeamsMeetingPolicy
         Write-Verbose "Found $($TeamsMeetingPolicy.Count) Teams Meeting policies"
-        $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
-        Write-Verbose "Filtered $( $TeamsMeetingPolicyGlobal.Count) Global Teams Meeting policy"
-
     } catch {
         Write-Verbose "Session is not established, run Connect-MicrosoftTeams before requesting access token"
     }
 }
 
-Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
+Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy", "All" {
 
+    It "MT.1037 Only users with Presenter role are allowed to present in Teams meetings" -Tag "MT.1037" -TestCases @{ TeamsMeetingPolicy = $TeamsMeetingPolicy } {
 
-    It "MT. Configure which users are allowed to present in Teams meetings" -Tag "AllowParticipantGiveRequestControl" {
+        $result = Test-MtTeamsRestrictParticipantGiveRequestControl -TeamsMeetingPolicy $TeamsMeetingPolicy
+        $result | Should -Be $true -Because "Standard attendees in a Teams meeting should not be allowed to present in Teams meetings unless they are assigned the Presenter role."
 
-        $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
-
-        if (!(Test-MtConnection Teams)) {
-            Add-MtTestResultDetail -SkippedBecause NotConnectedTeams
-            return $null
-        }
-
-        $result = $TeamsMeetingPolicyGlobal.AllowParticipantGiveRequestControl
-
-        if ($result -eq $false) {
-            $testResultMarkdown = "Well done. AllowParticipantGiveRequestControl is $($result)`n`n"
-        } else {
-            $testResultMarkdown = "AllowParticipantGiveRequestControl in [Meeting policies]($portalLink_MeetingPolicy) should be False and is $($result) `n`n"
-        }
-        $testDetailsMarkdown = "Only allow users with presenter rights to share content during meetings. Restricting who can present limits meeting disruptions and reduces the risk of unwanted or inappropriate content being shared."
-        Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown
-
-        $result | Should -Be $false -Because "AllowParticipantGiveRequestControl should be False"
     }
 
-    It "MT. Only invited users should be automatically admitted to Teams meetings" -Tag "AutoAdmittedUsers" {
+    It "MT.1038 Only invited users should be automatically admitted to Teams meetings" -Tag "MT.1038" -TestCases @{ TeamsMeetingPolicy = $TeamsMeetingPolicy } {
         #($TeamsMeetingPolicyGlobal.AutoAdmittedUsers -eq "InvitedUsers")
-
+        $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
         if (!(Test-MtConnection Teams)) {
@@ -59,8 +40,9 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be "InvitedUsers" -Because "AutoAdmittedUsers should be InvitedUsers"
     }
 
-    It "MT. Restrict anonymous users from joining meetings" -Tag "AllowAnonymousUsersToJoinMeeting" {
+    It "MT.1039 Restrict anonymous users from joining meetings" -Tag "MT.1039" -TestCases @{ TeamsMeetingPolicy = $TeamsMeetingPolicy } {
 
+        $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
         if (!(Test-MtConnection Teams)) {
@@ -81,8 +63,9 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowAnonymousUsersToJoinMeeting should be False"
     }
 
-    It "MT. Restrict anonymous users from starting Teams meetings" -Tag "AllowAnonymousUsersToStartMeeting" {
+    It "MT.1040 Restrict anonymous users from starting Teams meetings" -Tag "MT.1040" -TestCases @{ TeamsMeetingPolicy = $TeamsMeetingPolicy }{
 
+        $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
         if (!(Test-MtConnection Teams)) {
@@ -103,8 +86,9 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowAnonymousUsersToStartMeeting should be False"
     }
 
-    It "MT. Limit external participants from having control in a Teams meeting" -Tag "AllowExternalParticipantGiveRequestControl" {
+    It "MT.1041 Limit external participants from having control in a Teams meeting" -Tag "MT.1041" -TestCases @{ TeamsMeetingPolicy = $TeamsMeetingPolicy }{
 
+        $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
         if (!(Test-MtConnection Teams)) {
@@ -125,8 +109,9 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowExternalParticipantGiveRequestControl should be False"
     }
 
-    It "MT. Restrict dial-in users from bypassing a meeting lobby " -Tag "AllowPSTNUsersToBypassLobby" {
+    It "MT.1042 Restrict dial-in users from bypassing a meeting lobby " -Tag "MT.1042" -TestCases @{ TeamsMeetingPolicy = $TeamsMeetingPolicy }{
 
+        $TeamsMeetingPolicyGlobal = $TeamsMeetingPolicy | Where-Object { $_.Identity -eq "Global" }
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
         if (!(Test-MtConnection Teams)) {

--- a/tests/Maester/Teams/Test-TeamsMeeting.Tests.ps1
+++ b/tests/Maester/Teams/Test-TeamsMeeting.Tests.ps1
@@ -14,7 +14,7 @@ BeforeDiscovery {
 Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
 
 
-    It "Configure which users are allowed to present in Teams meetings" -Tag "AllowParticipantGiveRequestControl" {
+    It "MT. Configure which users are allowed to present in Teams meetings" -Tag "AllowParticipantGiveRequestControl" {
 
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
@@ -36,7 +36,7 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowParticipantGiveRequestControl should be False"
     }
 
-    It "Only invited users should be automatically admitted to Teams meetings" -Tag "AutoAdmittedUsers" {
+    It "MT. Only invited users should be automatically admitted to Teams meetings" -Tag "AutoAdmittedUsers" {
         #($TeamsMeetingPolicyGlobal.AutoAdmittedUsers -eq "InvitedUsers")
 
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
@@ -59,7 +59,7 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be "InvitedUsers" -Because "AutoAdmittedUsers should be InvitedUsers"
     }
 
-    It "Restrict anonymous users from joining meetings" -Tag "AllowAnonymousUsersToJoinMeeting" {
+    It "MT. Restrict anonymous users from joining meetings" -Tag "AllowAnonymousUsersToJoinMeeting" {
 
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
@@ -81,7 +81,7 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowAnonymousUsersToJoinMeeting should be False"
     }
 
-    It "Restrict anonymous users from starting Teams meetings" -Tag "AllowAnonymousUsersToStartMeeting" {
+    It "MT. Restrict anonymous users from starting Teams meetings" -Tag "AllowAnonymousUsersToStartMeeting" {
 
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
@@ -103,7 +103,7 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowAnonymousUsersToStartMeeting should be False"
     }
 
-    It "Limit external participants from having control in a Teams meeting" -Tag "AllowExternalParticipantGiveRequestControl" {
+    It "MT. Limit external participants from having control in a Teams meeting" -Tag "AllowExternalParticipantGiveRequestControl" {
 
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 
@@ -125,7 +125,7 @@ Describe "Teams Meeting policies" -Tag "Maester", "Teams", "MeetingPolicy" {
         $result | Should -Be $false -Because "AllowExternalParticipantGiveRequestControl should be False"
     }
 
-    It "Restrict dial-in users from bypassing a meeting lobby " -Tag "AllowPSTNUsersToBypassLobby" {
+    It "MT. Restrict dial-in users from bypassing a meeting lobby " -Tag "AllowPSTNUsersToBypassLobby" {
 
         $portalLink_MeetingPolicy = "https://admin.teams.microsoft.com/policies/meetings"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,7 @@
 This folder contains the tests that Maester will run to validate your environment. The tests are organized into the following folders:
 
 - **Custom**: Place your custom Pester tests in this directory. The file name should end with `.Tests.ps1`.
+- **CIS**: Contains the tests that verifies the tenant's configuration conforms to the guidelines identified by the [Center for Internet Security (CIS) bechmark](https://www.cisecurity.org/benchmark/microsoft_365).
 - **CISA**: Contains the tests that verifies the tenant’s configuration conforms to the policies described in the Secure Cloud Business Applications ([SCuBA](https://cisa.gov/scuba)) Security Configuration Baseline [documents](https://github.com/cisagov/ScubaGear/blob/main/baselines/README.md).
 - **EIDSCA**: Contains tests based on the [Entra ID Security Config Analyzer](https://maester.dev/docs/tests/eidsca/).
 - **Maester**: Contains the tests that are built by the Maester team with contributions from the community. To learn more about the tests see [Maester Tests](https://maester.dev/docs/tests/maester).

--- a/tests/cis/Test-MtCisInternalMalwareNotification.Tests.ps1
+++ b/tests/cis/Test-MtCisInternalMalwareNotification.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS 2.1.3", "L1", "CIS E3 Level 1", "CIS E3", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.3 (L1) Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy)" {
+    It "CIS 2.1.3 (L1) Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisInternalMalwareNotification
 

--- a/tests/cis/Test-MtCisOutboundSpamFilterPolicy.Tests.ps1
+++ b/tests/cis/Test-MtCisOutboundSpamFilterPolicy.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS 2.1.6", "L1", "CIS E3 Level 1", "CIS E3", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.6 (L1) Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy)" {
+    It "CIS 2.1.6 (L1) Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy)" {
 
         $result = Test-MtCisOutboundSpamFilterPolicy
 

--- a/tests/cis/Test-MtCisSafeAntiPhishingPolicy.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeAntiPhishingPolicy.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS 2.1.7", "L1", "CIS E5 Level 1", "CIS E5", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.7 (L1) Ensure that an anti-phishing policy has been created (Only Checks Default Policy)" {
+    It "CIS 2.1.7 (L1) Ensure that an anti-phishing policy has been created (Only Checks Default Policy)" {
 
         $result = Test-MtCisSafeAntiPhishingPolicy
 

--- a/tests/cis/Test-MtCisSafeAttachment.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeAttachment.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS 2.1.4", "L2", "CIS E5 Level 2", "CIS E5", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.4 (L2) Ensure Safe Attachments policy is enabled (Only Checks Default Policy)" {
+    It "CIS 2.1.4 (L2) Ensure Safe Attachments policy is enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisSafeAttachment
 

--- a/tests/cis/Test-MtCisSafeAttachmentsAtpPolicy.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeAttachmentsAtpPolicy.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS 2.1.5", "L2", "CIS E5 Level 2", "CIS E5", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.5 (L2) Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled" {
+    It "CIS 2.1.5 (L2) Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled" {
 
         $result = Test-MtCisSafeAttachmentsAtpPolicy
 

--- a/tests/cis/Test-MtCisSafeLink.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeLink.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS 2.1.1", "L2", "CIS E5 Level 2", "CIS E5", "CIS", "Security", "All", "CIS M365 v3.1.0" {
-    It "2.1.1 (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy)" {
+    It "CIS 2.1.1 (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy)" {
 
         $result = Test-MtCisSafeLink
 

--- a/tests/cisa/exchange/Test-MtCisaAttachmentFileType.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaAttachmentFileType.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.9.2", "CISA", "Security", "All" {
-    It "MS.EXO.9.2: The attachment filter SHOULD attempt to determine the true file type and assess the file extension." {
+    It "MS.EXO.09.2: The attachment filter SHOULD attempt to determine the true file type and assess the file extension." {
 
         $result = Test-MtCisaAttachmentFileType
 

--- a/tests/cisa/exchange/Test-MtCisaAttachmentFilter.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaAttachmentFilter.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.9.1", "CISA", "Security", "All" {
-    It "MS.EXO.9.1: Emails SHALL be filtered by attachment file types." {
+    It "MS.EXO.09.1: Emails SHALL be filtered by attachment file types." {
 
         $result = Test-MtCisaAttachmentFilter
 

--- a/tests/cisa/exchange/Test-MtCisaAutoExternalForwarding.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaAutoExternalForwarding.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.1.1", "CISA", "Security", "All" {
-    It "MS.EXO.1.1: Automatic forwarding to external domains SHALL be disabled." {
+    It "MS.EXO.01.1: Automatic forwarding to external domains SHALL be disabled." {
 
         $cisaAutoExternalForwarding = Test-MtCisaAutoExternalForwarding
 

--- a/tests/cisa/exchange/Test-MtCisaBlockExecutable.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaBlockExecutable.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.9.5", "CISA", "Security", "All" {
-    It "MS.EXO.9.5: At a minimum, click-to-run files SHOULD be blocked (e.g., .exe, .cmd, and .vbe)." {
+    It "MS.EXO.09.5: At a minimum, click-to-run files SHOULD be blocked (e.g., .exe, .cmd, and .vbe)." {
 
         $result = Test-MtCisaBlockExecutable
 

--- a/tests/cisa/exchange/Test-MtCisaBlockFileType.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaBlockFileType.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.9.3", "CISA", "Security", "All" {
-    It "MS.EXO.9.3: Disallowed file types SHALL be determined and enforced." {
+    It "MS.EXO.09.3: Disallowed file types SHALL be determined and enforced." {
 
         $result = Test-MtCisaAttachmentFileType
 

--- a/tests/cisa/exchange/Test-MtCisaCalendarSharing.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaCalendarSharing.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.6.2", "CISA", "Security", "All" {
-    It "MS.EXO.6.2: Calendar details SHALL NOT be shared with all domains." {
+    It "MS.EXO.06.2: Calendar details SHALL NOT be shared with all domains." {
 
         $cisaCalendarSharing = Test-MtCisaCalendarSharing
 

--- a/tests/cisa/exchange/Test-MtCisaContactSharing.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaContactSharing.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.6.1", "CISA", "Security", "All" {
-    It "MS.EXO.6.1: Contact folders SHALL NOT be shared with all domains." {
+    It "MS.EXO.06.1: Contact folders SHALL NOT be shared with all domains." {
 
         $cisaContactSharing = Test-MtCisaContactSharing
 

--- a/tests/cisa/exchange/Test-MtCisaDkim.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDkim.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.3.1", "CISA", "Security", "All" {
-    It "MS.EXO.3.1: DKIM SHOULD be enabled for all domains." {
+    It "MS.EXO.03.1: DKIM SHOULD be enabled for all domains." {
         $cisaDkim = Test-MtCisaDkim
 
         if ($null -ne $cisaDkim) {

--- a/tests/cisa/exchange/Test-MtCisaDlp.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDlp.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.8.1", "CISA", "Security", "All" {
-    It "MS.EXO.8.1: A DLP solution SHALL be used." {
+    It "MS.EXO.08.1: A DLP solution SHALL be used." {
 
         $cisaDlp = Test-MtCisaDlp
 

--- a/tests/cisa/exchange/Test-MtCisaDlpAlternate.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDlpAlternate.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.8.3", "CISA", "Security", "All" {
-    It "MS.EXO.8.3: The selected DLP solution SHOULD offer services comparable to the native DLP solution offered by Microsoft." {
+    It "MS.EXO.08.3: The selected DLP solution SHOULD offer services comparable to the native DLP solution offered by Microsoft." {
 
         $cisa = Test-MtCisaDlpAlternate
 

--- a/tests/cisa/exchange/Test-MtCisaDlpBaselineRule.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDlpBaselineRule.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.8.4", "CISA", "Security", "All" {
-    It "MS.EXO.8.4: At a minimum, the DLP solution SHALL restrict sharing credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN) via email." {
+    It "MS.EXO.08.4: At a minimum, the DLP solution SHALL restrict sharing credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN) via email." {
 
         $cisa = Test-MtCisaDlpBaselineRule
 

--- a/tests/cisa/exchange/Test-MtCisaDlpPii.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDlpPii.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.8.2", "CISA", "Security", "All" {
-    It "MS.EXO.8.2: The DLP solution SHALL protect personally identifiable information (PII) and sensitive information, as defined by the agency." {
+    It "MS.EXO.08.2: The DLP solution SHALL protect personally identifiable information (PII) and sensitive information, as defined by the agency." {
 
         $cisaDlpPii = Test-MtCisaDlpPii
 

--- a/tests/cisa/exchange/Test-MtCisaDmarcAggregateCisa.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcAggregateCisa.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.3", "CISA", "Security", "All" {
-    It "MS.EXO.4.3: The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov." {
+    It "MS.EXO.04.3: The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov." {
         $cisaDmarcAggregateCisa = Test-MtCisaDmarcAggregateCisa
 
         if ($null -ne $cisaDmarcAggregateCisa) {

--- a/tests/cisa/exchange/Test-MtCisaDmarcRecordExist.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcRecordExist.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.1", "CISA", "Security", "All" {
-    It "MS.EXO.4.1: A DMARC policy SHALL be published for every second-level domain." {
+    It "MS.EXO.04.1: A DMARC policy SHALL be published for every second-level domain." {
         $cisaDmarcRecordExist = Test-MtCisaDmarcRecordExist
 
         if ($null -ne $cisaDmarcRecordExist) {

--- a/tests/cisa/exchange/Test-MtCisaDmarcRecordReject.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcRecordReject.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.2", "CISA", "Security", "All" {
-    It "MS.EXO.4.2: The DMARC message rejection option SHALL be p=reject." {
+    It "MS.EXO.04.2: The DMARC message rejection option SHALL be p=reject." {
         $cisaDmarcRecordReject = Test-MtCisaDmarcRecordReject
 
         if ($null -ne $cisaDmarcRecordReject) {

--- a/tests/cisa/exchange/Test-MtCisaDmarcReport.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcReport.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.4", "CISA", "Security", "All" {
-    It "MS.EXO.4.4: An agency point of contact SHOULD be included for aggregate and failure reports." {
+    It "MS.EXO.04.4: An agency point of contact SHOULD be included for aggregate and failure reports." {
         $cisaDmarcReport = Test-MtCisaDmarcReport
 
         if ($null -ne $cisaDmarcReport) {

--- a/tests/cisa/exchange/Test-MtCisaEmailFilterAlternative.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaEmailFilterAlternative.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.9.4", "CISA", "Security", "All" {
-    It "MS.EXO.9.4: Alternatively chosen filtering solutions SHOULD offer services comparable to Microsoft Defender's Common Attachment Filter." {
+    It "MS.EXO.09.4: Alternatively chosen filtering solutions SHOULD offer services comparable to Microsoft Defender's Common Attachment Filter." {
 
         $result = Test-MtCisaEmailFilterAlternative
 

--- a/tests/cisa/exchange/Test-MtCisaExternalSenderWarning.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaExternalSenderWarning.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.7.1", "CISA", "Security", "All" {
-    It "MS.EXO.7.1: External sender warnings SHALL be implemented." {
+    It "MS.EXO.07.1: External sender warnings SHALL be implemented." {
 
         $cisaExternalSenderWarning = Test-MtCisaExternalSenderWarning
 

--- a/tests/cisa/exchange/Test-MtCisaSmtpAuthentication.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaSmtpAuthentication.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.5.1", "CISA", "Security", "All" {
-    It "MS.EXO.5.1: SMTP AUTH SHALL be disabled." {
+    It "MS.EXO.05.1: SMTP AUTH SHALL be disabled." {
 
         $cisaSmtpAuthentication = Test-MtCisaSmtpAuthentication
 

--- a/tests/cisa/exchange/Test-MtCisaSpfDirective.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaSpfDirective.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.2.2", "CISA", "Security", "All" {
-    It "MS.EXO.2.2: An SPF policy SHALL be published for each domain, designating only these addresses as approved senders." {
+    It "MS.EXO.02.2: An SPF policy SHALL be published for each domain, designating only these addresses as approved senders." {
         $cisaSpfDirective = Test-MtCisaSpfDirective
 
         if ($null -ne $cisaSpfDirective) {

--- a/tests/cisa/exchange/Test-MtCisaSpfRestriction.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaSpfRestriction.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.2.1", "CISA", "Security", "All" {
-    It "MS.EXO.2.1: A list of approved IP addresses for sending mail SHALL be maintained." {
+    It "MS.EXO.02.1: A list of approved IP addresses for sending mail SHALL be maintained." {
         $cisaSpfRestriction = Test-MtCisaSpfRestriction
 
         if ($null -ne $cisaSpfRestriction) {

--- a/website/docs/commands/Test-MtTeamsRestrictParticipantGiveRequestControl.mdx
+++ b/website/docs/commands/Test-MtTeamsRestrictParticipantGiveRequestControl.mdx
@@ -1,0 +1,87 @@
+---
+sidebar_class_name: hidden
+description: Checks if Teams is configured to only allow users with presenter rights to share content during meetings.
+id: Test-MtTeamsRestrictParticipantGiveRequestControl
+title: Test-MtTeamsRestrictParticipantGiveRequestControl
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: https://github.com/maester365/maester/blob/main/powershell/public/Test-MtTeamsRestrictParticipantGiveRequestControl.ps1
+---
+
+## SYNOPSIS
+
+Checks if Teams is configured to only allow users with presenter rights to share content during meetings.
+
+## SYNTAX
+
+```powershell
+Test-MtTeamsRestrictParticipantGiveRequestControl [[-TeamsMeetingPolicy] <Object>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Restricting who can present limits meeting disruptions and reduces the risk of unwanted or inappropriate content being shared.
+
+Learn more:
+https://techcommunity.microsoft.com/blog/microsoftteamsblog/7-tips-for-safe-online-meetings-and-collaboration-with-microsoft-teams/2072303
+https://learn.microsoft.com/en-us/microsoftteams/meeting-policies-content-sharing
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Test-MtTeamsRestrictParticipantGiveRequestControl
+```
+
+## PARAMETERS
+
+### -TeamsMeetingPolicy
+
+The TeamsMeetingPolicy object to check
+Run `Get-CsTeamsMeetingPolicy` to get the policy
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+
+\{\{ Fill ProgressAction Description \}\}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Boolean
+
+## NOTES
+
+## RELATED LINKS
+
+[https://maester.dev/docs/commands/Test-MtTeamsBlockParticipantGiveRequestControl](https://maester.dev/docs/commands/Test-MtTeamsBlockParticipantGiveRequestControl)

--- a/website/docs/commands/docusaurus.sidebar.js
+++ b/website/docs/commands/docusaurus.sidebar.js
@@ -201,5 +201,6 @@ module.exports = [
     'commands/Test-MtEidscaST09',
     'commands/Test-MtPimAlertsExists',
     'commands/Test-MtPrivPermanentDirectoryRole',
+    'commands/Test-MtTeamsRestrictParticipantGiveRequestControl',
     'commands/Update-MaesterTests'
 ];

--- a/website/docs/connect-maester/connect-maester-advanced.md
+++ b/website/docs/connect-maester/connect-maester-advanced.md
@@ -15,6 +15,15 @@ There are two main methods of authenticating sessions for use with Maester:
 * Within the Maester module
 * Within the respective modules for the tests
 
+### Module Integrations
+
+The Maester module integrates with the following modules:
+
+* Microsoft.Graph.Authentication
+* Az.Accounts
+* ExchangeOnlineManagement
+* MicrosoftTeams
+
 ### Within the Maester module
 
 :::tip
@@ -49,6 +58,7 @@ graph TD;
   Connect-Maester-->Microsoft.Graph.Authentication;
   Connect-Maester-->Az.Accounts;
   Connect-Maester-->ExchangeOnlineManagement;
+  Connect-Maester-->a[Additional Modules];
   Microsoft.Graph.Authentication-->Get-MgContext;
   Microsoft.Graph.Authentication-->Get-MgEnvironment;
   Microsoft.Graph.Authentication-->Invoke-MgGraphRequest;


### PR DESCRIPTION
- [x] Teams not connected link goes through to Install Guide and not connect-Maester
- [x] Add list of modules to Connect-Maester docs
- [x] CIS 2.x aren't prepended with CIS
- [x] Prepend Teams tests with MTxxx - #569 Added a placeholder
- [x] AAD.7.1,2,3,EXO.16.1,17.3,8.1,2,4 no details on failure
- [x] EXO.1-9 - Prepend a 0 for sort order