### PR TITLE
Spelling and whitespace fixes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,33 @@
+{
+  "import": [
+    "@cspell/dict-powershell/cspell-ext.json",
+    "@cspell/dict-csharp/cspell-ext.json"
+  ],
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "Maester",
+    "Docusaurus",
+    "Entra",
+    "Contoso"
+  ],
+  "ignoreWords": [
+    "maester",
+    "eidsca",
+    "merill",
+    "docusaurus"
+  ],
+  "patterns": [
+    {
+      "name": "ALL-CAPS-WORDS",
+      "pattern": "/\b[A-Z0-9]+\b/g",
+      "description": "Any word in ALL CAPS."
+    }
+  ],
+  "ignoreRegExpList": [
+    "ALL-CAPS-WORDS",
+    "Email",
+    "github.com/",
+    "@"
+  ]
+}

--- a/.cspell.json
+++ b/.cspell.json
@@ -19,7 +19,9 @@
     "docusaurus",
     "devcontainers",
     "codespaces",
-    "multifactor"
+    "multifactor",
+    "Dmarc",
+    "Siem"
   ],
   "patterns": [
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -10,7 +10,8 @@
     "Docusaurus",
     "Entra",
     "Contoso",
-    "SSPR"
+    "SSPR",
+    "passwordless"
   ],
   "ignoreWords": [
     "maester",
@@ -21,7 +22,10 @@
     "codespaces",
     "multifactor",
     "Dmarc",
-    "Siem"
+    "Siem",
+    "pscustomobject",
+    "psobject",
+    "testresults"
   ],
   "patterns": [
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -9,7 +9,8 @@
     "Maester",
     "Docusaurus",
     "Entra",
-    "Contoso"
+    "Contoso",
+    "SSPR"
   ],
   "ignoreWords": [
     "maester",
@@ -17,7 +18,8 @@
     "merill",
     "docusaurus",
     "devcontainers",
-    "codespaces"
+    "codespaces",
+    "multifactor"
   ],
   "patterns": [
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -15,7 +15,9 @@
     "maester",
     "eidsca",
     "merill",
-    "docusaurus"
+    "docusaurus",
+    "devcontainers",
+    "codespaces"
   ],
   "patterns": [
     {

--- a/.github/workflows/get-version.ps1
+++ b/.github/workflows/get-version.ps1
@@ -4,14 +4,14 @@ Param(
     [string]$ModuleRoot = "$($env:GITHUB_WORKSPACE)/powershell"
 )
 
-$ManfifestPath = "$($ModuleRoot)/Maester.psd1"
+$ManifestPath = "$($ModuleRoot)/Maester.psd1"
 
-if ( -not (Test-Path $ManfifestPath )) {
-    Write-Error "Could not find PowerShell module manifest ($ManfifestPath)"
+if ( -not (Test-Path $ManifestPath )) {
+    Write-Error "Could not find PowerShell module manifest ($ManifestPath)"
     throw
 } else {
     # Get the current version of the module from the module manifest
-    $Version = (Test-ModuleManifest $ManfifestPath).Version
+    $Version = (Test-ModuleManifest $ManifestPath).Version
     $Version = '{0}.{1}.{2}' -f $Version.Major, $Version.Minor, $Version.Build
 }
 

--- a/.github/workflows/minor-version-update.ps1
+++ b/.github/workflows/minor-version-update.ps1
@@ -7,10 +7,10 @@ Param(
     [switch]$preview = $false
 )
 
-$ManfifestPath = "$($ModuleRoot)/Maester.psd1"
+$ManifestPath = "$($ModuleRoot)/Maester.psd1"
 
-if ( -not (Test-Path $ManfifestPath )) {
-    Write-Error "Could not find PowerShell module manifest ($ManfifestPath)"
+if ( -not (Test-Path $ManifestPath )) {
+    Write-Error "Could not find PowerShell module manifest ($ManifestPath)"
     throw
 } else {
     # Get the current version of the module from the PowerShell gallery
@@ -42,7 +42,7 @@ if ( -not (Test-Path $ManfifestPath )) {
 
     $previewLabel = if ($preview) { '-preview' } else { '' }
 
-    Update-ModuleManifest -Path $ManfifestPath -ModuleVersion $NewVersion -FunctionsToExport $FunctionNames -Prerelease $previewLabel
+    Update-ModuleManifest -Path $ManifestPath -ModuleVersion $NewVersion -FunctionsToExport $FunctionNames -Prerelease $previewLabel
 }
 
 $NewVersion += $previewLabel

--- a/build/CommonFunctions.psm1
+++ b/build/CommonFunctions.psm1
@@ -291,7 +291,7 @@ function Use-StartBitsTransfer {
         # Specifies the credentials to use to authenticate the user at the proxy
         [Parameter(Mandatory = $false, Position = 6)]
         [pscredential] $ProxyCredential,
-        # Returns an object representing transfered item.
+        # Returns an object representing transferred item.
         [Parameter(Mandatory = $false)]
         [switch] $PassThru
     )
@@ -304,7 +304,7 @@ function Use-StartBitsTransfer {
 
     if (!$Destination) { $Destination = (Get-Location).ProviderPath }
     if (![System.IO.Path]::HasExtension($Destination)) { $Destination = Join-Path $Destination (Split-Path $Source -Leaf) }
-    if (Test-Path $Destination) { Write-Verbose ('The Source [{0}] was not transfered to Destination [{0}] because it already exists.' -f $Source, $Destination) }
+    if (Test-Path $Destination) { Write-Verbose ('The Source [{0}] was not transferred to Destination [{0}] because it already exists.' -f $Source, $Destination) }
     else {
         Write-Verbose ('Downloading Source [{0}] to Destination [{1}]' -f $Source, $Destination);
         Start-BitsTransfer $Source $Destination @paramStartBitsTransfer

--- a/build/Launch-PSModule.ps1
+++ b/build/Launch-PSModule.ps1
@@ -28,8 +28,8 @@ if ($NoNewWindow) {
     [scriptblock] $ScriptBlock = {
         param ([string]$ModulePath, [string]$PSModuleCacheDirectory, [scriptblock]$PostImportScriptBlock)
         ## Reset PSModulePath environment variable to default value because starting powershell.exe from pwsh.exe (or vice versa) will inherit environment variables for the wrong version of PowerShell.
-        $PSModulePathDefault = [System.Management.Automation.ModuleIntrinsics]::GetModulePath($null, [System.Environment]::GetEnvironmentVariable('PSMODULEPATH', [EnvironmentVariableTarget]::Machine), [System.Environment]::GetEnvironmentVariable('PSMODULEPATH', [EnvironmentVariableTarget]::User))
-        [Environment]::SetEnvironmentVariable("PSMODULEPATH", $PSModulePathDefault)
+        $PSModulePathDefault = [System.Management.Automation.ModuleIntrinsics]::GetModulePath($null, [System.Environment]::GetEnvironmentVariable('PSModulePath', [EnvironmentVariableTarget]::Machine), [System.Environment]::GetEnvironmentVariable('PSModulePath', [EnvironmentVariableTarget]::User))
+        [Environment]::SetEnvironmentVariable("PSModulePath", $PSModulePathDefault)
         ## Add PSModuleCacheDirectory to PSModulePath environment variable
         if (!$env:PSModulePath.Contains($PSModuleCacheDirectory)) { $env:PSModulePath += '{0}{1}' -f [IO.Path]::PathSeparator, $PSModuleCacheDirectory }
         ## Import Module and Execute Post-Import ScriptBlock

--- a/build/Update-CommandReference.ps1
+++ b/build/Update-CommandReference.ps1
@@ -15,7 +15,7 @@ Import-Module DnsClient
 $commandsIndexFile = "./website/docs/commands/readme.md"
 $readmeContent = Get-Content $commandsIndexFile  # Backup the readme.md since it will be deleted by New-DocusaurusHelp
 
-# Get all the filenames in the ./powershell/internal folder wihtout the extension
+# Get all the filenames in the ./powershell/internal folder without the extension
 $internalCommands = Get-ChildItem ./powershell/internal -Filter *.ps1 | ForEach-Object { $_.BaseName }
 
 New-DocusaurusHelp -Module ./powershell/Maester.psm1 -DocsFolder ./website/docs -NoPlaceHolderExamples -EditUrl https://github.com/maester365/maester/blob/main/powershell/public/ -Exclude $internalCommands

--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -20,7 +20,7 @@ param (
     # Folder where control functions should be generated
     [string] $PowerShellFunctionsPath = "$PSScriptRoot/../../powershell/internal/eidsca",
 
-    # Foldere where the public function should be generated
+    # Folder where the public function should be generated
     [string] $PublicFunctionPath = "$PSScriptRoot/../../powershell/public/eidsca",
 
     # Control name to filter on

--- a/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAF01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAG01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.policyMigrationState

--- a/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAG03 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.reportSuspiciousActivitySettings.includeTarget.id

--- a/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAM01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToUseSSPR

--- a/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP04 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowInvitesFrom

--- a/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP05 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToSignUpEmailBasedSubscriptions

--- a/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP06 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowEmailVerifiedUsersToJoinOrganization

--- a/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP07 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.guestUserRoleId

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP08 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1

--- a/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP09 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowUserConsentForRiskyApps

--- a/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP10 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToCreateApps

--- a/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAP14 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToReadOtherUsers

--- a/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAT01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaAV01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaCR01 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.isEnabled

--- a/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaPR02 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableBannedPasswordCheckOnPremises' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaPR05 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaPR06 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutThreshold' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaST08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST08.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaST08 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToBeGroupOwner' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaST09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST09.ps1
@@ -21,7 +21,6 @@ function Test-MtEidscaST09 {
     [OutputType([bool])]
     param()
 
-    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToAccessGroups' | select-object -expand value

--- a/powershell/public/Send-MtMail.ps1
+++ b/powershell/public/Send-MtMail.ps1
@@ -53,7 +53,7 @@ function Send-MtMail {
         # Developer guide for editing the html report.
         - Authoring of the email template is done using Word. Open /powershell/assets/EmailTemplate.docx and make changes as needed
         - Select all and copy/paste the content into a new email in Outlook and send it to yourself
-        - When the email is recieved, view the source (either through Graph API, View Source in Outlook for Mac or save as .eml and open in a text editor)
+        - When the email is received, view the source (either through Graph API, View Source in Outlook for Mac or save as .eml and open in a text editor)
         - Copy the source (<html>..</html>) and paste it into the /powershell/assets/EmailTemplate.html file in the assets folder
         - Search for cid:image in the html and update the -replace commands in the script below.
     #>

--- a/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Invoking PSScriptAnalyzer against commandbase' -ForEach @{ commandFile
     }
 
     # The next Context blocks are kinda duplicate, but helps us document both
-    # which files and which rules where evaluated without running every rule for every file 
+    # which files and which rules where evaluated without running every rule for every file
     Context 'Analyzing rule <_.RuleName>' -ForEach $scriptAnalyzerRules {
         BeforeAll {
             $rule = $_

--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -24,11 +24,11 @@ const FeatureList = [
     ),
   },
   {
-    title: "Continous monitoring",
+    title: "Continuous monitoring",
     Svg: require("@site/static/img/home/feature_monitor.svg").default,
     description: (
       <>
-        Set up continous monitoring of your tenant configuration using your
+        Set up continuous monitoring of your tenant configuration using your
         favorite CI/CD pipeline and alert if any test fails.
       </>
     ),

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -10,7 +10,7 @@ import styles from "./index.module.css";
 const textContent = {
   customTests: `
   Write Pester tests that encode your organization's business and security policies.<br/><br/>
-  <strong>Apply modern DevSecOps practices</strong> and continously monitor critical aspects of your Microsoft cloud.
+  <strong>Apply modern DevSecOps practices</strong> and continuously monitor critical aspects of your Microsoft cloud.
   `,
   whatIf: `
   Avoid creating loopholes in your conditional access policies and test to see the impact of a policy change before it is applied.<br/><br/>
@@ -48,7 +48,7 @@ and when changes are introduced in your Microsoft 365 tenant.
 <strong>Follow the step-by-step guide</strong> in the Maester docs to set up
 an automation account with Workload Identify Federation.`,
   gitHub: `
-Integrate Maester with GitHub Actions to continously monitor your tenant configuration.
+Integrate Maester with GitHub Actions to continuously monitor your tenant configuration.
 <br/><br/>
 <strong>Build an archive history</strong> of Maester test runs against your tenant with the native
 workflow integration in Maester.


### PR DESCRIPTION
A little bit of polish for Maester:

- Add cSpell settings with project word list and ignored words
- Import cSpell dictionaries for PowerShell and C# projects
- Fix multiple typos
- Remove trailing whitespace and lines that only contain extraneous whitespace