### PR TITLE
Add new test MT.1049

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -94,7 +94,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Test-MtCaExclusionForDirectorySyncAccount',
                'Test-MtCaLicenseUtilization', 'Test-MtCaMfaForAdmin',
                'Test-MtCaMfaForAdminManagement', 'Test-MtCaMfaForAllUsers',
-               "Test-MtCaGroupsRestricted",
+               "Test-MtCaGroupsRestricted", 'Test-MtCaMisconfiguredIDProtection',
                "Test-MtCaGap", "Test-MtCaReferencedGroupsExist",
                'Test-MtCaMfaForGuest', 'Test-MtCaMfaForRiskySignIn',
                'Test-MtCaRequirePasswordChangeForHighUserRisk',

--- a/powershell/public/Test-MtCaMisconfiguredIDProtection.md
+++ b/powershell/public/Test-MtCaMisconfiguredIDProtection.md
@@ -1,4 +1,9 @@
-Checks for common misconfigurations in Conditional Access: both user risk and sign-in risk are configured in one policy.
+Checks if both user risk and sign-in risk are configured in one conditional access policy.
+
+Combining sign in risk and user risk in one policy will only block access if both types of risk are flagged for a given sign in.
+
+This means if only one type of risk is present (eg Sign-in risk = High, User risk = None), the sign-in will be allowed to proceed. This could create a security gap since risky activities might slip through.
+
 
 See [Sign-in risk-based multifactor authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-risk)
 <!--- Results --->

--- a/powershell/public/Test-MtCaMisconfiguredIDProtection.md
+++ b/powershell/public/Test-MtCaMisconfiguredIDProtection.md
@@ -1,0 +1,5 @@
+Checks for common misconfigurations in Conditional Access: both user risk and sign-in risk are configured in one policy.
+
+See [Sign-in risk-based multifactor authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-risk)
+<!--- Results --->
+%TestResult%

--- a/powershell/public/Test-MtCaMisconfiguredIDProtection.ps1
+++ b/powershell/public/Test-MtCaMisconfiguredIDProtection.ps1
@@ -1,0 +1,50 @@
+<#
+ .Synopsis
+Checks for common misconfigurations in Conditional Access: both user risk and sign-in risk are configured in one policy.
+
+ .Description
+Conditional Access policies' access controls are enforced only if ALL conditions are met. Therefore, sign-in risk and user risk should be configured separately.
+
+  Learn more:
+  https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies 
+
+ .Example
+  Test-MtCaMisconfiguredIDProtection
+#>
+
+Function Test-MtCaMisconfiguredIDProtection {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param ()
+
+    if ( ( Get-MtLicenseInformation EntraID ) -ne "P2" ) {
+        Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP2
+        return $null
+    }
+
+    $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq "enabled" }
+    $policiesResult = New-Object System.Collections.ArrayList
+
+    $result = $false
+    foreach ($policy in $policies) {
+        if ($policy.conditions.userRiskLevels -and $policy.conditions.signInRiskLevels) {
+            $result = $true
+            $currentresult = $true
+            $policiesResult.Add($policy) | Out-Null
+        } else {
+            $currentresult = $false
+        }
+        Write-Verbose "$($policy.displayName) - $currentresult"
+    }
+
+    $testDescription = "This test will check if both sign-in risk and user risk are configured in the same policy."
+
+    if ( $result ) {
+        $testResult = "The following conditional access policies have both sign-in risk and user risk controls configured:`n`n%TestResult%"
+    } else {
+        $testResult = "No conditional access policies detected where sign-in risk and user risk are combined."
+    }
+    Add-MtTestResultDetail -Description $testDescription -Result $testResult -GraphObjects $policiesResult -GraphObjectType ConditionalAccess
+
+    return $result
+}

--- a/powershell/public/Test-MtCaMisconfiguredIDProtection.ps1
+++ b/powershell/public/Test-MtCaMisconfiguredIDProtection.ps1
@@ -10,6 +10,9 @@ Conditional Access policies' access controls are enforced only if ALL conditions
 
  .Example
   Test-MtCaMisconfiguredIDProtection
