### PR TITLE
Update for CA Test - Major Changes (Connect Sync)

### DIFF
--- a/powershell/public/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -62,6 +62,15 @@ function Test-MtCaExclusionForDirectorySyncAccount {
             continue
         }
 
+        if ( $policy.grantcontrols.builtincontrols -contains 'block' `
+            -and "exchangeActiveSync" -in $policy.conditions.clientAppTypes `
+            -and "other" -in $policy.conditions.clientAppTypes){
+            # Skip this policy, because it just blocks legacy authentication
+            $currentresult = $true
+            Write-Verbose "Skipping $($policy.displayName) legacy auth is not used for sync - $currentresult"
+            continue
+        }
+
         $PolicyIncludesAllUsers = $false
         $PolicyIncludesRole = $false
         $DirectorySynchronizationAccounts | ForEach-Object {

--- a/powershell/public/Test-MtCaGap.ps1
+++ b/powershell/public/Test-MtCaGap.ps1
@@ -132,7 +132,11 @@ function Test-MtCaGap {
         $_.Conditions.Users.IncludeUsers | ForEach-Object { $includedUsers.Add($_) | Out-Null }
         $_.Conditions.Users.ExcludeGroups | ForEach-Object { $excludedGroups.Add($_) | Out-Null }
         $_.Conditions.Users.IncludeGroups | ForEach-Object { $includedGroups.Add($_) | Out-Null }
-        $_.Conditions.Users.ExcludeRoles | ForEach-Object { $excludedRoles.Add($_) | Out-Null }
+        If ($_ -ne "d29b2b05-8046-44ba-8758-1e26182fcf32") {
+            # Role: 'Directory Synchronization Accounts' excluded
+            # Policy: 'Multifactor authentication for Microsoft partners and vendors'
+            $_.Conditions.Users.ExcludeRoles | ForEach-Object { $excludedRoles.Add($_) | Out-Null }
+        }
         $_.Conditions.Users.IncludeRoles | ForEach-Object { $includedRoles.Add($_) | Out-Null }
         $_.Conditions.Applications.ExcludeApplications | ForEach-Object { $excludedApplications.Add($_) | Out-Null }
         $_.Conditions.Applications.IncludeApplications | ForEach-Object { $includedApplications.Add($_) | Out-Null }


### PR DESCRIPTION
Warning: This change does change the behavior of the Test

**Do not check blocks for Legacy Auth**
In my opinion, blocks which are not targeting Modern Auth, should not be considered

**Ignore excludes for Synchronization Accounts**
As this service accounts are hardened by Microsoft, I believe we can skip them

</br>
_Reference: Entra ID Connect Sync / Entra Connect Sync_