### PR TITLE
Add getting started welcome message during Import-Module

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -63,7 +63,7 @@ RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '88
 # RequiredAssemblies = @()
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
+ScriptsToProcess = @('Show-MaesterWelcome.ps1')
 
 # Type files (.ps1xml) to be loaded when importing this module
 # TypesToProcess = @()

--- a/powershell/Show-MaesterWelcome.ps1
+++ b/powershell/Show-MaesterWelcome.ps1
@@ -2,7 +2,13 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
 param ()
 
-Show-MtLogo
+try {
+    . "$PSScriptRoot/internal/Show-MtLogo.ps1" -ErrorAction Stop
+    Show-MtLogo
+} catch {
+    Write-Host "Importing Maester v$((Import-PowerShellDataFile -Path "$PSScriptRoot/../Maester.psd1" -ErrorAction SilentlyContinue).ModuleVersion)." -ForegroundColor Green
+}
+
 Write-Host "    To get started, install Maester tests and connect before running Maester:`n" -ForegroundColor Yellow
 Write-Host "`tmd 'Maester-Tests'           " -ForegroundColor Black -BackgroundColor Gray -NoNewline
 Write-Host ''

--- a/powershell/Show-MaesterWelcome.ps1
+++ b/powershell/Show-MaesterWelcome.ps1
@@ -1,0 +1,17 @@
+﻿[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
+param ()
+
+Show-MtLogo
+Write-Host "    To get started, install Maester tests and connect before running Maester:`n" -ForegroundColor Yellow
+Write-Host "`tmd 'Maester-Tests'           " -ForegroundColor Black -BackgroundColor Gray -NoNewline
+Write-Host ''
+Write-Host "`tcd 'Maester-Tests'           " -ForegroundColor Black -BackgroundColor Gray -NoNewline
+Write-Host ''
+Write-Host "`tInstall-MtTests              " -ForegroundColor Black -BackgroundColor Gray -NoNewline
+Write-Host ''
+Write-Host "`tConnect-Maester -Service All " -ForegroundColor Black -BackgroundColor Gray -NoNewline
+Write-Host ''
+Write-Host "`tInvoke-Maester               " -ForegroundColor Black -BackgroundColor Gray -NoNewline
+Write-Host ''
+Write-Host "`n    See https://maester.dev for more info.🔥`n" -ForegroundColor Yellow

--- a/powershell/internal/Show-MtLogo.ps1
+++ b/powershell/internal/Show-MtLogo.ps1
@@ -1,0 +1,21 @@
+﻿function Show-MtLogo {
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
+    [OutputType([string])]
+    param ()
+
+    $Version = (Import-PowerShellDataFile -Path "$PSScriptRoot/../Maester.psd1").ModuleVersion
+    # ASCII Art using style "ANSI Shadow"
+    $Logo = @"
+
+    ███╗   ███╗ █████╗ ███████╗███████╗████████╗███████╗██████╗
+    ████╗ ████║██╔══██╗██╔════╝██╔════╝╚══██╔══╝██╔════╝██╔══██╗
+    ██╔████╔██║███████║█████╗  ███████╗   ██║   █████╗  ██████╔╝
+    ██║╚██╔╝██║██╔══██║██╔══╝  ╚════██║   ██║   ██╔══╝  ██╔══██╗
+    ██║ ╚═╝ ██║██║  ██║███████╗███████║   ██║   ███████╗██║  ██║
+    ╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝   ╚═╝   ╚══════╝╚═╝  ╚═╝ v$Version
+
+"@
+
+    Write-Host $Logo -ForegroundColor Green
+}


### PR DESCRIPTION
This pull request adds a new "getting started" welcome message that runs whenever the Maester module is imported.

### Enhancements

* **Added a welcome script (`Show-MaesterWelcome.ps1`)**: Displays a colorful welcome message with step-by-step setup instructions for getting started with Maester. It also provides a link to the official documentation for more info.
* **Integrated the welcome script into the module manifest (`Maester.psd1`)**: Configured the `ScriptsToProcess` property to automatically run the `Show-MaesterWelcome.ps1` script when the module is imported.
* **Introduced a logo display function (`Show-MtLogo.ps1`)**: Displays an ASCII art logo with the current module version in green text. This function can also be used to replace the logo output within `Invoke-Maester.ps1`.

**NOTE:** `Show-MaesterWelcome.ps1` is not included in the `powershell/internal` or `powershell/public` folders because the PSM1 import steps make the welcome message appear a second time.