### PR TITLE
Patch-issue-759

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ jobs:
         client_id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant_id: ${{ secrets.AZURE_TENANT_ID }}
         include_public_tests: true # Optional
+        include_exchange: false # Optional
         pester_verbosity: None # Optional - 'None', 'Normal', 'Detailed', 'Diagnostic'
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ inputs:
     type: boolean
     description: "Include Exchange Online tests in the test run."
     required: false
-    default: true
+    default: false
   include_teams:
     type: boolean
     description: "Include Teams tests in the test run."

--- a/website/docs/monitoring/github.md
+++ b/website/docs/monitoring/github.md
@@ -118,6 +118,7 @@ jobs:
         client_id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant_id: ${{ secrets.AZURE_TENANT_ID }}
         include_public_tests: true # Optional: Set to false if you are keeping to a certain version of tests or have your own tests
+        include_exchange: false    # Optional: Set to true to include the Exchange tests
         step_summary: true         # Optional: Set to false if you don't want a summary added to your GitHub Action run
         artifact_upload: true      # Optional: Set to false if you don't want summaries uploaded to GitHub Artifacts
         install_prerelease: false  # Optional: Set to true if you want to use Measter Preview Build when running tests


### PR DESCRIPTION
Change the include_exchange to be optional (like it is in the documentation) so the Github action does not fail.
#759