### PR TITLE
Merge potential fix for CIS 2.1.1

### DIFF
--- a/powershell/public/cis/Test-MtCisSafeLink.ps1
+++ b/powershell/public/cis/Test-MtCisSafeLink.ps1
@@ -33,10 +33,12 @@ function Test-MtCisSafeLink {
     }
 
     Write-Verbose "Getting Safe Links Policy..."
-    $policies = Get-MtExo -Request SafeLinksPolicy
 
-    # We grab the default policy as that is what CIS checks
-    $policy = $policies | Where-Object { $_.Name -eq 'Built-In Protection Policy' }
+    # Get the name of highest priority policy
+    $priority0Policy = Get-MtExo -Request SafeLinksRule | Where-Object { $_.Priority -eq "0" }
+
+    # Get policy highest priority policy
+    $policy = Get-MtExo -Request SafeLinksPolicy | Where-Object { $_.Name -eq $priority0Policy }
 
     $safeLinkCheckList = @()
 
@@ -112,10 +114,10 @@ function Test-MtCisSafeLink {
     $portalLink = "https://security.microsoft.com/presetSecurityPolicies"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenants default safe link policy matches CIS recommendations ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Safe link policy" + $priority0Policy.Name + " (Priority 0 policy) matches CIS recommendations ($portalLink).`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "Your tenants default safe link policy does not match CIS recommendations ($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Safe link policy" + $priority0Policy.Name + " (Priority 0 policy) does not match CIS recommendations ($portalLink).`n`n%TestResult%"
     }
 
 

--- a/powershell/public/core/Invoke-MtAzureRequest.ps1
+++ b/powershell/public/core/Invoke-MtAzureRequest.ps1
@@ -15,6 +15,7 @@
 #>
 
 function Invoke-MtAzureRequest {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingCmdletAliases', '', Justification = 'Invoke-MtAzureRequest is required')]
     [CmdletBinding()]
     param(
         # Graph endpoint such as "users".

--- a/tests/cis/Test-MtCisSafeLink.Tests.ps1
+++ b/tests/cis/Test-MtCisSafeLink.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "CIS" -Tag "CIS.M365.2.1.1", "L2", "CIS E5 Level 2", "CIS E5", "CIS", "Security", "All", "CIS M365 v4.0.0" {
-    It "CIS.M365.2.1.1: (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy)" {
+    It "CIS.M365.2.1.1: (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Priority 0 Policy)" {
 
         $result = Test-MtCisSafeLink
 
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "the default safe link policy matches CIS recommendations"
+            $result | Should -Be $true -Because "the priority 0 safe link policy matches CIS recommendations"
         }
     }
 }


### PR DESCRIPTION
Potential fix for issues described in https://github.com/maester365/maester/issues/859

This test now grabs policy 0 (as per CIS recommendations) and checks that policy, rather than the default policy which cannot be changed.