### PR TITLE
Test-MtCisaSpfDirective: skip coexistence domains

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.md
@@ -2,6 +2,9 @@ An SPF policy SHALL be published for each domain, designating only these address
 
 Rationale: An adversary may modify the `FROM` field of an email such that it appears to be a legitimate email sent by an agency, facilitating phishing attacks. Publishing an SPF policy for each agency domain mitigates forged `FROM` fields by providing a means for recipients to detect emails spoofed in this way. SPF is required for FCEB departments and agencies by Binding Operational Directive (BOD) 18-01, "Enhance Email and Web Security".
 
+Coexistence domains related to Hybrid Configuration Wizard (HCW) are skipped.
+Production use of coexistence domains is discouraged, and additional controls, such as transport rules, should be used to restrict their use.
+
 #### Remediation action:
 
 SPF is not configured through the Exchange admin center, but rather via DNS records hosted by the agency's domain. Thus, the exact steps needed to set up SPF varies from agency to agency. See [Add or edit an SPF TXT record to help prevent email spam (Outlook, Exchange Online) | Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide#add-or-edit-an-spf-txt-record-to-help-prevent-email-spam-outlook-exchange-online) for more details.

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.ps1
@@ -43,6 +43,9 @@ function Test-MtCisaSpfDirective {
         if(($directives|Measure-Object).Count -ge 1 -and $check){
             $spfRecord.pass = "Passed"
             $spfRecord.reason = "1+ mechanism targets"
+        }elseif($domain.IsCoexistenceDomain){
+            $spfRecord.pass = "Skipped"
+            $spfRecord.reason = "coexistence domain"
         }elseif(($directives|Measure-Object).Count -ge 1 -and -not $check){
             $spfRecord.reason = "No EXO directive"
         }elseif($spfRecord.spfRecord -like "*not available"){


### PR DESCRIPTION
Domains associated with Exchange Hybrid Configuration Wizard should be skipped.

Fixes: #686 