### PR TITLE
Issue #653 fix: remove unnecessary string casting

### DIFF
--- a/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaCR04.ps1
@@ -27,9 +27,9 @@ function Test-MtEidscaCR04 {
     }
     $result = Invoke-MtGraphRequest -RelativeUri "policies/adminConsentRequestPolicy" -ApiVersion beta
 
-    [string]$tenantValue = $result.requestDurationInDays
-    $testResult = $tenantValue -le '30'
-    $tenantValueNotSet = $null -eq $tenantValue -and '30' -notlike '*$null*'
+    $tenantValue = $result.requestDurationInDays
+    $testResult = $tenantValue -le 30
+    $tenantValueNotSet = [string]::IsNullOrEmpty($tenantValue) -or $tenantValue -eq 0
 
     if($testResult){
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is less than or equal to **'30'** for **policies/adminConsentRequestPolicy**"


### PR DESCRIPTION
fix: remove unnecessary string casting and improve tenant value checks in admin consent policy test

Previously, the test for "policies/adminConsentRequestPolicy" incorrectly cast the RequestDurationInDays value to a string, resulting in faulty comparisons. This change removes the string cast, allowing for proper numeric comparison, and improves the handling of unset tenant values using [string]::IsNullOrEmpty() and a check for a zero value.

- Removed casting of RequestDurationInDays to string.
- Compared tenantValue directly against the integer 30.
- Updated tenantValueNotSet logic to reliably detect unset or default values.
- Ensured the testResultMarkdown messages remain consistent with the new logic.