### PR TITLE
Fix duplicate check of mfamigration

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaWeakFactor.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaWeakFactor.ps1
@@ -35,15 +35,13 @@ function Test-MtCisaWeakFactor {
         "Email"
     )
 
-    $isMethodsMigrationComplete = Test-MtCisaMethodsMigration
-
     $result = Get-MtAuthenticationMethodPolicyConfig
 
     $weakAuthMethods = $result | Where-Object { $_.id -in $weakFactors }
 
     $enabledWeakMethods = $weakAuthMethods | Where-Object { $_.state -eq "enabled" }
 
-    $testResult = (($enabledWeakMethods|Measure-Object).Count -eq 0) -and $isMethodsMigrationComplete
+    $testResult = (($enabledWeakMethods|Measure-Object).Count -eq 0)
 
     if ($testResult) {
         $testResultMarkdown = "Well done. All weak authentication methods are disabled in your tenant.`n`n%TestResult%"
@@ -53,10 +51,8 @@ function Test-MtCisaWeakFactor {
 
     # Auth method does not support deep links.
     $authMethodsLink = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods"
-    $migrationResult = "❌ Fail"
-    if($isMethodsMigrationComplete){$migrationResult = "✅ Pass"}
-    $result = "[Authentication Methods]($authMethodsLink) Migration Complete: $migrationResult`n`n"
-    $result += "| Authentication Method | State | Test Result |`n"
+
+    $result = "| Authentication Method | State | Test Result |`n"
     $result += "| --- | --- | --- |`n"
     foreach ($item in $weakAuthMethods) {
         $methodResult = "✅ Pass"


### PR DESCRIPTION
CISA Test "MS.AAD.3.5: The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled." fails if MFA Migrations is not completet but the weak factors are disabled.
But CISA Test "MS.AAD.3.4: The Authentication Methods Manage Migration feature SHALL be set to Migration Complete." already checks if mfa migration is completed.