### PR TITLE
Detect Duo Etc Custom Controls

### DIFF
--- a/powershell/public/Test-MtCaMfaForAllUsers.ps1
+++ b/powershell/public/Test-MtCaMfaForAllUsers.ps1
@@ -33,7 +33,8 @@ function Test-MtCaMfaForAllUsers {
     $result = $false
     foreach ($policy in $policies) {
         if ( ( $policy.grantcontrols.builtincontrols -contains 'mfa' `
-                    -or $policy.grantcontrols.authenticationStrength.requirementsSatisfied -contains 'mfa' ) `
+                    -or $policy.grantcontrols.authenticationStrength.requirementsSatisfied -contains 'mfa' 
+                    -or $policy.grantcontrols.customAuthenticationFactors -ne "" ) `
                 -and $policy.conditions.users.includeUsers -eq "All" `
                 -and $policy.conditions.applications.includeApplications -eq "All" `
         ) {


### PR DESCRIPTION
The check for all users are subject to MFA does not consider the nearly legacy "Custom Controls". If grantControls.customAuthenticationFactors is not "" then a custom control for external MFA is in place. This is typically the value "RequireDuoMfa" when it is used.