### PR TITLE
#825 Fix Error with Invoke-Item on Invoke-Maester with Bitbucket pipeline

### DIFF
--- a/website/docs/monitoring/bitbucket.md
+++ b/website/docs/monitoring/bitbucket.md
@@ -130,6 +130,7 @@ pipelines:
                         OutputFolder         = "test-results"
                         OutputFolderFileName = "test-results"
                         PassThru             = $true
+                        NonInteractive       = $true
                       }
 
                       # Add DisableTelemetry parameter


### PR DESCRIPTION
**Reason**
see also https://github.com/maester365/maester/issues/825 for this
* `$NonInteractive` parameter not in template file for Bitbucket pipeline
* result pipeline tries to open html file in browser

**Solution**
* adding `$NonInteractive = $true` to bitbucket pipeline template file