### PR TITLE
Add support to post message to Team Channel via Webhook Uri parameter

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -258,10 +258,21 @@ function Invoke-Maester {
 
     $isTeamsChannelMessage = -not ([String]::IsNullOrEmpty($TeamId) -or [String]::IsNullOrEmpty($TeamChannelId) -or [String]::IsNullOrEmpty($TeamChannelWebhookUri))
 
+    $isWebUri = -not ([String]::IsNullOrEmpty($TeamChannelWebhookUri))
+
     if ($SkipGraphConnect) {
         Write-Host "🔥 Skipping graph connection check" -ForegroundColor Yellow
     } else {
         if (!(Test-MtContext -SendMail:$isMail -SendTeamsMessage:$isTeamsChannelMessage)) { return }
+    }
+
+    if ($isWebUri) {
+        # Check if TeamChannelWebhookUri is a valid URL
+       $urlPattern = '^(https)://[^\s/$.?#].[^\s]*$'
+        if (-not ($TeamChannelWebhookUri -match $urlPattern)) {
+            Write-Output "Invalid Webhook URL: $TeamChannelWebhookUri"
+            return
+        }
     }
 
     $out = [PSCustomObject]@{

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -256,7 +256,7 @@ function Invoke-Maester {
 
     $isMail = $null -ne $MailRecipient
 
-    $isTeamsChannelMessage = -not ([String]::IsNullOrEmpty($TeamId) -or [String]::IsNullOrEmpty($TeamChannelId) -or [String]::IsNullOrEmpty($TeamChannelWebhookUri))
+    $isTeamsChannelMessage = -not ([String]::IsNullOrEmpty($TeamId) -or [String]::IsNullOrEmpty($TeamChannelId))
 
     $isWebUri = -not ([String]::IsNullOrEmpty($TeamChannelWebhookUri))
 

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -55,6 +55,11 @@ Invoke-Maester -TeamId '00000000-0000-0000-0000-000000000000' -TeamChannelId '19
 Runs all the tests and posts a summary of the results to a Teams channel.
 
 .EXAMPLE
+Invoke-Maester -TeamChannelWebhookUri 'https://some-url.logic.azure.com/workflows/invoke?api-version=2016-06-01'
+
+Runs all the tests and posts a summary of the results to a Teams channel.
+
+.EXAMPLE
 Invoke-Maester -Verbosity Normal
 
 Shows results of tests as they are run including details on failed tests.
@@ -144,6 +149,10 @@ function Invoke-Maester {
         # Optional. The channel where the message should be posted. e.g. 19%3A00000000000000000000000000000000%40thread.tacv2
         # To get the TeamChannelId, right-click on the channel in Teams and select 'Get link to channel'. Use the value found between channel and the channel name. e.g. /channel/<TeamChannelId>/my%20channel
         [string] $TeamChannelId,
+
+        # Optional. The webhook Uri where the message should be posted. e.g. https://some-url/?value=123
+        # To get the Webhook Uri, right-click on the channel in Teams and select 'Workflow'. Create a workflow using the 'Post to a channel when a webhook request is received' template. Use the value after complete
+        [string] $TeamChannelWebhookUri,
 
         # Skip the graph connection check.
         # This is used for running tests that does not require a graph connection.
@@ -247,7 +256,7 @@ function Invoke-Maester {
 
     $isMail = $null -ne $MailRecipient
 
-    $isTeamsChannelMessage = -not ([String]::IsNullOrEmpty($TeamId) -or [String]::IsNullOrEmpty($TeamChannelId))
+    $isTeamsChannelMessage = -not ([String]::IsNullOrEmpty($TeamId) -or [String]::IsNullOrEmpty($TeamChannelId) -or [String]::IsNullOrEmpty($TeamChannelWebhookUri))
 
     if ($SkipGraphConnect) {
         Write-Host "🔥 Skipping graph connection check" -ForegroundColor Yellow
@@ -342,6 +351,11 @@ function Invoke-Maester {
         if ($TeamId -and $TeamChannelId) {
             Write-MtProgress -Activity "Sending Teams message"
             Send-MtTeamsMessage -MaesterResults $maesterResults -TeamId $TeamId -TeamChannelId $TeamChannelId -TestResultsUri $MailTestResultsUri
+        }
+
+        if ($TeamChannelWebhookUri) {
+            Write-MtProgress -Activity "Sending Teams message"
+            Send-MtTeamsMessage -MaesterResults $maesterResults -TeamChannelWebhookUri $TeamChannelWebhookUri -TestResultsUri $MailTestResultsUri
         }
 
         if ($Verbosity -eq 'None') {

--- a/powershell/public/Send-MtTeamsMessage.ps1
+++ b/powershell/public/Send-MtTeamsMessage.ps1
@@ -21,6 +21,12 @@
 
     Sends an Adaptive Card in a Teams Channel with the summary of the Maester test results to the specified channel along with the link to the detailed test results.
 
+.EXAMPLE
+    Send-MtTeamsMessage -MaesterResults $MaesterResults -TeamChannelWebhookUri 'https://some-url.logic.azure.com/workflows/invoke?api-version=2016-06-01' -Subject 'Maester Results' -TestResultsUri "https://github.com/contoso/maester/runs/123456789"
+
+    Sends an Adaptive Card in a Teams Channel with the summary of the Maester test results to the specified channel along with the link to the detailed test results.
+
+
 .LINK
     https://maester.dev/docs/commands/Send-MtTeamsMessage
 #>
@@ -41,7 +47,7 @@ function Send-MtTeamsMessage {
         [Parameter(Mandatory = $true, Position = 2, ParameterSetName = "MSGraph")]
         [string] $TeamChannelId,
 
-        # The URL of the webhook where the message should be posted. e.g. 19%3A00000000000000000000000000000000%40thread.tacv2
+        # The URL of the webhook where the message should be posted. e.g. 'https://some-url.logic.azure.com/workflows/invoke?api-version=2016-06-01'
         # To get the webhook Url, right-click on the channel in Teams and select 'Workflow'. Create a workflow using the 'Post to a channel when a webhook request is received' template. Use the value after complete
         [Parameter(Mandatory = $true, Position = 1, ParameterSetName = "Webhook")]
         [string] $TeamChannelWebhookUri,

--- a/powershell/public/Send-MtTeamsMessage.ps1
+++ b/powershell/public/Send-MtTeamsMessage.ps1
@@ -73,6 +73,13 @@ function Send-MtTeamsMessage {
     #>
     if (!$TeamChannelWebhookUri) {
       if (!(Test-MtContext -SendTeamsMessage)) { return }
+    } else {
+        # Check if TeamChannelWebhookUri is a valid URL
+        $urlPattern = '^(https)://[^\s/$.?#].[^\s]*$'
+        if (-not ($TeamChannelWebhookUri -match $urlPattern)) {
+            Write-Output "Invalid Webhook URL: $TeamChannelWebhookUri"
+            return
+        }
     }
 
     if (!$Subject) { $Subject = "Maester Test Results" }


### PR DESCRIPTION
Wanted to be able to post a message to a Microsoft Teams Team Channel using the App Registration. 

Added **TeamChannelWebhookUri** parameter to **Invoke-Maester** and **Send-MtTeamsMessage**

To get the webhook Url, right-click on the channel in Teams and select 'Workflow'. Create a workflow using the 'Post to a channel when a webhook request is received' template. Use the value after complete

Here is an example of the post to a Team Channel

![image](https://github.com/user-attachments/assets/937b9f46-f73a-42e6-ae21-926b52a8048f)
