### PR TITLE
fix(MS.AAD.6.1): password expiration must be configured for all domains

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -38,11 +38,13 @@ function Test-MtCisaPasswordExpiration {
     #$federatedDomains = $result | Where-Object {`
     #    $_.authenticationType -ne "Managed"}
 
-    $managedDomains = $result | Where-Object authenticationType -eq "Managed"
+    $verifiedDomains = $result | Where-Object isVerified
+
+    $managedDomains = $verifiedDomains | Where-Object authenticationType -eq "Managed"
 
     $compliantDomains = $managedDomains | Where-Object PasswordValidityPeriodInDays -ge 36500
 
-    $testResult = ($managedDomains | Measure-Object).Count - ($compliantDomains|Measure-Object).Count -eq 0
+    $testResult = ($managedDomains | Measure-Object).Count - ($compliantDomains | Measure-Object).Count -eq 0
 
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire."

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -8,7 +8,8 @@
 .EXAMPLE
     Test-MtCisaPasswordExpiration
 
-    Returns true if all domains have password expiration of 100 years or greater
+    Returns true if all managed domains have password expiration configured
+    to be of 100 years or greater
 
 .LINK
     https://maester.dev/docs/commands/Test-MtCisaPasswordExpiration
@@ -37,11 +38,11 @@ function Test-MtCisaPasswordExpiration {
     #$federatedDomains = $result | Where-Object {`
     #    $_.authenticationType -ne "Managed"}
 
-    $managedDomains = $result | Where-Object {`
-        $_.authenticationType -eq "Managed" -and `
-        $_.PasswordValidityPeriodInDays -ge 36500}
+    $managedDomains = $result | Where-Object authenticationType -eq "Managed"
 
-    $testResult = ($result | Measure-Object).Count - ($managedDomains|Measure-Object).Count -eq 0
+    $compliantDomains = $managedDomains | Where-Object PasswordValidityPeriodInDays -ge 36500
+
+    $testResult = ($managedDomains | Measure-Object).Count - ($compliantDomains|Measure-Object).Count -eq 0
 
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire."

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks if passwords are set to not expire
 
@@ -34,10 +34,6 @@ function Test-MtCisaPasswordExpiration {
     #$users = Get-MgUser -All -Property PasswordPolicies
     #$users|?{$_.PasswordPolicies -like "*DisablePasswordExpiration*"}
 
-    #Would need to handle exception for federated domains
-    #$federatedDomains = $result | Where-Object {`
-    #    $_.authenticationType -ne "Managed"}
-
     $verifiedDomains = $result | Where-Object isVerified
 
     $managedDomains = $verifiedDomains | Where-Object authenticationType -eq "Managed"
@@ -47,10 +43,41 @@ function Test-MtCisaPasswordExpiration {
     $testResult = ($managedDomains | Measure-Object).Count - ($compliantDomains | Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire."
+        $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire.`n`n%TestResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have password expiration set to never expire."
+        $testResultMarkdown = "Your tenant does not have password expiration set to never expire.`n`n%TestResult%"
     }
+
+    $pass = "✅ Pass"
+    $fail = "❌ Fail"
+    $skip = "🗄️ Skipped"
+    $default = "✔️"
+
+    $resultDetails = "| Domain (Default) | Verified | Type | Validation |`n"
+    $resultDetails += "| --- | --- | --- | --- |`n"
+    foreach($domain in $result){
+        if($domain.isDefault){
+            $isDefault = "$($domain.id) ($default)"
+        }else{
+            $isDefault = "$($domain.id) ()"
+        }
+        if($domain.isVerified){
+            $isVerified = "Verified"
+        }else{
+            $isVerified = "Unverified"
+        }
+        if($domain.id -in $compliantDomains.id){
+            $testValue = $pass
+        }elseif($domain.authenticationType -eq "Federated"){
+            $testValue = $skip
+        }else{
+            $testValue = $fail
+        }
+
+        $resultDetails += "| $isDefault | $isVerified | $($domain.authenticationType) | $testValue |`n"
+    }
+
+    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $resultDetails
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -8,7 +8,7 @@
 .EXAMPLE
     Test-MtCisaPasswordExpiration
 
-    Returns true if all managed domains have password expiration configured
+    Returns true if all verified managed domains have password expiration configured
     to be of 100 years or greater
 
 .LINK

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -8,7 +8,7 @@
 .EXAMPLE
     Test-MtCisaPasswordExpiration
 
-    Returns true if at least 1 domain has password expiration of 100 years or greater
+    Returns true if all domains have password expiration of 100 years or greater
 
 .LINK
     https://maester.dev/docs/commands/Test-MtCisaPasswordExpiration
@@ -41,7 +41,7 @@ function Test-MtCisaPasswordExpiration {
         $_.authenticationType -eq "Managed" -and `
         $_.PasswordValidityPeriodInDays -ge 36500}
 
-    $testResult = ($managedDomains|Measure-Object).Count -ge 1
+    $testResult = ($result | Measure-Object).Count - ($managedDomains|Measure-Object).Count -eq 0
 
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire."

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -70,6 +70,8 @@ function Test-MtCisaPasswordExpiration {
             $testValue = $pass
         }elseif($domain.authenticationType -eq "Federated"){
             $testValue = $skip
+        }elseif($isVerified -eq "Unverified"){
+            $testValue = $skip
         }else{
             $testValue = $fail
         }


### PR DESCRIPTION
addresses https://github.com/maester365/maester/issues/594

This may be an opinionated change, and I am happy to discuss.

To comply with MS.AAD.6.1, all verified domains should be evaluated for this configuration value. 

If configuring the primary domain is sufficient for compliance (i.e. the configured value for non-primary domains becomes irrelevant), then the `isDefault` attribute should be used to filter the results down to a single domain.

This PR is with the following requirement in mind:

**ALL** verified managed domains shall be configured to not require password expiry.