### PR TITLE
Respect value of install_prerelease for Maester module in the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,10 +98,13 @@ runs:
 
           # Install Maester
           if ( [string]::IsNullOrWhiteSpace( '${{ inputs.install_prerelease}}' ) -eq $true ){
+            Write-Host "Installing prerelease version"
             Install-Module Maester -AllowPrerelease -Force
           } else {
+            Write-Host "Installing latest version"
             Install-Module Maester -Force
           }
+          
 
           # Configure test results
           $PesterConfiguration = New-PesterConfiguration

--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
           Connect-MgGraph -AccessToken $accessToken -NoWelcome
 
           # Install Maester
-          if ( [string]::IsNullOrWhiteSpace( '${{ inputs.install_prerelease}}' ) -eq $true ){
+           if ( '${{ inputs.install_prerelease}}' -eq $true ){
             Write-Host "Installing prerelease version"
             Install-Module Maester -AllowPrerelease -Force
           } else {


### PR DESCRIPTION
The if condition always evaluated to false when install_prerelease was true or false as it was only checked for being null. Write out to the log file whether the latest or prerelease module was used. 