### PR TITLE
Enhanced logic for discovery of default settings in recently new created tenants and bug fixes

### DIFF
--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -366,7 +366,7 @@ function UpdateTemplate($template, $control, $controlItem, $docName, $isDoc) {
         $output = $output -replace '%SkipCheck%', "$($SkipCheck)"
 
         # Extract variable name from the condition to build syntax for TestCases
-        $SkipConditionVariable = ($controlItem.SkipCondition -split ' ')[0]
+        $SkipConditionVariable = ($controlItem.SkipCondition  | Select-String -Pattern '\$([^\s]+)').Matches.Value
         $SkipConditionVariableName = $SkipConditionVariable -replace '[$()]', ''
         $output = $output -replace '%TestCases%', " -TestCases @{ $($SkipConditionVariableName) = $($SkipConditionVariable) }"
     } else {

--- a/powershell/internal/eidsca/@templateps1.txt
+++ b/powershell/internal/eidsca/@templateps1.txt
@@ -26,7 +26,7 @@ function %PSFunctionName% {
 
     [string]$tenantValue = $result.%CurrentValue%
     $testResult = $tenantValue -%PwshCompareOperator% %RecommendedValue%
-    $tenantValueNotSet = $null -eq $tenantValue -and %RecommendedValue% -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and %RecommendedValue% -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value %CompareOperatorText% **%RecommendedValue%** for **%RelativeUri%**"

--- a/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAF01 {
 
     [string]$tenantValue = $result.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF01.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAF01 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAF02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF02.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAF02 {
 
     [string]$tenantValue = $result.isSelfServiceRegistrationAllowed
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAF03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF03.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAF03 {
 
     [string]$tenantValue = $result.isAttestationEnforced
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAF04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF04.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAF04 {
 
     [string]$tenantValue = $result.keyRestrictions.isEnforced
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAF05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF05.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAF05 {
 
     [string]$tenantValue = $result.keyRestrictions.aaGuids -notcontains $null
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAF06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAF06.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAF06 {
 
     [string]$tenantValue = $result.keyRestrictions.aaGuids -notcontains $null -and ($result.keyRestrictions.enforcementType -eq 'allow' -or $result.keyRestrictions.enforcementType -eq 'block')
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Fido2')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAG01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAG01.md
@@ -5,7 +5,7 @@ On September 30th, 2025, the legacy multifactor authentication and self-service 
 #### Test script
 ```
 https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy
-.policyMigrationState -eq 'migrationComplete'
+.policyMigrationState -in @('migrationComplete', '')
 ```
 
 #### Related links

--- a/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Checks if Authentication Method - General Settings - Manage migration is set to 'migrationComplete'
+    Checks if Authentication Method - General Settings - Manage migration is set to @('migrationComplete', '')
 
 .DESCRIPTION
 
@@ -8,12 +8,12 @@
 
     Queries policies/authenticationMethodsPolicy
     and returns the result of
-     graph/policies/authenticationMethodsPolicy.policyMigrationState -eq 'migrationComplete'
+     graph/policies/authenticationMethodsPolicy.policyMigrationState -in @('migrationComplete', '')
 
 .EXAMPLE
     Test-MtEidscaAG01
 
-    Returns the result of graph.microsoft.com/beta/policies/authenticationMethodsPolicy.policyMigrationState -eq 'migrationComplete'
+    Returns the result of graph.microsoft.com/beta/policies/authenticationMethodsPolicy.policyMigrationState -in @('migrationComplete', '')
 #>
 
 function Test-MtEidscaAG01 {
@@ -25,15 +25,15 @@ function Test-MtEidscaAG01 {
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.policyMigrationState
-    $testResult = $tenantValue -eq 'migrationComplete'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'migrationComplete' -notlike '*$null*'
+    $testResult = $tenantValue -in @('migrationComplete', '')
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and @('migrationComplete', '') -notlike '*$null*'
 
     if($testResult){
-        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'migrationComplete'** for **policies/authenticationMethodsPolicy**"
+        $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is one of the following values **@('migrationComplete', '')** for **policies/authenticationMethodsPolicy**"
     } elseif ($tenantValueNotSet) {
-        $testResultMarkdown = "Your tenant is **not configured explicitly**.`n`nThe recommended value is **'migrationComplete'** for **policies/authenticationMethodsPolicy**. It seems that you are using a default value by Microsoft. We recommend to set the setting value explicitly since non set values could change depending on what Microsoft decides the current default should be."
+        $testResultMarkdown = "Your tenant is **not configured explicitly**.`n`nThe recommended value is **@('migrationComplete', '')** for **policies/authenticationMethodsPolicy**. It seems that you are using a default value by Microsoft. We recommend to set the setting value explicitly since non set values could change depending on what Microsoft decides the current default should be."
     } else {
-        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'migrationComplete'** for **policies/authenticationMethodsPolicy**"
+        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is one of the following values **@('migrationComplete', '')** for **policies/authenticationMethodsPolicy**"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG01.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAG01 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.policyMigrationState

--- a/powershell/internal/eidsca/Test-MtEidscaAG02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG02.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAG02 {
 
     [string]$tenantValue = $result.reportSuspiciousActivitySettings.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAG03 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.reportSuspiciousActivitySettings.includeTarget.id

--- a/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAG03.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAG03 {
 
     [string]$tenantValue = $result.reportSuspiciousActivitySettings.includeTarget.id
     $testResult = $tenantValue -eq 'all_users'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'all_users' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'all_users' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAM01 {
 
     [string]$tenantValue = $result.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM01.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAM01 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAM02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM02.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM02 {
 
     [string]$tenantValue = $result.isSoftwareOathEnabled
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM03.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM03 {
 
     [string]$tenantValue = $result.featureSettings.numberMatchingRequiredState.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM04.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM04 {
 
     [string]$tenantValue = $result.featureSettings.numberMatchingRequiredState.includeTarget.id
     $testResult = $tenantValue -eq 'all_users'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'all_users' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'all_users' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM06.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM06 {
 
     [string]$tenantValue = $result.featureSettings.displayAppInformationRequiredState.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM07.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM07.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM07 {
 
     [string]$tenantValue = $result.featureSettings.displayAppInformationRequiredState.includeTarget.id
     $testResult = $tenantValue -eq 'all_users'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'all_users' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'all_users' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM09.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM09 {
 
     [string]$tenantValue = $result.featureSettings.displayLocationInformationRequiredState.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAM10.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAM10.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAM10 {
 
     [string]$tenantValue = $result.featureSettings.displayLocationInformationRequiredState.includeTarget.id
     $testResult = $tenantValue -eq 'all_users'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'all_users' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'all_users' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'all_users'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('MicrosoftAuthenticator')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [authorizationPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy)
-
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/PasswordResetMenuBlade/~/AdminPasswordResetPolicy)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -21,6 +21,10 @@ function Test-MtEidscaAP01 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'allowedToUseSSPR' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            return $null
+    }
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToUseSSPR

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -21,7 +21,7 @@ function Test-MtEidscaAP01 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'allowedToUseSSPR' ) {
+    if ( $AuthorizationPolicyAvailable -notcontains 'allowedToUseSSPR' ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
             return $null
     }

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -22,7 +22,7 @@ function Test-MtEidscaAP01 {
     param()
 
     if ( $AuthorizationPolicyAvailable -notcontains 'allowedToUseSSPR' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants or tenants that are not licensed for Entra ID P1.'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAP01 {
 
     [string]$tenantValue = $result.allowedToUseSSPR
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.ps1
@@ -21,7 +21,7 @@ function Test-MtEidscaAP01 {
     [OutputType([bool])]
     param()
 
-    if ( $AuthorizationPolicyAvailable -notcontains 'allowedToUseSSPR' ) {
+    if ( $AuthorizationPolicyAvailable -notmatch 'allowedToUseSSPR' ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants or tenants that are not licensed for Entra ID P1.'
             return $null
     }

--- a/powershell/internal/eidsca/Test-MtEidscaAP04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP04.md
@@ -1,4 +1,4 @@
-Manages controls who can invite guests to your directory to collaborate on resources secured by your Azure AD, such as SharePoint sites or Azure resources.
+Manages controls who can invite guests to your directory to collaborate on resources secured by your Entra ID (Azure AD), such as SharePoint sites or Azure resources.
 
 CISA SCuBA 2.18: Only users with the Guest Inviter role SHOULD be able to invite guest users
 
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [authorizationPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/CompanyRelationshipsMenuBlade/~/Settings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AllowlistPolicyBlade)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
 
-    Manages controls who can invite guests to your directory to collaborate on resources secured by your Azure AD, such as SharePoint sites or Azure resources.
+    Manages controls who can invite guests to your directory to collaborate on resources secured by your Entra ID (Azure AD), such as SharePoint sites or Azure resources.
 
     Queries policies/authorizationPolicy
     and returns the result of
@@ -21,6 +21,7 @@ function Test-MtEidscaAP04 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowInvitesFrom

--- a/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP04.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAP04 {
 
     [string]$tenantValue = $result.allowInvitesFrom
     $testResult = $tenantValue -in @('adminsAndGuestInviters','none')
-    $tenantValueNotSet = $null -eq $tenantValue -and @('adminsAndGuestInviters','none') -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and @('adminsAndGuestInviters','none') -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is one of the following values **@('adminsAndGuestInviters','none')** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAP05 {
 
     [string]$tenantValue = $result.allowedToSignUpEmailBasedSubscriptions
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP05.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP05 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowedToSignUpEmailBasedSubscriptions

--- a/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAP06 {
 
     [string]$tenantValue = $result.allowEmailVerifiedUsersToJoinOrganization
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP06.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP06 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowEmailVerifiedUsersToJoinOrganization

--- a/powershell/internal/eidsca/Test-MtEidscaAP07.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP07.md
@@ -1,6 +1,6 @@
 Represents role templateId for the role that should be granted to guest user.
 
-CISA SCuBA 2.18: Guest users SHOULD have limited access to Azure AD directory objects.
+CISA SCuBA 2.18: Guest users SHOULD have limited access to Entra ID (Azure AD) directory objects.
 
 #### Test script
 ```
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [authorizationPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AllowlistPolicyBlade)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AllowlistPolicyBlade)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAP07 {
 
     [string]$tenantValue = $result.guestUserRoleId
     $testResult = $tenantValue -eq '2af84b1e-32c8-42b7-82bc-daa82404023b'
-    $tenantValueNotSet = $null -eq $tenantValue -and '2af84b1e-32c8-42b7-82bc-daa82404023b' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and '2af84b1e-32c8-42b7-82bc-daa82404023b' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'2af84b1e-32c8-42b7-82bc-daa82404023b'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP07.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP07 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.guestUserRoleId

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [authorizationPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserManagementMenuBlade/~/UserSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.md
@@ -5,7 +5,7 @@ Microsoft recommends to allow to user consent for apps from verified publisher f
 #### Test script
 ```
 https://graph.microsoft.com/beta/policies/authorizationPolicy
-.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1 -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
+.permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*' -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
 ```
 
 #### Related links

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
@@ -21,7 +21,7 @@ function Test-MtEidscaAP08 {
     [OutputType([bool])]
     param()
 
-    if ( ($AuthorizationPolicyAvailable | where-object permissionGrantPolicyIdsAssignedToDefaultUserRole -Match 'ManagePermissionGrantsForSelf*').Count -eq 0 ) {
+    if ( ($AuthorizationPolicyAvailable | where-object permissionGrantPolicyIdsAssignedToDefaultUserRole -Match 'ManagePermissionGrantsForSelf.microsoft-').Count -eq 0 ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'User Consent has been disabled or customized using Microsoft Graph or Microsoft Graph PowerShell without any assignment to custom policy.'
             return $null
     }
@@ -29,7 +29,7 @@ function Test-MtEidscaAP08 {
 
     [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*'
     $testResult = $tenantValue -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'ManagePermissionGrantsForSelf.microsoft-user-default-low' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'ManagePermissionGrantsForSelf.microsoft-user-default-low' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'ManagePermissionGrantsForSelf.microsoft-user-default-low'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
@@ -21,7 +21,10 @@ function Test-MtEidscaAP08 {
     [OutputType([bool])]
     param()
 
-    
+    if ( ($AuthorizationPolicyAvailable | where-object permissionGrantPolicyIdsAssignedToDefaultUserRole -Match 'ManagePermissionGrantsForSelf*').Count -eq 0 ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'User Consent has been disabled or customized using Microsoft Graph or Microsoft Graph PowerShell without any assignment to custom policy.'
+            return $null
+    }
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*'

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP08 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.ps1
@@ -8,12 +8,12 @@
 
     Queries policies/authorizationPolicy
     and returns the result of
-     graph/policies/authorizationPolicy.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1 -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
+     graph/policies/authorizationPolicy.permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*' -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
 
 .EXAMPLE
     Test-MtEidscaAP08
 
-    Returns the result of graph.microsoft.com/beta/policies/authorizationPolicy.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1 -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
+    Returns the result of graph.microsoft.com/beta/policies/authorizationPolicy.permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*' -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
 #>
 
 function Test-MtEidscaAP08 {
@@ -24,7 +24,7 @@ function Test-MtEidscaAP08 {
     
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
-    [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1
+    [string]$tenantValue = $result.permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*'
     $testResult = $tenantValue -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
     $tenantValueNotSet = $null -eq $tenantValue -and 'ManagePermissionGrantsForSelf.microsoft-user-default-low' -notlike '*$null*'
 

--- a/powershell/internal/eidsca/Test-MtEidscaAP09.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP09.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [authorizationPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy)
-
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP09 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.allowUserConsentForRiskyApps

--- a/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP09.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Checks if Default Authorization Settings - Risk-based step-up consent is set to 'false'
+    Checks if Default Authorization Settings - Allow user consent on risk-based apps is set to 'false'
 
 .DESCRIPTION
 
@@ -26,7 +26,7 @@ function Test-MtEidscaAP09 {
 
     [string]$tenantValue = $result.allowUserConsentForRiskyApps
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP10.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP10.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authorizationPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [authorizationPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/UserSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserManagementMenuBlade/~/UserSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP10 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToCreateApps

--- a/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP10.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAP10 {
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToCreateApps
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAP14 {
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToReadOtherUsers
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authorizationPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAP14.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAP14 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.defaultUserRolePermissions.allowedToReadOtherUsers

--- a/powershell/internal/eidsca/Test-MtEidscaAS04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAS04.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAS04 {
 
     [string]$tenantValue = $result.includeTargets.isUsableForSignIn
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAT01 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAT01.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAT01 {
 
     [string]$tenantValue = $result.state
     $testResult = $tenantValue -eq 'enabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'enabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'enabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'enabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAT02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAT02.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaAT02 {
 
     [string]$tenantValue = $result.isUsableOnce
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('TemporaryAccessPass')**"

--- a/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaAV01 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')" -ApiVersion beta
 
     [string]$tenantValue = $result.state

--- a/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAV01.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaAV01 {
 
     [string]$tenantValue = $result.state
     $testResult = $tenantValue -eq 'disabled'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'disabled' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'disabled' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'disabled'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Voice')**"

--- a/powershell/internal/eidsca/Test-MtEidscaCP01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCP01.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCP01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCP01.ps1
@@ -22,14 +22,14 @@ function Test-MtEidscaCP01 {
     param()
 
     if ( $SettingsApiAvailable -notcontains 'EnableGroupSpecificConsent' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Group owner consent settings have been removed and replaced with Team owner consent settings.'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableGroupSpecificConsent' | select-object -expand value
     $testResult = $tenantValue -eq 'False'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'False' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'False' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'False'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaCP03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCP03.ps1
@@ -21,15 +21,12 @@ function Test-MtEidscaCP03 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'BlockUserConsentForRiskyApps' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
-            return $null
-    }
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'BlockUserConsentForRiskyApps' | select-object -expand value
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaCP04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCP04.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCP04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCP04.ps1
@@ -21,15 +21,12 @@ function Test-MtEidscaCP04 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'EnableAdminConsentRequests' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
-            return $null
-    }
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableAdminConsentRequests' | select-object -expand value
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaCR01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR01.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/adminConsentRequestPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [adminConsentRequestPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/adminconsentrequestpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaCR01 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
     [string]$tenantValue = $result.isEnabled

--- a/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR01.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaCR01 {
 
     [string]$tenantValue = $result.isEnabled
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/adminConsentRequestPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaCR02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR02.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/adminConsentRequestPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [adminConsentRequestPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/adminconsentrequestpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR02.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaCR02 {
 
     [string]$tenantValue = $result.notifyReviewers
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/adminConsentRequestPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaCR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR02.ps1
@@ -21,7 +21,7 @@ function Test-MtEidscaCR02 {
     [OutputType([bool])]
     param()
 
-    if ( ($EnabledAdminConsentWorkflow) -eq $false ) {
+    if ( $EnabledAdminConsentWorkflow -eq $false ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Admin Consent Workflow is not enabled'
             return $null
     }

--- a/powershell/internal/eidsca/Test-MtEidscaCR03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR03.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/adminConsentRequestPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [adminConsentRequestPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/adminconsentrequestpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR03.ps1
@@ -21,7 +21,7 @@ function Test-MtEidscaCR03 {
     [OutputType([bool])]
     param()
 
-    if ( ($EnabledAdminConsentWorkflow) -eq $false ) {
+    if ( $EnabledAdminConsentWorkflow -eq $false ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Admin Consent Workflow is not enabled'
             return $null
     }

--- a/powershell/internal/eidsca/Test-MtEidscaCR03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR03.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaCR03 {
 
     [string]$tenantValue = $result.remindersEnabled
     $testResult = $tenantValue -eq 'true'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'true' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'true' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'true'** for **policies/adminConsentRequestPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaCR04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR04.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/adminConsentRequestPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [adminConsentRequestPolicy resource type - Microsoft Graph v1.0 | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/adminconsentrequestpolicy)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
@@ -29,7 +29,7 @@ function Test-MtEidscaCR04 {
 
     [string]$tenantValue = $result.requestDurationInDays
     $testResult = $tenantValue -le '30'
-    $tenantValueNotSet = $null -eq $tenantValue -and '30' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and '30' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is less than or equal to **'30'** for **policies/adminConsentRequestPolicy**"

--- a/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
@@ -21,7 +21,7 @@ function Test-MtEidscaCR04 {
     [OutputType([bool])]
     param()
 
-    if ( ($EnabledAdminConsentWorkflow) -eq $false ) {
+    if ( $EnabledAdminConsentWorkflow -eq $false ) {
             Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Admin Consent Workflow is not enabled'
             return $null
     }

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
@@ -22,7 +22,7 @@ function Test-MtEidscaPR01 {
     param()
 
     if ( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
@@ -22,7 +22,7 @@ function Test-MtEidscaPR01 {
     param()
 
     if ( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants or tenants that are not licensed for Entra ID P1.'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.ps1
@@ -21,15 +21,15 @@ function Test-MtEidscaPR01 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'BannedPasswordCheckOnPremisesMode' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants or tenants that are not licensed for Entra ID P1.'
+    if ( $EntraIDPlan -eq 'Free' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'This test is for tenants that are licensed for Entra ID P1 or higher. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'BannedPasswordCheckOnPremisesMode' | select-object -expand value
     $testResult = $tenantValue -eq 'Enforce'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'Enforce' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'Enforce' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'Enforce'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaPR02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR02.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
@@ -21,12 +21,15 @@ function Test-MtEidscaPR02 {
     [OutputType([bool])]
     param()
 
-    
+    if ( $EntraIDPlan -eq 'Free' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'This test is for tenants that are licensed for Entra ID P1 or higher. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)'
+            return $null
+    }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableBannedPasswordCheckOnPremises' | select-object -expand value
     $testResult = $tenantValue -eq 'True'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'True' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'True' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'True'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR02.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaPR02 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableBannedPasswordCheckOnPremises' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR03.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR03.ps1
@@ -21,15 +21,15 @@ function Test-MtEidscaPR03 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'EnableBannedPasswordCheck' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants or tenants that are not licensed for Entra ID P1.'
+    if ( $EntraIDPlan -eq 'Free' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'This test is for tenants that are licensed for Entra ID P1 or higher. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'EnableBannedPasswordCheck' | select-object -expand value
     $testResult = $tenantValue -eq 'True'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'True' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'True' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'True'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaPR03.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR03.ps1
@@ -22,7 +22,7 @@ function Test-MtEidscaPR03 {
     param()
 
     if ( $SettingsApiAvailable -notcontains 'EnableBannedPasswordCheck' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants or tenants that are not licensed for Entra ID P1.'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -22,7 +22,7 @@ function Test-MtEidscaPR05 {
     param()
 
     if ( $SettingsApiAvailable -notcontains 'LockoutDurationInSeconds' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -21,6 +21,10 @@ function Test-MtEidscaPR05 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'LockoutDurationInSeconds' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            return $null
+    }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -21,15 +21,12 @@ function Test-MtEidscaPR05 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'LockoutDurationInSeconds' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
-            return $null
-    }
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value
     $testResult = $tenantValue -ge '60'
-    $tenantValueNotSet = $null -eq $tenantValue -and '60' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and '60' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is greater than or equal to **'60'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.md
@@ -12,7 +12,7 @@ https://graph.microsoft.com/beta/settings
 
 - [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=settings&method=GET&version=beta&GraphUrl=https://graph.microsoft.com)
 - [directorySetting resource type - Microsoft Graph beta | Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/directorysetting)
-- [View in Microsoft Entra admin center](https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
+- [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
 %TestResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
@@ -21,15 +21,12 @@ function Test-MtEidscaPR06 {
     [OutputType([bool])]
     param()
 
-    if ( $SettingsApiAvailable -notcontains 'LockoutThreshold' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
-            return $null
-    }
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutThreshold' | select-object -expand value
     $testResult = $tenantValue -eq '10'
-    $tenantValueNotSet = $null -eq $tenantValue -and '10' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and '10' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'10'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
@@ -21,6 +21,10 @@ function Test-MtEidscaPR06 {
     [OutputType([bool])]
     param()
 
+    if ( $SettingsApiAvailable -notcontains 'LockoutThreshold' ) {
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            return $null
+    }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [int]$tenantValue = $result.values | where-object name -eq 'LockoutThreshold' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.ps1
@@ -22,7 +22,7 @@ function Test-MtEidscaPR06 {
     param()
 
     if ( $SettingsApiAvailable -notcontains 'LockoutThreshold' ) {
-            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants (NotLicensedEntraIDP1).'
+            Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'Settings value is not available. This may be due to the change that this API is no longer available for recent created tenants.'
             return $null
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta

--- a/powershell/internal/eidsca/Test-MtEidscaST08.md
+++ b/powershell/internal/eidsca/Test-MtEidscaST08.md
@@ -1,6 +1,6 @@
 Indicating whether or not a guest user can be an owner of groups, manage
 
-CISA SCuBA 2.18: Guest users SHOULD have limited access to Azure AD directory objects
+CISA SCuBA 2.18: Guest users SHOULD have limited access to Entra ID (Azure AD) directory objects
 
 #### Test script
 ```

--- a/powershell/internal/eidsca/Test-MtEidscaST08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST08.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaST08 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToBeGroupOwner' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaST08.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST08.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaST08 {
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToBeGroupOwner' | select-object -expand value
     $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'false' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **settings**"

--- a/powershell/internal/eidsca/Test-MtEidscaST09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST09.ps1
@@ -21,6 +21,7 @@ function Test-MtEidscaST09 {
     [OutputType([bool])]
     param()
 
+    
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToAccessGroups' | select-object -expand value

--- a/powershell/internal/eidsca/Test-MtEidscaST09.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaST09.ps1
@@ -26,7 +26,7 @@ function Test-MtEidscaST09 {
 
     [string]$tenantValue = $result.values | where-object name -eq 'AllowGuestsToAccessGroups' | select-object -expand value
     $testResult = $tenantValue -eq 'True'
-    $tenantValueNotSet = $null -eq $tenantValue -and 'True' -notlike '*$null*'
+    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'True' -notlike '*$null*'
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'True'** for **settings**"

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -1,10 +1,11 @@
 BeforeDiscovery {
+$AuthorizationPolicyAvailable = (Invoke-MtGraphRequest -RelativeUri 'policies/authorizationpolicy' -ApiVersion beta).psobject.properties.name
 $SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
 $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
 $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
 }
 Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AP01" {
-    It "EIDSCA.AP01: Default Authorization Settings - Enabled Self service password reset for administrators. See https://maester.dev/docs/tests/EIDSCA.AP01" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.AP01: Default Authorization Settings - Enabled Self service password reset for administrators. See https://maester.dev/docs/tests/EIDSCA.AP01" -TestCases @{ AuthorizationPolicyAvailable = $AuthorizationPolicyAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authorizationPolicy"
             .allowedToUseSSPR -eq 'false'

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -1,6 +1,7 @@
 BeforeDiscovery {
 $AuthorizationPolicyAvailable = (Invoke-MtGraphRequest -RelativeUri 'policies/authorizationpolicy' -ApiVersion beta)
 $SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
+$EntraIDPlan = Get-MtLicenseInformation -Product 'EntraID'
 $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
 $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
 }
@@ -59,7 +60,7 @@ Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EID
     }
 }
 Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AP09" {
-    It "EIDSCA.AP09: Default Authorization Settings - Risk-based step-up consent. See https://maester.dev/docs/tests/EIDSCA.AP09" {
+    It "EIDSCA.AP09: Default Authorization Settings - Allow user consent on risk-based apps. See https://maester.dev/docs/tests/EIDSCA.AP09" {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authorizationPolicy"
             .allowUserConsentForRiskyApps -eq 'false'
@@ -96,7 +97,7 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
     }
 }
 Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP03" {
-    It "EIDSCA.CP03: Default Settings - Consent Policy Settings - Block user consent for risky apps. See https://maester.dev/docs/tests/EIDSCA.CP03" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.CP03: Default Settings - Consent Policy Settings - Block user consent for risky apps. See https://maester.dev/docs/tests/EIDSCA.CP03" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'BlockUserConsentForRiskyApps' | select-object -expand value -eq 'true'
@@ -105,7 +106,7 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
     }
 }
 Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.CP04" {
-    It "EIDSCA.CP04: Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. See https://maester.dev/docs/tests/EIDSCA.CP04" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.CP04: Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. See https://maester.dev/docs/tests/EIDSCA.CP04" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'EnableAdminConsentRequests' | select-object -expand value -eq 'true'
@@ -115,7 +116,7 @@ Describe "Default Settings - Consent Policy Settings" -Tag "EIDSCA", "Security",
 }
 
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR01" {
-    It "EIDSCA.PR01: Default Settings - Password Rule Settings - Password Protection - Mode. See https://maester.dev/docs/tests/EIDSCA.PR01" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.PR01: Default Settings - Password Rule Settings - Password Protection - Mode. See https://maester.dev/docs/tests/EIDSCA.PR01" -TestCases @{ EntraIDPlan = $EntraIDPlan } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'BannedPasswordCheckOnPremisesMode' | select-object -expand value -eq 'Enforce'
@@ -124,7 +125,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR02" {
-    It "EIDSCA.PR02: Default Settings - Password Rule Settings - Password Protection - Enable password protection on Windows Server Active Directory. See https://maester.dev/docs/tests/EIDSCA.PR02" {
+    It "EIDSCA.PR02: Default Settings - Password Rule Settings - Password Protection - Enable password protection on Windows Server Active Directory. See https://maester.dev/docs/tests/EIDSCA.PR02" -TestCases @{ EntraIDPlan = $EntraIDPlan } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'EnableBannedPasswordCheckOnPremises' | select-object -expand value -eq 'True'
@@ -133,7 +134,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR03" {
-    It "EIDSCA.PR03: Default Settings - Password Rule Settings - Enforce custom list. See https://maester.dev/docs/tests/EIDSCA.PR03" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.PR03: Default Settings - Password Rule Settings - Enforce custom list. See https://maester.dev/docs/tests/EIDSCA.PR03" -TestCases @{ EntraIDPlan = $EntraIDPlan } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'EnableBannedPasswordCheck' | select-object -expand value -eq 'True'
@@ -142,7 +143,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR05" {
-    It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -ge '60'
@@ -151,7 +152,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR06" {
-    It "EIDSCA.PR06: Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. See https://maester.dev/docs/tests/EIDSCA.PR06" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
+    It "EIDSCA.PR06: Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. See https://maester.dev/docs/tests/EIDSCA.PR06" {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutThreshold' | select-object -expand value -eq '10'
@@ -183,9 +184,9 @@ Describe "Authentication Method - General Settings" -Tag "EIDSCA", "Security", "
     It "EIDSCA.AG01: Authentication Method - General Settings - Manage migration. See https://maester.dev/docs/tests/EIDSCA.AG01" {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy"
-            .policyMigrationState -eq 'migrationComplete'
+            .policyMigrationState -in @('migrationComplete', '')
         #>
-        Test-MtEidscaControl -CheckId AG01 | Should -Be 'migrationComplete'
+        Test-MtEidscaControl -CheckId AG01 | Should -BeIn @('migrationComplete', '')
     }
 }
 Describe "Authentication Method - General Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AG02" {

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -4,7 +4,7 @@ $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
 $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
 }
 Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AP01" {
-    It "EIDSCA.AP01: Default Authorization Settings - Enabled Self service password reset for administrators. See https://maester.dev/docs/tests/EIDSCA.AP01" {
+    It "EIDSCA.AP01: Default Authorization Settings - Enabled Self service password reset for administrators. See https://maester.dev/docs/tests/EIDSCA.AP01" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authorizationPolicy"
             .allowedToUseSSPR -eq 'false'
@@ -141,7 +141,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR05" {
-    It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" {
+    It "EIDSCA.PR05: Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. See https://maester.dev/docs/tests/EIDSCA.PR05" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value -ge '60'
@@ -150,7 +150,7 @@ Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Default Settings - Password Rule Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.PR06" {
-    It "EIDSCA.PR06: Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. See https://maester.dev/docs/tests/EIDSCA.PR06" {
+    It "EIDSCA.PR06: Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. See https://maester.dev/docs/tests/EIDSCA.PR06" -TestCases @{ SettingsApiAvailable = $SettingsApiAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/settings"
             .values | where-object name -eq 'LockoutThreshold' | select-object -expand value -eq '10'

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -53,7 +53,7 @@ Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EID
     It "EIDSCA.AP08: Default Authorization Settings - User consent policy assigned for applications. See https://maester.dev/docs/tests/EIDSCA.AP08" {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authorizationPolicy"
-            .permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1 -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
+            .permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*' -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
         #>
         Test-MtEidscaControl -CheckId AP08 | Should -Be 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
     }

--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -1,5 +1,5 @@
 BeforeDiscovery {
-$AuthorizationPolicyAvailable = (Invoke-MtGraphRequest -RelativeUri 'policies/authorizationpolicy' -ApiVersion beta).psobject.properties.name
+$AuthorizationPolicyAvailable = (Invoke-MtGraphRequest -RelativeUri 'policies/authorizationpolicy' -ApiVersion beta)
 $SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
 $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
 $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
@@ -50,7 +50,7 @@ Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EID
     }
 }
 Describe "Default Authorization Settings" -Tag "EIDSCA", "Security", "All", "EIDSCA.AP08" {
-    It "EIDSCA.AP08: Default Authorization Settings - User consent policy assigned for applications. See https://maester.dev/docs/tests/EIDSCA.AP08" {
+    It "EIDSCA.AP08: Default Authorization Settings - User consent policy assigned for applications. See https://maester.dev/docs/tests/EIDSCA.AP08" -TestCases @{ AuthorizationPolicyAvailable = $AuthorizationPolicyAvailable } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/authorizationPolicy"
             .permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*' -eq 'ManagePermissionGrantsForSelf.microsoft-user-default-low'
@@ -384,7 +384,7 @@ Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR02" {
-    It "EIDSCA.CR02: Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. See https://maester.dev/docs/tests/EIDSCA.CR02" -TestCases @{ EnabledAdminConsentWorkflow = ($EnabledAdminConsentWorkflow) } {
+    It "EIDSCA.CR02: Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. See https://maester.dev/docs/tests/EIDSCA.CR02" -TestCases @{ EnabledAdminConsentWorkflow = $EnabledAdminConsentWorkflow } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy"
             .notifyReviewers -eq 'true'
@@ -393,7 +393,7 @@ Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR03" {
-    It "EIDSCA.CR03: Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. See https://maester.dev/docs/tests/EIDSCA.CR03" -TestCases @{ EnabledAdminConsentWorkflow = ($EnabledAdminConsentWorkflow) } {
+    It "EIDSCA.CR03: Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. See https://maester.dev/docs/tests/EIDSCA.CR03" -TestCases @{ EnabledAdminConsentWorkflow = $EnabledAdminConsentWorkflow } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy"
             .remindersEnabled -eq 'true'
@@ -402,7 +402,7 @@ Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", 
     }
 }
 Describe "Consent Framework - Admin Consent Request" -Tag "EIDSCA", "Security", "All", "EIDSCA.CR04" {
-    It "EIDSCA.CR04: Consent Framework - Admin Consent Request - Consent request duration (days). See https://maester.dev/docs/tests/EIDSCA.CR04" -TestCases @{ EnabledAdminConsentWorkflow = ($EnabledAdminConsentWorkflow) } {
+    It "EIDSCA.CR04: Consent Framework - Admin Consent Request - Consent request duration (days). See https://maester.dev/docs/tests/EIDSCA.CR04" -TestCases @{ EnabledAdminConsentWorkflow = $EnabledAdminConsentWorkflow } {
         <#
             Check if "https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy"
             .requestDurationInDays -le '30'

--- a/website/docs/tests/eidsca/EIDSCA.AG01.md
+++ b/website/docs/tests/eidsca/EIDSCA.AG01.md
@@ -25,7 +25,7 @@ The state of migration of the authentication methods policy from the legacy mult
 | **Recommendation** | On September 30th, 2025, the legacy multifactor authentication and self-service password reset policies will be deprecated and you'll manage all authentication methods here in the authentication methods policy. Use this control to manage your migration from the legacy policies to the new unified policy. |
 | **Configuration** | policies/authenticationMethodsPolicy |
 | **Setting** | `policyMigrationState` |
-| **Recommended Value** | 'migrationComplete' |
+| **Recommended Value** | 'migrationComplete', '' |
 | **Default Value** | premigration |
 | **Graph API Docs** | [Get authenticationMethodsPolicy - Microsoft Graph v1.0 - Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/authenticationmethodspolicy-get) |
 | **Graph Explorer** | [Open in Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer?request=policies/authenticationMethodsPolicy&method=GET&version=beta&GraphUrl=https://graph.microsoft.com) |

--- a/website/docs/tests/eidsca/EIDSCA.AP01.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP01.md
@@ -12,12 +12,12 @@ Indicates whether administrators of the tenant can use the Self-Service Password
 |-|-|
 | **Name** | allowedToUseSSPR |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | Informational |
 
 ## How to fix
 
-
+Update-MgPolicyAuthorizationPolicy -BodyParameter @{ allowedToUseSSPR = $false }
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP01.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP01.md
@@ -17,7 +17,7 @@ Indicates whether administrators of the tenant can use the Self-Service Password
 
 ## How to fix
 
-Update-MgPolicyAuthorizationPolicy -BodyParameter @{ allowedToUseSSPR = $false }
+Microsoft Graph PowerShell: ```Update-MgPolicyAuthorizationPolicy -BodyParameter @{ allowedToUseSSPR = $false }```
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP04.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP04.md
@@ -6,13 +6,13 @@ sidebar_class_name: hidden
 
 # Default Authorization Settings - Guest invite restrictions
 
-Manages controls who can invite guests to your directory to collaborate on resources secured by your Azure AD, such as SharePoint sites or Azure resources.
+Manages controls who can invite guests to your directory to collaborate on resources secured by your Entra ID (Azure AD), such as SharePoint sites or Azure resources.
 
 | | |
 |-|-|
 | **Name** | allowInvitesFrom |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | Medium |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.AP05.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP05.md
@@ -17,7 +17,7 @@ Indicates whether users can sign up for email based subscriptions.
 
 ## How to fix
 
-Update-MgPolicyAuthorizationPolicy -AllowedToSignupEmailBasedSubscriptions $false
+Microsoft Graph PowerShell: ```Update-MgPolicyAuthorizationPolicy -AllowedToSignupEmailBasedSubscriptions $false```
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP05.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP05.md
@@ -12,12 +12,12 @@ Indicates whether users can sign up for email based subscriptions.
 |-|-|
 | **Name** | allowedToSignUpEmailBasedSubscriptions |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | Medium |
 
 ## How to fix
 
-
+Update-MgPolicyAuthorizationPolicy -AllowedToSignupEmailBasedSubscriptions $false
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP06.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP06.md
@@ -12,7 +12,7 @@ Controls whether users can join the tenant by email validation. To join, the use
 |-|-|
 | **Name** | allowEmailVerifiedUsersToJoinOrganization |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | Medium |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.AP07.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP07.md
@@ -12,7 +12,7 @@ Represents role templateId for the role that should be granted to guest user.
 |-|-|
 | **Name** | guestUserRoleId |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** |  |
 
 ## How to fix
@@ -22,7 +22,7 @@ Represents role templateId for the role that should be granted to guest user.
 ### Details of configuration item
 | | |
 |-|-|
-| **Recommendation** | CISA SCuBA 2.18: Guest users SHOULD have limited access to Azure AD directory objects. |
+| **Recommendation** | CISA SCuBA 2.18: Guest users SHOULD have limited access to Entra ID (Azure AD) directory objects. |
 | **Configuration** | policies/authorizationPolicy |
 | **Setting** | `guestUserRoleId` |
 | **Recommended Value** | '2af84b1e-32c8-42b7-82bc-daa82404023b' |

--- a/website/docs/tests/eidsca/EIDSCA.AP08.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP08.md
@@ -12,7 +12,7 @@ Defines if user consent to apps is allowed, and if it is, which app consent poli
 |-|-|
 | **Name** | permissionGrantPolicyIdsAssignedToDefaultUserRole |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | High |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.AP08.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP08.md
@@ -24,7 +24,7 @@ Defines if user consent to apps is allowed, and if it is, which app consent poli
 |-|-|
 | **Recommendation** | Microsoft recommends to allow to user consent for apps from verified publisher for selected permissions. CISA SCuBA 2.7 defines that all Non-Admin Users SHALL Be Prevented From Providing Consent To Third-Party Applications. |
 | **Configuration** | policies/authorizationPolicy |
-| **Setting** | `permissionGrantPolicyIdsAssignedToDefaultUserRole | Sort-Object -Descending | select-object -first 1` |
+| **Setting** | `permissionGrantPolicyIdsAssignedToDefaultUserRole -clike 'ManagePermissionGrantsForSelf*'` |
 | **Recommended Value** | 'ManagePermissionGrantsForSelf.microsoft-user-default-low' |
 | **Default Value** | ManagePermissionGrantsForSelf.microsoft-user-default-legacy |
 | **Graph API Docs** | [authorizationPolicy resource type - Microsoft Graph v1.0 - Microsoft Learn](https://learn.microsoft.com/en-us/graph/api/resources/authorizationpolicy) |

--- a/website/docs/tests/eidsca/EIDSCA.AP09.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP09.md
@@ -1,10 +1,10 @@
 ---
-title: EIDSCA.AP09 - Default Authorization Settings - Risk-based step-up consent
+title: EIDSCA.AP09 - Default Authorization Settings - Allow user consent on risk-based apps
 slug: /tests/EIDSCA.AP09
 sidebar_class_name: hidden
 ---
 
-# Default Authorization Settings - Risk-based step-up consent
+# Default Authorization Settings - Allow user consent on risk-based apps
 
 Indicates whether user consent for risky apps is allowed. For example, consent requests for newly registered multi-tenant apps that are not publisher verified and require non-basic permissions are considered risky.
 

--- a/website/docs/tests/eidsca/EIDSCA.AP09.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP09.md
@@ -12,7 +12,7 @@ Indicates whether user consent for risky apps is allowed. For example, consent r
 |-|-|
 | **Name** | allowUserConsentForRiskyApps |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | High |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.AP10.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP10.md
@@ -17,7 +17,7 @@ Controls if non-admin users may register custom-developed applications for use w
 
 ## How to fix
 
-Update-MgPolicyAuthorizationPolicy -BodyParameter @{DefaultUserRolePermissions = @{AllowedToCreateApps = $false}}
+Microsoft Graph PowerShell: ```Update-MgPolicyAuthorizationPolicy -BodyParameter @{ DefaultUserRolePermissions = @{ AllowedToCreateApps = $false }}```
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP10.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP10.md
@@ -12,12 +12,12 @@ Controls if non-admin users may register custom-developed applications for use w
 |-|-|
 | **Name** | allowedToCreateApps |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | High |
 
 ## How to fix
 
-
+Update-MgPolicyAuthorizationPolicy -BodyParameter @{DefaultUserRolePermissions = @{AllowedToCreateApps = $false}}
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP14.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP14.md
@@ -17,7 +17,7 @@ Prevents all non-admins from reading user information from the directory. This f
 
 ## How to fix
 
-Update-MgPolicyAuthorizationPolicy -BodyParameter @{DefaultUserRolePermissions = @{AllowedToReadOtherUsers = $false}}
+Microsoft Graph PowerShell: ```PolicyAuthorizationPolicy -BodyParameter @{DefaultUserRolePermissions = @{AllowedToReadOtherUsers = $false}}```
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.AP14.md
+++ b/website/docs/tests/eidsca/EIDSCA.AP14.md
@@ -12,12 +12,12 @@ Prevents all non-admins from reading user information from the directory. This f
 |-|-|
 | **Name** | allowedToReadOtherUsers |
 | **Control** | Default Authorization Settings |
-| **Description** | Manages authorization settings in Azure AD |
+| **Description** | Manages authorization settings in Entra ID (Azure AD) |
 | **Severity** | Informational |
 
 ## How to fix
 
-
+Update-MgPolicyAuthorizationPolicy -BodyParameter @{DefaultUserRolePermissions = @{AllowedToReadOtherUsers = $false}}
 
 ### Details of configuration item
 | | |

--- a/website/docs/tests/eidsca/EIDSCA.CR01.md
+++ b/website/docs/tests/eidsca/EIDSCA.CR01.md
@@ -12,7 +12,7 @@ Defines if admin consent request feature is enabled or disabled
 |-|-|
 | **Name** | isEnabled |
 | **Control** | Consent Framework - Admin Consent Request |
-| **Description** | Represents the policy for enabling or disabling the Azure AD admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
+| **Description** | Represents the policy for enabling or disabling the Entra ID (Azure AD) admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
 | **Severity** |  |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.CR02.md
+++ b/website/docs/tests/eidsca/EIDSCA.CR02.md
@@ -12,7 +12,7 @@ Specifies whether reviewers will receive notifications
 |-|-|
 | **Name** | notifyReviewers |
 | **Control** | Consent Framework - Admin Consent Request |
-| **Description** | Represents the policy for enabling or disabling the Azure AD admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
+| **Description** | Represents the policy for enabling or disabling the Entra ID (Azure AD) admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
 | **Severity** |  |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.CR03.md
+++ b/website/docs/tests/eidsca/EIDSCA.CR03.md
@@ -12,7 +12,7 @@ Specifies whether reviewers will receive reminder emails
 |-|-|
 | **Name** | remindersEnabled |
 | **Control** | Consent Framework - Admin Consent Request |
-| **Description** | Represents the policy for enabling or disabling the Azure AD admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
+| **Description** | Represents the policy for enabling or disabling the Entra ID (Azure AD) admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
 | **Severity** |  |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.CR04.md
+++ b/website/docs/tests/eidsca/EIDSCA.CR04.md
@@ -12,7 +12,7 @@ Specifies the duration the request is active before it automatically expires if 
 |-|-|
 | **Name** | requestDurationInDays |
 | **Control** | Consent Framework - Admin Consent Request |
-| **Description** | Represents the policy for enabling or disabling the Azure AD admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
+| **Description** | Represents the policy for enabling or disabling the Entra ID (Azure AD) admin consent workflow. The admin consent workflow allows users to request access for apps that they wish to use and that require admin authorization before users can use the apps to access organizational data.  |
 | **Severity** |  |
 
 ## How to fix

--- a/website/docs/tests/eidsca/EIDSCA.ST08.md
+++ b/website/docs/tests/eidsca/EIDSCA.ST08.md
@@ -22,7 +22,7 @@ Indicating whether or not a guest user can be an owner of groups, manage
 ### Details of configuration item
 | | |
 |-|-|
-| **Recommendation** | CISA SCuBA 2.18: Guest users SHOULD have limited access to Azure AD directory objects |
+| **Recommendation** | CISA SCuBA 2.18: Guest users SHOULD have limited access to Entra ID (Azure AD) directory objects |
 | **Configuration** | settings |
 | **Setting** | `values | where-object name -eq 'AllowGuestsToBeGroupOwner' | select-object -expand value` |
 | **Recommended Value** | 'false' |


### PR DESCRIPTION
* Improvement in skip conditions to differentiate between missing properties in ```settings``` endpoint because of unlicensed tenant, deprecated settings or not explicitly configured values (instead of default tenant settings)
* Fix for deprecated settings on Group owner consent https://github.com/maester365/maester/issues/223
* Improvement to identify disabled or custom consent policy for skip check
* Required PowerShell module included in section HowToFix