### PR TITLE
MS.AAD2.2 to check notificationRecipients  and additionalRecipients

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaNotifyHighRisk.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaNotifyHighRisk.ps1
@@ -36,7 +36,7 @@ function Test-MtCisaNotifyHighRisk {
     #Connect-MgGraph -UseDeviceCode -Scopes IdentityRiskEvent.Read.All
     $result = Invoke-MtGraphRequest -RelativeUri "identityProtection/settings/notifications" -ApiVersion "beta"
 
-    $notficationRecipients = $result.notificationRecipients | Where-Object {`
+    $notficationRecipients =  ($result.notificationRecipients + $result.additionalRecipients) | Where-Object {`
             $_.isRiskyUsersAlertsRecipient }
 
     $testResult = ($notficationRecipients|Measure-Object).Count -ge 1


### PR DESCRIPTION
MS.AAD2.2 Test-MtCisaNotifyHighRisk.ps1 was only checking the `notificationRecipients` from `identityProtection/settings/notifications`. These only contain recipients based on Entra roles, not the additionally added recipients which are stored in `additionalRecipients`.

This change merges `$notficationRecipients = ($result.notificationRecipients + $result.additionalRecipients)` prior passing it to the filter to check if there is some for RiskUsersAlerts activated.