### PR TITLE
Convert json results to flat object and export CSV or Excel

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -176,7 +176,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-ORCA236', 'Test-ORCA237', 'Test-ORCA238',
                'Test-ORCA239', 'Test-ORCA240', 'Test-ORCA241',
                'Test-ORCA242', 'Test-ORCA243', 'Test-ORCA244',
-               'Convert-MtJsonResultsToFlatObject'
+               'Convert-MtResultsToFlatObject'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -175,7 +175,8 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-ORCA233', 'Test-ORCA234', 'Test-ORCA235',
                'Test-ORCA236', 'Test-ORCA237', 'Test-ORCA238',
                'Test-ORCA239', 'Test-ORCA240', 'Test-ORCA241',
-               'Test-ORCA242', 'Test-ORCA243', 'Test-ORCA244'
+               'Test-ORCA242', 'Test-ORCA243', 'Test-ORCA244',
+               'Convert-MtJsonResultsToFlatObject'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
+++ b/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
@@ -41,6 +41,9 @@
     .OUTPUTS
     System.Collections.Generic.List[PSObject]
 
+    .LINK
+    https://raw.githubusercontent.com/maester365/maester/refs/heads/main/powershell/README.md
+
     .NOTES
     Due to limitations in CSV files and Excel cells, the ResultDetails property is limited to 30000 characters. If the
     test result details are longer than this, that section will be truncated and a notification will be included in its
@@ -115,6 +118,7 @@
 
             # Truncate the ResultDetail.TestResult data if it is longer than 30000 characters.
             if ($_.ResultDetail.TestResult.Length -gt 30000) {
+                Write-Verbose -Message "Truncating the ResultDetail.TestResult data for test '$($_.Name)' to 30000 characters." -Verbose
                 $TestResultDetail = "$TruncationFYI`n`n$($TestResultDetail -replace '(?s)(.*?)#### Impacted resources.*?#### Remediation actions:','$1#### Remediation actions:')"
             } else {
                 $TestResultDetail = $_.ResultDetail.TestResult

--- a/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
+++ b/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
@@ -42,7 +42,7 @@
     System.Collections.Generic.List[PSObject]
 
     .LINK
-    https://raw.githubusercontent.com/maester365/maester/refs/heads/main/powershell/README.md
+    https://maester.dev/docs/commands/Convert-MtJsonResultsToFlatObject
 
     .NOTES
     Due to limitations in CSV files and Excel cells, the ResultDetails property is limited to 30000 characters. If the

--- a/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
+++ b/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
@@ -10,14 +10,20 @@
     .PARAMETER JsonFilePath
     The path of the file containing the Maester test results in JSON format.
 
+    .PARAMETER ExportCsv
+    Export the flattened object to a CSV file.
+
+    .PARAMETER ExportExcel
+    Export the flattened object to an Excel workbook using the ImportExcel module.
+
     .PARAMETER CsvFilePath
     The path of the file to export CSV data to.
 
     .PARAMETER ExcelFilePath
     The path of the file to export an Excel worksheet to.
 
-    .PARAMETER ExportExcel
-    Export the flattened object to an Excel workbook using the ImportExcel module.
+    .PARAMETER Force
+    Force the export to a CSV/XLSX file even if the file already exists.
 
     .PARAMETER Passthru
     Return the flattened object to the pipeline.
@@ -25,7 +31,7 @@
     .EXAMPLE
     Convert-MtJsonResultsToFlatObject -JsonFilePath 'C:\path\to\results.json'
 
-    Convert the Maester test results from JSON to a flattened object and then export that object to a CSV file.
+    Convert the Maester test results from JSON to a flattened object that is returned to the pipeline.
 
     .EXAMPLE
     Convert-MtJsonResultsToFlatObject -JsonFilePath 'C:\path\to\results.json' -ExportExcel
@@ -36,9 +42,10 @@
     System.Collections.Generic.List[PSObject]
 
     .NOTES
-    Due to limitations in CSV files and Excel cells, the ResultDetails property is truncated to only include the test
-    result and not details about impacted objects. The full details are still available in the JSON file.
-
+    Due to limitations in CSV files and Excel cells, the ResultDetails property is limited to 30000 characters. If the
+    test result details are longer than this, that section will be truncated and a notification will be included in its
+    place. This is most likely to happen when details about a large number of users is included in the result details.
+    The full details are still available in the JSON file and the HTML report.
     #>
     [CmdletBinding()]
     [OutputType([System.Collections.Generic.List[PSObject]])]
@@ -56,10 +63,20 @@
         [Parameter(HelpMessage = 'The path to the Excel file to which the Maester test results will be exported.')]
         [string]$ExcelFilePath = "$($JsonFilePath -replace '\.json$', '.xlsx')",
 
+        # Export the Maester test results to a CSV file.
+        [Parameter()]
+        [switch]
+        $ExportCsv,
+
         # Export the Maester test results to an Excel file.
         [Parameter()]
         [switch]
         $ExportExcel,
+
+        # Force the export to a CSV/XLSX file even if the file already exists.
+        [Parameter()]
+        [switch]
+        $Force,
 
         # Return the flattened object to the pipeline.
         [Parameter()]
@@ -67,66 +84,87 @@
         $Passthru
     )
 