+
+  .LINK
+  https://maester.dev/docs/commands/Test-MtCaMisconfiguredIDProtection
 #>
 
 Function Test-MtCaMisconfiguredIDProtection {

--- a/powershell/public/Test-MtCaMisconfiguredIDProtection.ps1
+++ b/powershell/public/Test-MtCaMisconfiguredIDProtection.ps1
@@ -42,7 +42,7 @@ Function Test-MtCaMisconfiguredIDProtection {
     if ( $result ) {
         $testResult = "The following conditional access policies have both sign-in risk and user risk controls configured:`n`n%TestResult%"
     } else {
-        $testResult = "No conditional access policies detected where sign-in risk and user risk are combined."
+        $testResult = "Well done! No conditional access policies detected where sign-in risk and user risk are combined."
     }
     Add-MtTestResultDetail -Description $testDescription -Result $testResult -GraphObjects $policiesResult -GraphObjectType ConditionalAccess
 

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -65,6 +65,9 @@
     It "MT.1038: Conditional Access policies should not include or exclude deleted groups. See https://maester.dev/docs/tests/MT.1038" -Tag "MT.1038", "Warning" {
         Test-MtCaReferencedGroupsExist | Should -Be $true -Because "there are one or more policies relying on deleted groups."
     }
+    It "MT.1049: Conditional Access policies for User Risk and Sign-in Risk should be configured separately. See https://maester.dev/docs/tests/MT.1049" -Tag "MT.1049" {
+        Test-MtCaMisconfiguredIDProtection | Should -Be $false -Because "there is one or more policy with common misconfiguration for ID Protection "
+    }
     Context "License utilization" -Tag "LicenseUtilization" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {
             $LicenseReport = Test-MtCaLicenseUtilization -License "P1"

--- a/website/docs/tests/maester/MT.1049.md
+++ b/website/docs/tests/maester/MT.1049.md
@@ -9,8 +9,11 @@ sidebar_class_name: hidden
 
 ## Description
 
-There are two types of risk policies in Microsoft Entra Conditional Access you can set up. You can use these policies to automate the response to risks allowing users to self-remediate when sign-in risk or user risk is detected.
-Sign-in risk and user risk should not be configured in a single policy, but instead be separated as Conditional Access policies will only be applied if ALL conditions match. 
+There are two types of risk policies in Microsoft Entra Conditional Access you can set up. You can use these policies to automate the response to risks allowing users to self-remediate when sign-in risk or user risk is detected. Sign-in risk and user risk should not be configured in a single policy, but instead be separated as Conditional Access policies will only be applied if ALL conditions match. 
+
+## Rationale
+
+If you configure both conditions in one policy, it will only block access if both types of risk are detected. This means if only one type of risk is present (like user risk only), the sign-in will be not be blocked or interrupted. This could lead to a security gap, as some risky actions might slip by.
 
 ## How to fix
 

--- a/website/docs/tests/maester/MT.1049.md
+++ b/website/docs/tests/maester/MT.1049.md
@@ -10,11 +10,11 @@ sidebar_class_name: hidden
 ## Description
 
 There are two types of risk policies in Microsoft Entra Conditional Access you can set up. You can use these policies to automate the response to risks allowing users to self-remediate when sign-in risk or user risk is detected.
-Sign-in risk and user risk should not be configured in a single policy, but instead be seperated as Conditional Access policies will only be applied if ALL conditions match. 
+Sign-in risk and user risk should not be configured in a single policy, but instead be separated as Conditional Access policies will only be applied if ALL conditions match. 
 
 ## How to fix
 
-Configure seperate Conditional Access policies for sign-in risk and user risk
+Configure separate Conditional Access policies for sign-in risk and user risk
 
 ## Learn more
   - [Microsoft Learn | Configure and enable risk policies](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies)

--- a/website/docs/tests/maester/MT.1049.md
+++ b/website/docs/tests/maester/MT.1049.md
@@ -1,0 +1,21 @@
+---
+title: MT.1049 - Sign-in risk and user risk conditions should be configured in separate Conditional Access policies
+description: Checks for common misconfigurations in Conditional Access: both user risk and sign-in risk are configured in one policy.
+slug: /tests/MT.1049
+sidebar_class_name: hidden
+---
+
+# Sign-in risk and user risk conditions should be configured in separate Conditional Access policies
+
+## Description
+
+There are two types of risk policies in Microsoft Entra Conditional Access you can set up. You can use these policies to automate the response to risks allowing users to self-remediate when sign-in risk or user risk is detected.
+Sign-in risk and user risk should not be configured in a single policy, but instead be seperated as Conditional Access policies will only be applied if ALL conditions match. 
+
+## How to fix
+
+Configure seperate Conditional Access policies for sign-in risk and user risk
+
+## Learn more
+  - [Microsoft Learn | Configure and enable risk policies](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies)
+  - [janbakker.tech | Conditional Access risk policies. Don’t get fooled!](https://janbakker.tech/conditional-access-risk-policies-dont-get-fooled/)


### PR DESCRIPTION
Add a new CA test: Checks for common misconfigurations in Conditional Access: both user risk and sign-in risk are configured in one policy.