### PR TITLE
MT1057 App registrations should not have secrets defined

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -86,7 +86,7 @@ FunctionsToExport = 'Add-MtTestResultDetail', 'Clear-MtGraphCache', 'Connect-Mae
                'Get-MtSession',
                'Install-MaesterTests', 'Invoke-Maester', 'Invoke-MtGraphRequest',
                'Invoke-MtAzureRequest',
-               'Send-MtMail', 'Send-MtTeamsMessage', 'Test-MtAppManagementPolicyEnabled',
+               'Send-MtMail', 'Send-MtTeamsMessage', 'Test-MtAppRegistrationsWithSecrets', 'Test-MtAppManagementPolicyEnabled',
                'Test-MtCaAllAppsExists', 'Test-MtCaApplicationEnforcedRestriction',
                'Test-MtCaBlockLegacyExchangeActiveSyncAuthentication',
                'Test-MtCaBlockLegacyOtherAuthentication',

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.md
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.md
@@ -1,0 +1,9 @@
+This test checks if you have any app registrations that have secrets configured. Using secrets is discouraged! There are better ways available to authenticate your applications.
+
+#### Remediation action
+
+Open all app registrations below and remove the secrets.
+
+<!--- Results --->
+
+%TestResult%

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
@@ -15,12 +15,10 @@
 #>
 function Test-MtAppRegistrationsWithSecrets {
     [CmdletBinding()]
-    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'This test checks multiple permissions.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'This test checks credentials for all apps.')]
     [OutputType([bool])]
     param(
-        # # Check for direct path to Global Admin or indirect path through a combination of permissions. Default is "All".
-        # [ValidateSet('All', 'Direct', 'Indirect')]
-        # [String] $AttackPath = "All"
+
     )
 
     if (-not (Test-MtConnection Graph)) {

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Check if any service principals are still using secrets instead of certificates or managed identities.
+
+.DESCRIPTION
+    It is adviced to use certificates or managed identities instead of secrets for service principals. This test checks if any service principals are still using secrets.
+
+.EXAMPLE
+    Test-MtAppRegistrationsWithSecrets
+
+    Returns true if no service principals are using secrets, otherwise returns false.
+
+.LINK
+    https://maester.dev/docs/commands/Test-MtAppRegistrationsWithSecrets
+#>
+function Test-MtAppRegistrationsWithSecrets {
+    [CmdletBinding()]
+    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'This test checks multiple permissions.')]
+    [OutputType([bool])]
+    param(
+        # # Check for direct path to Global Admin or indirect path through a combination of permissions. Default is "All".
+        # [ValidateSet('All', 'Direct', 'Indirect')]
+        # [String] $AttackPath = "All"
+    )
+
+    if (-not (Test-MtConnection Graph)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
+        return $null
+    }
+    try {
+        $apps = Invoke-MtGraphRequest -RelativeUri '/applications?$select=id,displayName,appId,passwordCredentials' -ErrorAction Stop | Where-Object { $_.passwordCredentials.Count -gt 0 } | Select-Object -Property id, displayName, passwordCredentials, appId
+        $return = $apps.Count -eq 0
+
+        if ($return) {
+            $testResultMarkdown = "Well done. No app registrations using secrets."
+        } else {
+            $testResultMarkdown = "You have $($apps.Count) app registrations that still use secrets.`n`n%TestResult%"
+
+            $result = "| ApplicationName | ApplicationId |`n"
+            $result += "| --- | --- |`n"
+            foreach ($app in $apps) {
+                $appMdLink = "[$($app.displayName)](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/$($app.appId)/isMSAApp~/false)"
+                $result += "| $($appMdLink) | $($app.appId) |`n"
+            }
+            $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+        }
+        Add-MtTestResultDetail -Result $testResultMarkdown
+    } catch {
+        $return = $false
+        Write-Error $_.Exception.Message
+    }
+    return $return
+}

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
@@ -26,7 +26,7 @@ function Test-MtAppRegistrationsWithSecrets {
         return $null
     }
     try {
-        $apps = Invoke-MtGraphRequest -RelativeUri '/applications?$select=id,displayName,appId,passwordCredentials' -ErrorAction Stop | Where-Object { $_.passwordCredentials.Count -gt 0 } | Select-Object -Property id, displayName, passwordCredentials, appId
+        $apps = Invoke-MtGraphRequest -RelativeUri 'applications?$select=id,displayName,appId,passwordCredentials' -ErrorAction Stop | Where-Object { $_.passwordCredentials.Count -gt 0 } | Select-Object -Property id, displayName, passwordCredentials, appId
         $return = $apps.Count -eq 0
 
         if ($return) {

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
@@ -34,11 +34,15 @@ function Test-MtAppRegistrationsWithSecrets {
         } else {
             $testResultMarkdown = "You have $($apps.Count) app registrations that still use secrets.`n`n%TestResult%"
 
+            Write-Verbose "Found $($apps.Count) app registrations using secrets."
+            Write-Verbose "Creating markdown table for app registrations using secrets."
+
             $result = "| ApplicationName | ApplicationId |`n"
             $result += "| --- | --- |`n"
             foreach ($app in $apps) {
                 $appMdLink = "[$($app.displayName)](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/$($app.appId)/isMSAApp~/false)"
                 $result += "| $($appMdLink) | $($app.appId) |`n"
+                Write-Verbose "Adding app registration $($app.displayName) with id $($app.appId) to markdown table."
             }
             $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
         }

--- a/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
+++ b/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Maester/Entra" -Tag "Maester", "App", "Security", "All" {
+Describe "Maester/Entra" -Tag "Maester", "App", "Security", "Full", "Entra", "Graph" {
     It "MT.1057: App registrations should no longer use secrets. See https://maester.dev/docs/tests/MT.1057" -Tag "MT.1057" {
 
         Test-MtAppRegistrationsWithSecrets | Should -Be $true -Because "app registrations should not use secrets and instead use workload identities or certificate-based authentication"

--- a/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
+++ b/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
@@ -1,0 +1,6 @@
+Describe "Maester/Entra" -Tag "Maester", "App", "Security", "All" {
+    It "MT.1057: App registrations should no longer use secrets. See https://maester.dev/docs/tests/MT.1057" -Tag "MT.1057" {
+
+        Test-MtAppRegistrationsWithSecrets | Should -Be $true -Because "app registrations should not use secrets and instead use workload identities or certificate-based authentication"
+    }
+}

--- a/website/docs/tests/maester/MT.1057.md
+++ b/website/docs/tests/maester/MT.1057.md
@@ -1,0 +1,20 @@
+---
+title: MT.1057 - App registrations should no longer use secrets
+description: You should move to other more secure ways to authenticate your applications
+slug: /tests/MT.1057
+sidebar_class_name: hidden
+---
+
+# App registrations should no longer use secrets
+
+## Description
+
+Use [federated credentials](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp) or [certificates](https://docs.azure.cn/en-us/entra/identity-platform/howto-create-self-signed-certificate) instead of secrets. Secrets are considered unsafe.
+
+## How to fix
+
+
+
+## Learn more
+
+


### PR DESCRIPTION
This pr needs to be squashed as we don’t want 4 commits just to add a single test