### PR TITLE
Improve mt.1029-1032 tests

### DIFF
--- a/powershell/public/Test-MtPimAlertsExists.ps1
+++ b/powershell/public/Test-MtPimAlertsExists.ps1
@@ -72,18 +72,19 @@ function Test-MtPimAlertsExists {
     }
 
     # Create test result and details
+    $convertHtmlLinkToMD = '<a.*?href=["'']([^"'']*)["''][^>]*>([^<]*)<\/a>' # Regular expression to detect HTML links
     if ($Alert.Count -gt "0" -and $AffectedRoleAssignments.Count -gt 0) {
 
       $testDescription = "
 
 **Security Impact**`n`n
-$($Alert.securityImpact)
+$($Alert.securityImpact -replace $convertHtmlLinkToMD, '[$2]($1)')
 
 **Mitigation steps**`n`n
-$($Alert.mitigationSteps)
+$($Alert.mitigationSteps -replace $convertHtmlLinkToMD, '[$2]($1)')
 
 **How to prevent**`n`n
-$($Alert.howToPrevent)
+$($Alert.howToPrevent -replace $convertHtmlLinkToMD, '[$2]($1)')
 "
 
       $AffectedRoleAssignmentSummary = @()


### PR DESCRIPTION
Links in alerts were HTML formatted, which needed to be converted to Markdown format.

If alerts did not have additional data, the outcome was not as expected.