### PR TITLE
Added ability to set Severity and Service name in Tag

### DIFF
--- a/powershell/internal/Get-MtPesterTagValue.ps1
+++ b/powershell/internal/Get-MtPesterTagValue.ps1
@@ -1,0 +1,49 @@
+﻿<#
+.SYNOPSIS
+    Gets the value of a specific tag from the current Pester test.
+
+.DESCRIPTION
+    This function extracts tag values from the current Pester test context.
+    It looks for tags in the format 'TagName:Value' and returns the value part.
+    If no matching tag is found in the current test, it checks the parent block.
+
+.EXAMPLE
+    Get-MtPesterTagValue -TagName 'Severity'
+
+    Returns the severity value (e.g. 'Critical', 'High') if a tag like 'Severity:Critical' exists.
+
+.PARAMETER TagName
+    The name of the tag to look for (without the colon).
+
+#>
+function Get-MtPesterTagValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $TagName
+    )
+
+    # Check if we're running in a Pester context
+    if (-not $____Pester) {
+        Write-Verbose "Not running in a Pester context."
+        return $null
+    }
+
+    # Check if the test has the specified tag
+    $tagPattern = "$TagName`:"
+    $matchingTag = $____Pester.CurrentTest.Tag | Where-Object { $_ -match $tagPattern }
+
+    # If not found in current test, check parent block
+    if ([string]::IsNullOrEmpty($matchingTag)) {
+        $matchingTag = $____Pester.CurrentTest.Block.Tag | Where-Object { $_ -match $tagPattern }
+    }
+
+    if ($matchingTag) {
+        # Extract the tag value and trim it
+        $tagValue = $matchingTag -replace $tagPattern, ''
+        return $tagValue.Trim()
+    }
+
+    return $null
+}

--- a/powershell/public/Add-MtTestResultDetail.ps1
+++ b/powershell/public/Add-MtTestResultDetail.ps1
@@ -136,6 +136,14 @@ function Add-MtTestResultDetail {
         # If no test title is provided, use the test name
         $TestTitle = $____Pester.CurrentTest.ExpandedName
     }
+
+    if ([string]::IsNullOrEmpty($Severity)) {
+        # Check if the test has a severity tag using the internal helper function
+        $Severity = Get-MtPesterTagValue -TagName 'Severity'
+    }
+
+    $Service = Get-MtPesterTagValue -TagName 'Service'
+
     $testInfo = @{
         TestTitle       = $TestTitle
         TestDescription = $Description
@@ -143,6 +151,7 @@ function Add-MtTestResultDetail {
         TestSkipped     = $SkippedBecause
         SkippedReason   = $SkippedReason
         Severity        = $Severity
+        Service         = $Service
     }
 
     Write-MtProgress -Activity "Running tests" -Status $testName

--- a/tests/cis/Test-MtCis365PublicGroup.Tests.ps1
+++ b/tests/cis/Test-MtCis365PublicGroup.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "CIS" -Tag "CIS.M365.1.2.1", "L2", "CIS E3 Level 2", "CIS E3", "CIS", "Security", "All", "CIS M365 v4.0.0" {
-    It "CIS.M365.1.2.1: (L2) Ensure that only organizationally managed/approved public groups exist" {
+    It "CIS.M365.1.2.1: (L2) Ensure that only organizationally managed/approved public groups exist" -Tag "Severity:Medium" {
 
         $result = Test-MtCis365PublicGroup
 


### PR DESCRIPTION
This will allow structured metadata to be added to tests through the Tag property.

Initial release supports

- Severity:<severity> e.g. Severity:Medium
- Service:<service> e.g. Service:Entra or Service:Exchange