### PR TITLE
Tags must always be an array

### DIFF
--- a/powershell/internal/ConvertTo-MtMaesterResult.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResult.ps1
@@ -103,7 +103,7 @@ function ConvertTo-MtMaesterResult {
         $mtTestInfo = [PSCustomObject]@{
             Name            = $name
             HelpUrl         = $helpUrl
-            Tag             = ($test.Block.Tag + $test.Tag | Select-Object -Unique)
+            Tag             = @($test.Block.Tag + $test.Tag | Select-Object -Unique)
             Result          = $test.Result
             ScriptBlock     = $test.ScriptBlock.ToString()
             ScriptBlockFile = $test.ScriptBlock.File


### PR DESCRIPTION
Otherwise props.Item.Tag.map() in ResultInfoDialog.jsx will result in blank screen