-    #region ReplacementStrings
-    # Replacement strings for emoji characters and apostrophes that do not translate well to CSV files.
-    $ReplacementStrings = @{
-        'âŒ'       = ''
-        'âž¡ï¸'    = ''
-        'âœ…'       = ''
-        'youâ€™re'  = 'you are'
-        'arenâ€™nt' = 'are not'
-    } ; [void]$ReplacementStrings # Not Used Yet
-
-    [string]$TruncationFYI = 'NOTE: DETAILS ARE TRUNCATED DUE TO FIELD SIZE LIMITATIONS. PLEASE SEE THE HTML REPORT FOR FULL DETAILS.'
-    #endregion ReplacementStrings
-
-    $MaesterResults = New-Object System.Collections.Generic.List[PSObject]
-
-    $JsonData = (Get-Content -Path $JsonFilePath | ConvertFrom-Json).Tests
-    $JsonData | ForEach-Object {
-        # Truncate the ResultDetail.TestResult data if it is longer than 30000 characters.
-        if ($_.ResultDetail.TestResult.Length -gt 30000) {
-            $TestResultDetail = "$TruncationFYI`n`n$($TestResultDetail -replace '(?s)(.*?)#### Impacted resources.*?#### Remediation actions:','$1#### Remediation actions:')"
-        } else {
-            $TestResultDetail = $_.ResultDetail.TestResult
+    begin {
+        # Check for an existing CSV file.
+        if ($CsvFilePath -and (Test-Path -Path $CsvFilePath -PathType Leaf) -and -not $Force.IsPresent) {
+            throw "The specified CSV file path '$CsvFilePath' already exists. Use -Force if you want to overwrite this file."
         }
 
-        $MaesterResults.Add([PSCustomObject]@{
-                Name           = $_.Name
-                Tag            = $_.Tag -join ', '
-                Block          = $_.Block
-                Result         = $_.Result
-                Description    = $_.ResultDetail.TestDescription
-                ResultDetail   = $TestResultDetail
-                TestSkipped    = $_.ResultDetail.TestSkipped
-                SkippedReason  = $_.ResultDetail.SkippedReason
-                ErrorMessage   = $_.ErrorRecord.Exception.Message
-                HelpUrl        = $_.HelpUrl
-                TestScriptFile = [System.IO.Path]::GetFileName($_.ScriptBlockFile)
-            })
-    }
+        # Check for an existing Excel file.
+        if ($ExcelFilePath -and (Test-Path -Path $ExcelFilePath -PathType Leaf) -and -not $Force.IsPresent) {
+            throw "The specified Excel file path '$ExcelFilePath' already exists. Use -Force if you want to overwrite this file."
+        }
 
-    try {
-        $MaesterResults | Export-Csv -Path $CsvFilePath -UseQuotes Always -NoTypeInformation
-        Write-Information "Exported the Maester test results to '$CsvFilePath'." -InformationAction Continue
-    } catch {
-        Write-Error "Failed to export the Maester test results to a CSV file. $_"
-    }
+        # Replacement strings for emoji characters and apostrophes that do not translate well to CSV files.
+        [hashtable]$ReplacementStrings = @{
+            'âŒ'       = ''
+            'âž¡ï¸'    = ''
+            'âœ…'       = ''
+            'youâ€™re'  = 'you are'
+            'arenâ€™nt' = 'are not'
+        } ; [void]$ReplacementStrings # Not Used Yet
+        [string]$TruncationFYI = 'NOTE: DETAILS ARE TRUNCATED DUE TO FIELD SIZE LIMITATIONS. PLEASE SEE THE HTML REPORT FOR FULL DETAILS.'
 
-    if ($ExportExcel.IsPresent) {
-        try {
-            $MaesterResults | Export-Excel -Path $ExcelFilePath -FreezeTopRow -AutoFilter -BoldTopRow -WorksheetName 'Results'
-            Write-Information "Exported the Maester test results to '$ExcelFilePath'." -InformationAction Continue
-        } catch [System.Management.Automation.CommandNotFoundException] {
-            Write-Error "The ImportExcel module is required to export the Maester test results to an Excel file. Install the module using ``Import-Module -Name 'ImportExcel'`` and try again."
+        $MaesterResults = New-Object System.Collections.Generic.List[PSObject]
 
-        } catch {
-            Write-Error "Failed to export the Maester test results to an Excel file. $_"
+        $JsonData = (Get-Content -Path $JsonFilePath | ConvertFrom-Json).Tests
+    } #end begin
+
+    process {
+        $JsonData | ForEach-Object {
+
+            # Truncate the ResultDetail.TestResult data if it is longer than 30000 characters.
+            if ($_.ResultDetail.TestResult.Length -gt 30000) {
+                $TestResultDetail = "$TruncationFYI`n`n$($TestResultDetail -replace '(?s)(.*?)#### Impacted resources.*?#### Remediation actions:','$1#### Remediation actions:')"
+            } else {
+                $TestResultDetail = $_.ResultDetail.TestResult
+            }
+
+            # Add the flattened object to the MaesterResults list.
+            $MaesterResults.Add([PSCustomObject]@{
+                    Name           = $_.Name
+                    Tag            = $_.Tag -join ', '
+                    Block          = $_.Block
+                    Result         = $_.Result
+                    Description    = $_.ResultDetail.TestDescription
+                    ResultDetail   = $TestResultDetail
+                    TestSkipped    = $_.ResultDetail.TestSkipped
+                    SkippedReason  = $_.ResultDetail.SkippedReason
+                    ErrorMessage   = $_.ErrorRecord.Exception.Message
+                    HelpUrl        = $_.HelpUrl
+                    TestScriptFile = [System.IO.Path]::GetFileName($_.ScriptBlockFile)
+                })
+        }
+
+        # Export the MaesterResults list to a CSV if requested.
+        if ($ExportCsv.IsPresent) {
+            try {
+                $MaesterResults | Export-Csv -Path $CsvFilePath -UseQuotes Always -NoTypeInformation
+                Write-Information "Exported the Maester test results to '$CsvFilePath'." -InformationAction Continue
+            } catch {
+                Write-Error "Failed to export the Maester test results to a CSV file. $_"
+            }
+        }
+
+        # Export the MaesterResults list to an Excel file if requested.
+        if ($ExportExcel.IsPresent) {
+            try {
+                $MaesterResults | Export-Excel -Path $ExcelFilePath -FreezeTopRow -AutoFilter -BoldTopRow -WorksheetName 'Results'
+                Write-Information "Exported the Maester test results to '$ExcelFilePath'." -InformationAction Continue
+            } catch [System.Management.Automation.CommandNotFoundException] {
+                Write-Error "The ImportExcel module is required to export the Maester test results to an Excel file. Install the module using ``Import-Module -Name 'ImportExcel'`` and try again."
+
+            } catch {
+                Write-Error "Failed to export the Maester test results to an Excel file. $_"
+            }
         }
     }
 
-    if ($Passthru.IsPresent) {
-        $MaesterResults
+    end {
+        # Return the flattened object to the pipeline if requested or if no export is requested.
+        if ($Passthru.IsPresent -or (-not $ExportCsv.IsPresent -and -not $ExportExcel.IsPresent)) {
+            $MaesterResults
+        }
     }
 
 } #end function Convert-MtJsonResultsToFlatObject

--- a/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
+++ b/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
@@ -1,0 +1,101 @@
+﻿function Convert-MtJsonResultsToFlatObject {
+    <#
+    .SYNOPSIS
+    Convert Maester test results from JSON to a flattened object that can be exported to CSV or Excel.
+
+    .DESCRIPTION
+    Convert Maester test results from JSON to a flattened object that can be exported to CSV or Excel. This function exports
+    the data to a CSV file by default, but can also export to an Excel file if the ImportExcel module is installed.
+
+    .PARAMETER JsonFilePath
+    The path of the file containing the Maester test results in JSON format.
+
+    .PARAMETER CsvFilePath
+    The path of the file to export CSV data to.
+
+    .PARAMETER ExcelFilePath
+    The path of the file to export an Excel worksheet to.
+
+    .PARAMETER ExportExcel
+    Export the flattened object to an Excel workbook using the ImportExcel module.
+
+    .EXAMPLE
+    Convert-MtJsonResultsToFlatObject -JsonFilePath 'C:\path\to\results.json'
+
+    Convert the Maester test results from JSON to a flattened object and then export that object to a CSV file.
+
+    .EXAMPLE
+    Convert-MtJsonResultsToFlatObject -JsonFilePath 'C:\path\to\results.json' -ExportExcel
+
+    Convert the Maester test results from JSON to a flattened object and then export that object to an Excel file.
+
+    .OUTPUTS
+    System.Collections.Generic.List[PSObject]
+
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[PSObject]])]
+    param (
+        # The path to the JSON file containing the Maester test results.
+        [Parameter(Mandatory, Position = 0, HelpMessage = 'The path to the JSON file containing the Maester test results.')]
+        [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]
+        [string]$JsonFilePath,
+
+        # The path to the CSV file to which the Maester test results will be exported.
+        [Parameter(HelpMessage = 'The path to the CSV file to which the Maester test results will be exported.')]
+        [string]$CsvFilePath = "$($JsonFilePath -replace '\.json$', '.csv')",
+
+        # The path to the Excel file to which the Maester test results will be exported.
+        [Parameter(HelpMessage = 'The path to the Excel file to which the Maester test results will be exported.')]
+        [string]$ExcelFilePath = "$($JsonFilePath -replace '\.json$', '.xlsx')",
+
+        # Export the Maester test results to an Excel file.
+        [Parameter()]
+        [switch]
+        $ExportExcel
+    )
+
+    #region ReplacementStrings
+    # Replacement strings for emoji characters and apostrophes that do not translate well to CSV files.
+    $ReplacementStrings = @{
+        'âŒ'       = ''
+        'âž¡ï¸'    = ''
+        'âœ…'       = ''
+        'youâ€™re'  = 'you are'
+        'arenâ€™nt' = 'are not'
+    } ; [void]$ReplacementStrings # Not Used Yet
+    #endregion ReplacementStrings
+
+    $MaesterResults = New-Object System.Collections.Generic.List[PSObject]
+
+    $JsonData = (Get-Content -Path $JsonFilePath | ConvertFrom-Json).Tests
+    $JsonData | ForEach-Object {
+        $MaesterResults.Add([PSCustomObject]@{
+                Name           = $_.Name
+                Tag            = $_.Tag -join ', '
+                Block          = $_.Block
+                Result         = $_.Result
+                Description    = $_.ResultDetail.TestDescription
+                ResultDetail   = "$($_.ResultDetail.TestResult -replace '(?s)(.*?)#### Impacted resources.*?#### Remediation actions:','$1#### Remediation actions:')"
+                TestSkipped    = $_.ResultDetail.TestSkipped
+                SkippedReason  = $_.ResultDetail.SkippedReason
+                ErrorMessage   = $_.ErrorRecord.Exception.Message
+                HelpUrl        = $_.HelpUrl
+                TestScriptFile = [System.IO.Path]::GetFileName($_.ScriptBlockFile)
+            })
+    }
+
+    try {
+        $MaesterResults | Export-Csv -Path $CsvFilePath -UseQuotes Always -NoTypeInformation
+    } catch {
+        Write-Error "Failed to export the Maester test results to a CSV file. $_"
+    }
+
+    if ($ExportExcel.IsPresent) {
+        try {
+            $MaesterResults | Export-Excel -Path $ExcelFilePath -FreezeTopRow -AutoFilter -BoldTopRow -WorksheetName 'Results'
+        } catch {
+            Write-Error "Failed to export the Maester test results to an Excel file. $_"
+        }
+    }
+} #end function Convert-MtJsonResultsToFlatObject

