### PR TITLE
Update required version of Microsoft.Graph.Authentication module to 2.25.0

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -55,7 +55,7 @@ PowerShellVersion = '5.1'
    pre-installed with Windows. See <https://pester.dev/docs/introduction/installation/#windows>. Pester will be updated
    if necessary by Install-MaesterTests.
 #>
-RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.2.0'; }
+RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.25.0'; }
                      @{ModuleName = 'Pester'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71'; ModuleVersion = '0.0.0'; } )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
This pull request includes an update to the `powershell/Maester.psd1` file to ensure compatibility with the latest version of the Microsoft Graph Authentication module.

* Update the required `Microsoft.Graph.Authentication` module version from `2.2.0` to `2.25.0` in the `RequiredModules` section.

Resolves #618 and also pertinent to a [suggested workaround](https://github.com/maester365/maester/issues/651#issuecomment-2647137154) for #651.