### PR TITLE
Update Test-MtConditionalAccessWhatIf.mdx

### DIFF
--- a/website/docs/commands/Test-MtConditionalAccessWhatIf.mdx
+++ b/website/docs/commands/Test-MtConditionalAccessWhatIf.mdx
@@ -88,7 +88,7 @@ This example tests the Conditional Access policies for a user signing into **Off
 ```powershell
 Test-MtConditionalAccessWhatIf -UserId '7a6da1c3-616a-416b-a820-cbe4fa8e225e' `
     -IncludeApplications 'bbad9299-f060-4e15-9a9a-285980ae00fc' `
-    -DeviceInfo { 'isCompliant' = 'true'; 'Manufacturer' = 'Dell' } `
+    -DeviceInfo @{ 'isCompliant' = 'true'; 'Manufacturer' = 'Dell' } `
     -InsiderRiskLevel 'Minor'
 ```
 


### PR DESCRIPTION
In the example, an @ is missing before the {} of the 'DeviceInfo' parameter. This causes a syntax error. The example has been corrected in this PR.