### PR TITLE
Update teams.md - Update heading.

### DIFF
--- a/website/docs/monitoring/teams.md
+++ b/website/docs/monitoring/teams.md
@@ -4,9 +4,9 @@ sidebar_position: 9
 title: Set up Maester Teams alerts
 ---
 
-# Set up Maester Slack Alerts
+# Set up Maester Teams Alerts
 
-Your Maester monitoring workflow can be configured to send an adaptive card in a teams channel with the summary of the Maester test results at the end of each monitoring cycle in Slack. This guide will walk you through the steps to set up Teams alerts in Maester.
+Your Maester monitoring workflow can be configured to send an adaptive card in a team channel with the summary of the Maester test results at the end of each monitoring cycle in Slack. This guide will walk you through the steps to set up Teams alerts in Maester.
 
 ![Maester - Microsoft Teams Alerts](assets/maester-teams-alert-test-result.png)
 


### PR DESCRIPTION
This pull request includes a small change to the `website/docs/monitoring/teams.md` file. The change updates the title and description to correctly refer to "Teams" instead of "Slack" for setting up Maester alerts.

Documentation update:

* [`website/docs/monitoring/teams.md`](diffhunk://#diff-002e0bf065dfb7cfd603187bcda7087dddd556a81c5301cd066cb04ccea6f3b0L7-R9): Changed references from "Slack" to "Teams" to accurately describe the setup process for Maester Teams alerts.