### PR TITLE
Changed Domain query to use API instead of cmdlet

### DIFF
--- a/powershell/public/cis/Test-MtCisPasswordExpiry.ps1
+++ b/powershell/public/cis/Test-MtCisPasswordExpiry.ps1
@@ -32,7 +32,7 @@ function Test-MtCisPasswordExpiry {
     }
 
     Write-Verbose "Get domain details the password expiry period"
-    $domains = Get-MgDomain
+    $domains = Invoke-MtGraphRequest -RelativeUri "domains"
 
     Write-Verbose "Get domains where passwords are set to expire"
     $result = $domains | Where-Object { $_.PasswordValidityPeriodInDays -ne "2147483647" }


### PR DESCRIPTION
Changed query of all domains to use the Graph API instead of the function that requires an additional cmdlet to be installed.