### PR TITLE
Changes to enable a -Force flag to be supplied to Update-MaesterTests

### DIFF
--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -13,7 +13,11 @@ function Update-MtMaesterTests {
 
         # Defaults to update, used to show the correct message as 'installed' or 'updated'.
         [Parameter(Mandatory = $false)]
-        [switch] $Install
+        [switch] $Install,
+
+        # Switch to control the toggling off of the "Are you sure?" prompt
+        [Parameter(Mandatory = $false)]
+        [switch] $NoPrompt
     )
 
     $MaesterTestsPath = Get-MtMaesterTestFolderPath
@@ -45,9 +49,15 @@ function Update-MtMaesterTests {
         if ($itemsToDelete.Count -gt 0) {
             $message = "`nThe following items will be deleted when installing the latest Maester tests:`n"
             $itemsToDelete | ForEach-Object { $message += "  $($_.FullName)`n" }
-            $message += "Do you want to continue? (y/n): "
-            $continue = Get-MtConfirmation $message
-            if ($continue) {
+
+            # Display prompt unless NoPrompt has been explicitly set
+            if (!$NoPrompt) {
+                $message += "Do you want to continue? (y/n): "
+                $continue = Get-MtConfirmation $message
+            }
+
+            # Continue if either user has accepted prompt, or NoPrompt has been explicitly set
+            if ($continue -or $NoPrompt) {
                 foreach ($item in $itemsToDelete) {
                     if ($item.Attributes -ne "Directory") {
                         Remove-Item -Path $item.FullName -Force

--- a/powershell/internal/Update-MtMaesterTests.ps1
+++ b/powershell/internal/Update-MtMaesterTests.ps1
@@ -17,7 +17,7 @@ function Update-MtMaesterTests {
 
         # Switch to control the toggling off of the "Are you sure?" prompt
         [Parameter(Mandatory = $false)]
-        [switch] $NoPrompt
+        [switch] $Force
     )
 
     $MaesterTestsPath = Get-MtMaesterTestFolderPath
@@ -50,14 +50,14 @@ function Update-MtMaesterTests {
             $message = "`nThe following items will be deleted when installing the latest Maester tests:`n"
             $itemsToDelete | ForEach-Object { $message += "  $($_.FullName)`n" }
 
-            # Display prompt unless NoPrompt has been explicitly set
-            if (!$NoPrompt) {
+            # Display prompt unless Force has been explicitly set
+            if (!$Force) {
                 $message += "Do you want to continue? (y/n): "
                 $continue = Get-MtConfirmation $message
             }
 
-            # Continue if either user has accepted prompt, or NoPrompt has been explicitly set
-            if ($continue -or $NoPrompt) {
+            # Continue if either user has accepted prompt, or Force has been explicitly set
+            if ($continue -or $Force) {
                 foreach ($item in $itemsToDelete) {
                     if ($item.Attributes -ne "Directory") {
                         Remove-Item -Path $item.FullName -Force

--- a/powershell/public/core/Update-MaesterTests.ps1
+++ b/powershell/public/core/Update-MaesterTests.ps1
@@ -36,11 +36,11 @@ function Update-MaesterTests {
 
         # Switch to control the toggling off of the "Are you sure?" prompt
         [Parameter(Mandatory = $false)]
-        [switch] $NoPrompt
+        [switch] $Force
     )
     Write-Verbose 'Checking if newer version is availble.'
     Get-IsNewMaesterVersionAvailable | Out-Null
 
     Write-Verbose "Updating Maester tests in '$Path'."
-    Update-MtMaesterTests -Path $Path -NoPrompt:$NoPrompt
+    Update-MtMaesterTests -Path $Path -Force:$Force
 }

--- a/powershell/public/core/Update-MaesterTests.ps1
+++ b/powershell/public/core/Update-MaesterTests.ps1
@@ -32,11 +32,15 @@ function Update-MaesterTests {
     param(
         # The path to install or update Maester tests in. Defaults to the current directory.
         [Parameter(Mandatory = $false)]
-        [string] $Path = '.\'
+        [string] $Path = '.\',
+
+        # Switch to control the toggling off of the "Are you sure?" prompt
+        [Parameter(Mandatory = $false)]
+        [switch] $NoPrompt
     )
     Write-Verbose 'Checking if newer version is availble.'
     Get-IsNewMaesterVersionAvailable | Out-Null
 
     Write-Verbose "Updating Maester tests in '$Path'."
-    Update-MtMaesterTests -Path $Path
+    Update-MtMaesterTests -Path $Path -NoPrompt:$NoPrompt
 }


### PR DESCRIPTION
If `-Force` is passed to `Update-MaesterTests` then the "Do you want to continue?" prompt will not be displayed.
E.g. `Update-MaesterTests -Force`

fixes #787