### PR TITLE
Suppress the welcome message if running in a non-interactive session.

### DIFF
--- a/powershell/Show-MaesterWelcome.ps1
+++ b/powershell/Show-MaesterWelcome.ps1
@@ -2,6 +2,13 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
 param ()
 
+$NonInteractive = if ( (-not [Environment]::UserInteractive) -or ([Environment]::GetCommandLineArgs() -match 'NonInteractive') -or ($env:GITHUB_ACTIONS -eq 'true') -or ($env:GITLAB_CI -eq 'true') ) { $true }
+
+if ($NonInteractive) {
+    Write-Verbose "Maester is running in non-interactive mode. Skipping welcome message."
+    return
+}
+
 try {
     . "$PSScriptRoot/internal/Show-MtLogo.ps1" -ErrorAction Stop
     Show-MtLogo


### PR DESCRIPTION
@svrooij raised a valid point in #907 that the welcome message should not be shown in GitHub actions or other non-interactive sessions.

This pull request introduces a change to `powershell/Show-MaesterWelcome.ps1` that skips the welcome message in non-interactive environments.

The `$NonInteractive` variable to detects non-interactive environments based the `UserInteractive` environment variable, the use of a `NonInteractive` command-line argument for PowerShell, or specific CI environment variables (`GITHUB_ACTIONS` or `GITLAB_CI`).