### PR TITLE
Update error message when DNS record cannot be found

### DIFF
--- a/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDkim.ps1
+++ b/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDkim.ps1
@@ -118,7 +118,7 @@ function ConvertFrom-MailAuthenticationRecordDkim {
                     if ($record) {
                         $dkimRecord = [DKIMRecord]::new($record)
                     } else {
-                        return "Failure to obtain record"
+                        return "Record does not exist"
                     }
                 } else {
                     Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."

--- a/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDmarc.ps1
+++ b/powershell/public/cisa/exchange/ConvertFrom-MailAuthenticationRecordDmarc.ps1
@@ -248,7 +248,7 @@ function ConvertFrom-MailAuthenticationRecordDmarc {
                     if ($record) {
                         $dmarcRecord = [DMARCRecord]::new($record)
                     } else {
-                        return "Failure to obtain record"
+                        return "Record does not exist"
                     }
                 } else {
                     Write-Verbose "`nFor non-Windows platforms, please install DnsClient-PS module."


### PR DESCRIPTION
I recently worked on installing `DNSClient-PS` on the environment which I use to run `maester` so that some of the ExchangeOnline tests can properly work. One tricky thing that I faced while working on this is that the general error message and the error message when a record isn't located is exactly the same, however not finding a record is actually a "successful" execution with a failed result while the general exception is a complete failure to execute. Making these error message different would help diagnose the state of the system and the result of the tests.