### PR TITLE
Add DNS server IP address parameter to Invoke-Maester

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
@@ -17,6 +17,9 @@ function Test-MtCisaDkim {
     [CmdletBinding()]
     [OutputType([bool])]
     param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress,
+
         # Selector-name for the DKIM record to test..
         [string]$Selector = "selector1"
     )
@@ -51,7 +54,7 @@ function Test-MtCisaDkim {
             $selector = $config.SelectorBeforeRotateOnDate
         }
 
-        $dkimRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -DkimSelector $Selector -Records DKIM
+        $dkimRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -DkimSelector $Selector -Records DKIM -DnsServerIpAddress $DnsServerIpAddress
         $dkimRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $dkimRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcAggregateCisa.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcAggregateCisa.ps1
@@ -22,6 +22,9 @@ function Test-MtCisaDmarcAggregateCisa {
     [CmdletBinding()]
     [OutputType([bool])]
     param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress,
+
         # Check all domains, not only .gov domains.
         [switch]$Force,
 
@@ -69,7 +72,7 @@ function Test-MtCisaDmarcAggregateCisa {
 
     $dmarcRecords = @()
     foreach($domain in $expandedDomains){
-        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domain -Records DMARC
+        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domain -Records DMARC -DnsServerIpAddress $DnsServerIpAddress
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordExist.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordExist.ps1
@@ -17,6 +17,9 @@ function Test-MtCisaDmarcRecordExist {
     [CmdletBinding()]
     [OutputType([bool])]
     param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress,
+
         # Check 2nd Level Domains Explicitly per CISA
         [switch]$Strict
     )
@@ -45,7 +48,7 @@ function Test-MtCisaDmarcRecordExist {
             $domainName = $domain.domainname
         }
 
-        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domainName -Records DMARC
+        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domainName -Records DMARC -DnsServerIpAddress $DnsServerIpAddress
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
@@ -17,6 +17,9 @@ function Test-MtCisaDmarcRecordReject {
     [CmdletBinding()]
     [OutputType([bool])]
     param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress,
+
         # Check 2nd Level Domains Explicitly per CISA
         [switch]$Strict
     )
@@ -50,7 +53,7 @@ function Test-MtCisaDmarcRecordReject {
 
     $dmarcRecords = @()
     foreach($domain in $expandedDomains){
-        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domain -Records DMARC
+        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domain -Records DMARC -DnsServerIpAddress $DnsServerIpAddress
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcReport.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcReport.ps1
@@ -20,6 +20,9 @@ function Test-MtCisaDmarcReport {
     [CmdletBinding()]
     [OutputType([bool])]
     param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress,
+
         # Check 2nd Level Domains Explicitly per CISA
         [switch]$Strict
     )
@@ -53,7 +56,7 @@ function Test-MtCisaDmarcReport {
 
     $dmarcRecords = @()
     foreach($expandedDomain in $expandedDomains){
-        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $expandedDomain -Records DMARC
+        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $expandedDomain -Records DMARC -DnsServerIpAddress $DnsServerIpAddress
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.ps1
@@ -16,7 +16,10 @@
 function Test-MtCisaSpfDirective {
     [CmdletBinding()]
     [OutputType([bool])]
-    param()
+    param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress
+    )
 
     if(!(Test-MtConnection ExchangeOnline)){
         Add-MtTestResultDetail -SkippedBecause NotConnectedExchange
@@ -30,7 +33,7 @@ function Test-MtCisaSpfDirective {
 
     $spfRecords = @()
     foreach($domain in $sendingDomains){
-        $spfRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -Records SPF
+        $spfRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -Records SPF -DnsServerIpAddress $DnsServerIpAddress
         $spfRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $spfRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfRestriction.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfRestriction.ps1
@@ -16,7 +16,10 @@
 function Test-MtCisaSpfRestriction {
     [CmdletBinding()]
     [OutputType([bool])]
-    param()
+    param(
+        # DNS-server to use for lookup.
+        [string]$DnsServerIpAddress
+    )
 
     if(!(Test-MtConnection ExchangeOnline)){
         Add-MtTestResultDetail -SkippedBecause NotConnectedExchange
@@ -32,7 +35,7 @@ function Test-MtCisaSpfRestriction {
 
     $spfRecords = @()
     foreach($domain in $acceptedDomains){
-        $spfRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -Records SPF
+        $spfRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -Records SPF -DnsServerIpAddress $DnsServerIpAddress
         $spfRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $spfRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 

--- a/tests/cisa/exchange/Test-MtCisaDkim.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDkim.Tests.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.3.1", "CISA", "Security", "All" {
     It "MS.EXO.03.1: DKIM SHOULD be enabled for all domains." {
-        $cisaDkim = Test-MtCisaDkim
+        $cisaDkim = Test-MtCisaDkim -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaDkim) {
             $cisaDkim | Should -Be $true -Because "DKIM record should exist and be configured."

--- a/tests/cisa/exchange/Test-MtCisaDmarcAggregateCisa.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcAggregateCisa.Tests.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.3", "CISA", "Security", "All" {
     It "MS.EXO.04.3: The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov." {
-        $cisaDmarcAggregateCisa = Test-MtCisaDmarcAggregateCisa
+        $cisaDmarcAggregateCisa = Test-MtCisaDmarcAggregateCisa -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaDmarcAggregateCisa) {
             $cisaDmarcAggregateCisa | Should -Be $true -Because "DMARC record includes proper aggregate target."

--- a/tests/cisa/exchange/Test-MtCisaDmarcRecordExist.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcRecordExist.Tests.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.1", "CISA", "Security", "All" {
     It "MS.EXO.04.1: A DMARC policy SHALL be published for every second-level domain." {
-        $cisaDmarcRecordExist = Test-MtCisaDmarcRecordExist
+        $cisaDmarcRecordExist = Test-MtCisaDmarcRecordExist -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaDmarcRecordExist) {
             $cisaDmarcRecordExist | Should -Be $true -Because "DMARC record should exist."

--- a/tests/cisa/exchange/Test-MtCisaDmarcRecordReject.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcRecordReject.Tests.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.2", "CISA", "Security", "All" {
     It "MS.EXO.04.2: The DMARC message rejection option SHALL be p=reject." {
-        $cisaDmarcRecordReject = Test-MtCisaDmarcRecordReject
+        $cisaDmarcRecordReject = Test-MtCisaDmarcRecordReject -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaDmarcRecordReject) {
             $cisaDmarcRecordReject | Should -Be $true -Because "DMARC record policy should be reject."

--- a/tests/cisa/exchange/Test-MtCisaDmarcReport.ps1
+++ b/tests/cisa/exchange/Test-MtCisaDmarcReport.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.4.4", "CISA", "Security", "All" {
     It "MS.EXO.04.4: An agency point of contact SHOULD be included for aggregate and failure reports." {
-        $cisaDmarcReport = Test-MtCisaDmarcReport
+        $cisaDmarcReport = Test-MtCisaDmarcReport -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaDmarcReport) {
             $cisaDmarcReport | Should -Be $true -Because "DMARC report targets should exist."

--- a/tests/cisa/exchange/Test-MtCisaSpfDirective.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaSpfDirective.Tests.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.2.2", "CISA", "Security", "All" {
     It "MS.EXO.02.2: An SPF policy SHALL be published for each domain, designating only these addresses as approved senders." {
-        $cisaSpfDirective = Test-MtCisaSpfDirective
+        $cisaSpfDirective = Test-MtCisaSpfDirective -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaSpfDirective) {
             $cisaSpfDirective | Should -Be $true -Because "SPF record should restrict authorized senders."

--- a/tests/cisa/exchange/Test-MtCisaSpfRestriction.Tests.ps1
+++ b/tests/cisa/exchange/Test-MtCisaSpfRestriction.Tests.ps1
@@ -1,6 +1,10 @@
+param(
+    [string]$DnsServerIpAddress
+)
+
 Describe "CISA SCuBA" -Tag "MS.EXO", "MS.EXO.2.1", "CISA", "Security", "All" {
     It "MS.EXO.02.1: A list of approved IP addresses for sending mail SHALL be maintained." {
-        $cisaSpfRestriction = Test-MtCisaSpfRestriction
+        $cisaSpfRestriction = Test-MtCisaSpfRestriction -DnsServerIpAddress $DnsServerIpAddress
 
         if ($null -ne $cisaSpfRestriction) {
             $cisaSpfRestriction | Should -Be $true -Because "SPF record should restrict authorized senders."


### PR DESCRIPTION
To allow the user to pass a custom DNS server IP address down to the underlying CISA Exchange tests, add a cmdlet parameter named DnsServerIpAddress to Invoke-Maester.  The default value remains `1.1.1.1`.

To enable passing custom data down to the tests, I began using the $PesterConfiguration.Run.Container property.  The container will now hold the Path to the tests as well as the custom Data object. The DnsServerIpAddress parameter will be passed to all tests, but the parameter will be silently ignored by any tests without that parameter defined.

Updates: #612