### PR TITLE
Workaround for Invoke-MtGraphRequest assembly error on GitHub-hosted runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,10 @@ runs:
             Install-Module Maester -Force
           }
 
+          # Delete Microsoft.Graph.Authentication 2.9.1 (issue #606)
+          Write-Host "Delete module version 2.9.1 of Microsoft.Graph.Authentication"  
+          rm -r /home/runner/.local/share/powershell/Modules/Microsoft.Graph.Authentication/2.9.1
+
           # Configure test results
           $PesterConfiguration = New-PesterConfiguration
           $PesterConfiguration.Output.Verbosity = '${{ inputs.pester_verbosity }}'


### PR DESCRIPTION
The 'Invoke-MtGraphRequest' command was found in the module 'Maester', but the module could not be loaded due to the following error: [Assembly with same name is already loaded]

Brute force removal of offending module version (required by Maester)