--- a/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
+++ b/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
@@ -35,6 +35,10 @@
     .OUTPUTS
     System.Collections.Generic.List[PSObject]
 
+    .NOTES
+    Due to limitations in CSV files and Excel cells, the ResultDetails property is truncated to only include the test
+    result and not details about impacted objects. The full details are still available in the JSON file.
+
     #>
     [CmdletBinding()]
     [OutputType([System.Collections.Generic.List[PSObject]])]
@@ -102,6 +106,9 @@
     if ($ExportExcel.IsPresent) {
         try {
             $MaesterResults | Export-Excel -Path $ExcelFilePath -FreezeTopRow -AutoFilter -BoldTopRow -WorksheetName 'Results'
+        } catch [System.Management.Automation.CommandNotFoundException] {
+            Write-Error "The ImportExcel module is required to export the Maester test results to an Excel file. Install the module using ``Import-Module -Name 'ImportExcel'`` and try again."
+
         } catch {
             Write-Error "Failed to export the Maester test results to an Excel file. $_"
         }

--- a/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
+++ b/powershell/public/Convert-MtJsonResultsToFlatObject.ps1
@@ -19,6 +19,9 @@
     .PARAMETER ExportExcel
     Export the flattened object to an Excel workbook using the ImportExcel module.
 
+    .PARAMETER Passthru
+    Return the flattened object to the pipeline.
+
     .EXAMPLE
     Convert-MtJsonResultsToFlatObject -JsonFilePath 'C:\path\to\results.json'
 
@@ -52,7 +55,12 @@
         # Export the Maester test results to an Excel file.
         [Parameter()]
         [switch]
-        $ExportExcel
+        $ExportExcel,
+
+        # Return the flattened object to the pipeline.
+        [Parameter()]
+        [switch]
+        $Passthru
     )
 
     #region ReplacementStrings
