### PR TITLE
🧹 Cleanup Invoke-Maester.ps1

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -65,15 +65,15 @@ Invoke-Maester -Verbosity Normal
 Shows results of tests as they are run including details on failed tests.
 
 .EXAMPLE
-```
+```powershell
 $configuration = New-PesterConfiguration
 $configuration.Run.Path = './tests/Maester'
 $configuration.Filter.Tag = 'CA'
 $configuration.Filter.ExcludeTag = 'App'
 
 Invoke-Maester -PesterConfiguration $configuration
-
 ```
+
 Runs all the Pester tests in the EIDSCA folder.
 
 .LINK
@@ -162,7 +162,7 @@ function Invoke-Maester {
         # Disable Telemetry
         # If set, telemetry information will not be logged.
         [switch] $DisableTelemetry,
-`
+
         # Skip the version check.
         # If set, the version check will not be performed.
         [switch] $SkipVersionCheck,


### PR DESCRIPTION
### Code formatting improvements:

* Updated the code block in the `.EXAMPLE` section to specify the `powershell` language for syntax highlighting. (`[powershell/public/Invoke-Maester.ps1L68-R76](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL68-R76)`)

### Minor fixes:

* Removed an extraneous backtick (`) in the parameter declaration of the `Invoke-Maester` function. (`[powershell/public/Invoke-Maester.ps1L165-R165](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL165-R165)`)