### PR TITLE
Update installation instructions to only use necessary Az sub-modules

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -32,7 +32,7 @@ Maester includes optional [CISA](tests/cisa/) tests that require additional perm
 ### Installing Azure and Exchange Online modules
 
 ```powershell
-Install-Module Az -Scope CurrentUser
+Install-Module Az.Accounts -Scope CurrentUser
 Install-Module ExchangeOnlineManagement -Scope CurrentUser
 ```
 


### PR DESCRIPTION
Update the installation guide users to only install the **Az.Accounts** module instead of all 104 Az sub-modules. 🏗️