@@ -97,5 +105,9 @@
         } catch {
             Write-Error "Failed to export the Maester test results to an Excel file. $_"
         }
+    }
+
+    if ($Passthru.IsPresent) {
+        $MaesterResults
     }
 } #end function Convert-MtJsonResultsToFlatObject

--- a/powershell/public/core/Convert-MtResultsToFlatObject.ps1
+++ b/powershell/public/core/Convert-MtResultsToFlatObject.ps1
@@ -47,7 +47,7 @@
     System.Collections.Generic.List[PSObject]
 
     .LINK
-    https://maester.dev/docs/commands/Convert-MtJsonResultsToFlatObject
+    https://maester.dev/docs/commands/Convert-MtResultsToFlatObject
 
     .NOTES
     Due to limitations in CSV files and Excel cells, the ResultDetails property is limited to 30000 characters. If the

--- a/website/docs/export-results.md
+++ b/website/docs/export-results.md
@@ -1,0 +1,41 @@
+---
+title: Exporting results
+---
+
+Maester supports exporting test results to CSV and Excel files. This is useful for sharing test results with others or for further analysis in a spreadsheet program.
+
+## Exporting results to CSV
+
+To export test results to a CSV file, use the `Convert-MtResultsToFlatObject` command with the `-CsvFilePath` parameter. The following example exports test results to a CSV file:
+
+```powershell
+$results = Invoke-Maester -PassThru
+Convert-MtResultsToFlatObject -Results $results -CsvFilePath "C:\path\to\results.csv"
+```
+
+## Exporting results to Excel
+
+To export test results to an Excel file, use the `Convert-MtResultsToFlatObject` command with the `-ExcelFilePath` parameter.
+
+:::info
+
+The `Convert-MtResultsToFlatObject` command requires the `ImportExcel` module. You can install the module by running `Install-Module ImportExcel`.
+
+:::
+
+The following example exports test results to an Excel file:
+
+```powershell
+$results = Invoke-Maester -PassThru
+Convert-MtResultsToFlatObject -Results $results -ExcelFilePath "C:\path\to\results.xlsx"
+```
+
+## Flattening results
+
+To export just the test results without the test suite hierarchy, use the `-PassThru` parameter with the `Convert-MtResultsToFlatObject` command. The following example exports flattened test results.
+
+```powershell
+$results = Invoke-Maester -PassThru
+Convert-MtResultsToFlatObject -Results $results -PassThru
+```
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -21,6 +21,7 @@ const sidebars = {
     },
     "ca-what-if",
     "updating-tests",
+    "export-results",
     {
       type: "category",
       label: "Connect-Maester",


### PR DESCRIPTION
This pull request introduces a new PowerShell function `Convert-MtJsonResultsToFlatObject` to convert Maester test results from JSON to a flattened object that can be exported to CSV or Excel. The function includes detailed parameter descriptions, examples, and output types.