### PR TITLE
Exchange Online: Application access policies for applications with specific permissions

### DIFF
--- a/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
+++ b/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
@@ -76,7 +76,7 @@ Microsoft Graph permissions that should be secured by application access policie
 See https://learn.microsoft.com/graph/auth-limit-mailbox-access
 "@
 
-        Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown -Severity 'High'
+        Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown -Severity 'Medium'
 
         # Test should fail if any apps are missing policies
         $missingPolicies = $principalsWithExchangePerms | Where-Object { $appAccessPolicies.AppId -notcontains $_.AppId }

--- a/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
+++ b/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Maester/Exchange" -Tag "Maester", "Exchange", "Security", "MT.1058" {
+Describe "Maester/Exchange" -Tag "Maester", "Exchange", "MT.1058" {
     BeforeAll {
         # Skip all tests if Exchange Online or Graph is not connected
         if (-not (Test-MtConnection ExchangeOnline)) {
@@ -79,7 +79,7 @@ Best practices:
 Learn more: https://learn.microsoft.com/graph/auth-limit-mailbox-access
 "@
 
-        Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown
+        Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown -Severity 'High'
 
         # Test should fail if any apps are missing policies
         $missingPolicies = $principalsWithExchangePerms | Where-Object { $appAccessPolicies.AppId -notcontains $_.AppId }

--- a/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
+++ b/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
@@ -12,15 +12,10 @@ Describe "Maester/Exchange" -Tag "Maester", "Exchange", "Security", "MT.1060" {
     It "MT.1060: Ensure Exchange Application Access Policy is configured" -Tag "MT.1060", "ApplicationAccess" {
         # Define Exchange permissions that require app access policies (from Microsoft docs)
         $exchangePermissions = @(
-            # Mail permissions
-            "Mail.Read", "Mail.ReadBasic", "Mail.ReadBasic.All", "Mail.ReadWrite",
-            "Mail.Send", "Mail.Read.All", "Mail.ReadWrite.All", "Mail.Send.All",
-            # MailboxSettings permissions
+            "Mail.Read", "Mail.ReadBasic", "Mail.ReadBasic.All", "Mail.ReadWrite", "Mail.Send",
             "MailboxSettings.Read", "MailboxSettings.ReadWrite",
-            # Calendar permissions
-            "Calendars.Read", "Calendars.ReadWrite", "Calendars.Read.All", "Calendars.ReadWrite.All",
-            # Contacts permissions
-            "Contacts.Read", "Contacts.ReadWrite", "Contacts.Read.All", "Contacts.ReadWrite.All"
+            "Calendars.Read", "Calendars.ReadWrite",
+            "Contacts.Read", "Contacts.ReadWrite"
         )
 
         # Get service principals with Exchange permissions

--- a/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
+++ b/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Maester/Exchange" -Tag "Maester", "Exchange", "MT.1058" {
         }
     }
 
-    It "MT.1060: Ensure Exchange Application Access Policy is configured" -Tag "MT.1060", "ApplicationAccess" {
+    It "MT.1058: Ensure Exchange Application Access Policy is configured" -Tag "MT.1058", "ApplicationAccess" {
         # Define Exchange permissions that require app access policies (from Microsoft docs)
         $exchangePermissions = @(
             "Mail.Read", "Mail.ReadBasic", "Mail.ReadBasic.All", "Mail.ReadWrite", "Mail.Send",
@@ -52,7 +52,8 @@ Describe "Maester/Exchange" -Tag "Maester", "Exchange", "MT.1058" {
         foreach ($app in $principalsWithExchangePerms) {
             $hasPolicy = $appAccessPolicies.AppId -contains $app.AppId
             $policyStatus = if ($hasPolicy) { "✅ Yes" } else { "❌ No" }
-            $testResultMarkdown += "| $($app.Name) | $($app.AppId) | $($app.Permissions) | $policyStatus |`n"
+            $filteredPermissions = $app.Permissions -split ', ' | Where-Object { $_ -in $exchangePermissions }
+            $testResultMarkdown += "| $($app.Name) | $($app.AppId) | $($filteredPermissions -join ', ') | $policyStatus |`n"
         }
 
         $testDetailsMarkdown = @"
@@ -72,11 +73,7 @@ Microsoft Graph permissions that should be secured by application access policie
 - Contacts.Read
 - Contacts.ReadWrite
 
-Best practices:
-- Create policies to restrict application access to only required mailboxes
-- Ensure every application with Exchange permissions has an access policy
-
-Learn more: https://learn.microsoft.com/graph/auth-limit-mailbox-access
+See https://learn.microsoft.com/graph/auth-limit-mailbox-access
 "@
 
         Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown -Severity 'High'

--- a/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
+++ b/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Maester/Exchange" -Tag "Maester", "Exchange", "Security", "MT.1060" {
+Describe "Maester/Exchange" -Tag "Maester", "Exchange", "Security", "MT.1058" {
     BeforeAll {
         # Skip all tests if Exchange Online or Graph is not connected
         if (-not (Test-MtConnection ExchangeOnline)) {

--- a/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
+++ b/tests/Maester/Exchange/Test-ExchangeApplicationAccessPolicy.Tests.ps1
@@ -1,0 +1,93 @@
+Describe "Maester/Exchange" -Tag "Maester", "Exchange", "Security", "MT.1060" {
+    BeforeAll {
+        # Skip all tests if Exchange Online or Graph is not connected
+        if (-not (Test-MtConnection ExchangeOnline)) {
+            Set-ItResult -Skipped -Because "Exchange Online is not connected"
+        }
+        if (-not (Test-MtConnection Graph)) {
+            Set-ItResult -Skipped -Because "Graph API is not connected"
+        }
+    }
+
+    It "MT.1060: Ensure Exchange Application Access Policy is configured" -Tag "MT.1060", "ApplicationAccess" {
+        # Define Exchange permissions that require app access policies (from Microsoft docs)
+        $exchangePermissions = @(
+            # Mail permissions
+            "Mail.Read", "Mail.ReadBasic", "Mail.ReadBasic.All", "Mail.ReadWrite",
+            "Mail.Send", "Mail.Read.All", "Mail.ReadWrite.All", "Mail.Send.All",
+            # MailboxSettings permissions
+            "MailboxSettings.Read", "MailboxSettings.ReadWrite",
+            # Calendar permissions
+            "Calendars.Read", "Calendars.ReadWrite", "Calendars.Read.All", "Calendars.ReadWrite.All",
+            # Contacts permissions
+            "Contacts.Read", "Contacts.ReadWrite", "Contacts.Read.All", "Contacts.ReadWrite.All"
+        )
+
+        # Get service principals with Exchange permissions
+        $msGraph = Invoke-MtGraphRequest -RelativeUri "servicePrincipals" -Filter "appId eq '00000003-0000-0000-c000-000000000000'"
+        $availablePermissions = $msGraph.AppRoles | Select-Object Id, Value
+
+        $servicePrincipals = Invoke-MtGraphRequest -RelativeUri "servicePrincipals"
+        $principalsWithExchangePerms = $servicePrincipals | ForEach-Object {
+            $sp = $_
+            $appRoles = Invoke-MtGraphRequest -RelativeUri "servicePrincipals/$($sp.Id)/appRoleAssignments"
+            $permissions = $appRoles.AppRoleId | ForEach-Object {
+                $roleId = $_
+                ($availablePermissions | Where-Object { $_.Id -eq $roleId }).Value
+            }
+
+            if ($permissions | Where-Object { $_ -in $exchangePermissions }) {
+                [PSCustomObject]@{
+                    Name = $sp.DisplayName
+                    AppId = $sp.AppId
+                    Permissions = $permissions -join ", "
+                }
+            }
+        }
+
+
+        # Get application access policies
+        $appAccessPolicies = Get-ApplicationAccessPolicy
+
+        # Prepare result table showing all apps with Exchange permissions
+        $testResultMarkdown = "### Applications with Exchange Permissions`n`n"
+        $testResultMarkdown += "| Application Name | AppId | Permissions | Has Access Policy |`n"
+        $testResultMarkdown += "| --- | --- | --- | --- |`n"
+
+        foreach ($app in $principalsWithExchangePerms) {
+            $hasPolicy = $appAccessPolicies.AppId -contains $app.AppId
+            $policyStatus = if ($hasPolicy) { "✅ Yes" } else { "❌ No" }
+            $testResultMarkdown += "| $($app.Name) | $($app.AppId) | $($app.Permissions) | $policyStatus |`n"
+        }
+
+        $testDetailsMarkdown = @"
+Application access policies in Exchange Online help you control which applications can access which mailboxes.
+Without these policies, applications with Exchange permissions can access all mailboxes in your organization.
+
+Microsoft Graph permissions that should be secured by application access policies:
+- Mail.Read
+- Mail.ReadBasic
+- Mail.ReadBasic.All
+- Mail.ReadWrite
+- Mail.Send
+- MailboxSettings.Read
+- MailboxSettings.ReadWrite
+- Calendars.Read
+- Calendars.ReadWrite
+- Contacts.Read
+- Contacts.ReadWrite
+
+Best practices:
+- Create policies to restrict application access to only required mailboxes
+- Ensure every application with Exchange permissions has an access policy
+
+Learn more: https://learn.microsoft.com/graph/auth-limit-mailbox-access
+"@
+
+        Add-MtTestResultDetail -Description $testDetailsMarkdown -Result $testResultMarkdown
+
+        # Test should fail if any apps are missing policies
+        $missingPolicies = $principalsWithExchangePerms | Where-Object { $appAccessPolicies.AppId -notcontains $_.AppId }
+        $missingPolicies.Count | Should -Be 0 -Because "all applications with Exchange permissions should have an access policy configured"
+    }
+}

--- a/website/docs/tests/maester/MT.1058.md
+++ b/website/docs/tests/maester/MT.1058.md
@@ -1,0 +1,92 @@
+---
+title: MT.1058 - Exchange Application Access Policies must be configured
+description: Checks if applications with Exchange permissions have application access policies configured
+slug: /tests/MT.1058
+sidebar_class_name: hidden
+---
+
+# Exchange Application Access Policies must be configured
+
+## Description
+
+Applications that use Microsoft Graph API permissions for Exchange Online (Mail, Calendar, Contacts) can access all mailboxes in your organization by default. This presents a significant security risk as a compromised application could access sensitive data across all mailboxes.
+
+Application access policies help mitigate this risk by:
+- Restricting which mailboxes an application can access
+- Limiting the scope of potential data breaches
+- Enforcing the principle of least privilege
+
+The following Microsoft Graph permissions require application access policies:
+
+**Mail Access:**
+- Mail.Read
+- Mail.ReadBasic
+- Mail.ReadBasic.All
+- Mail.ReadWrite
+- Mail.Send
+
+**Mailbox Settings:**
+- MailboxSettings.Read
+- MailboxSettings.ReadWrite
+
+**Calendar Access:**
+- Calendars.Read
+- Calendars.ReadWrite
+
+**Contacts Access:**
+- Contacts.Read
+- Contacts.ReadWrite
+
+
+
+
+## How to fix
+
+1. Connect to Exchange Online:
+```powershell
+Connect-ExchangeOnline
+```
+
+2. Define variables for your application:
+```powershell
+# Get these values from your Application Registration
+$AppID = "<your-app-id>"  # e.g. "0a3ad682-b031-416d-86c2-bf263f8b46a3"
+$GroupName = "AAP_$AppID"  # example naming convention for clarity
+$Description = "Restrict this app to members of distribution group"
+```
+
+3. Create a mail-enabled security group for policy scope:
+```powershell
+# Create group and hide from address list
+$DGroup = New-DistributionGroup -Name $GroupName -Type Security
+Start-Sleep -Seconds 5  # Wait for group creation to propagate
+Set-DistributionGroup -Identity $DGroup.WindowsEmailAddress -HiddenFromAddressListsEnabled $true
+```
+
+4. Create the application access policy:
+```powershell
+New-ApplicationAccessPolicy -AppId $AppID `
+                          -PolicyScopeGroupId $DGroup.WindowsEmailAddress `
+                          -AccessRight RestrictAccess `
+                          -Description $Description
+```
+
+5. Add members to the security group:
+```powershell
+Add-DistributionGroupMember -Identity $GroupName -Member user@contoso.com
+```
+
+6. Verify the policy:
+```powershell
+# List all policies
+Get-ApplicationAccessPolicy
+
+# Test for specific user
+Test-ApplicationAccessPolicy -Identity user@contoso.com -AppId $AppID
+```
+
+## Learn more
+
+* [Control application access to Exchange Online mailboxes](https://learn.microsoft.com/graph/auth-limit-mailbox-access)
+* [New-ApplicationAccessPolicy](https://learn.microsoft.com/powershell/module/exchange/new-applicationaccesspolicy)
+* [Test-ApplicationAccessPolicy](https://learn.microsoft.com/powershell/module/exchange/test-applicationaccesspolicy)

--- a/website/docs/tests/maester/MT.1058.md
+++ b/website/docs/tests/maester/MT.1058.md
@@ -1,11 +1,11 @@
 ---
-title: MT.1058 - Exchange Application Access Policies must be configured
+title: MT.1058 - Exchange Application Access Policies should be configured
 description: Checks if applications with Exchange permissions have application access policies configured
 slug: /tests/MT.1058
 sidebar_class_name: hidden
 ---
 
-# Exchange Application Access Policies must be configured
+# Exchange Application Access Policies should be configured
 
 ## Description
 
@@ -37,8 +37,7 @@ The following Microsoft Graph permissions require application access policies:
 - Contacts.Read
 - Contacts.ReadWrite
 
-
-
+**Note: Only the listed permissions are restricted by the application access policy.**
 
 ## How to fix
 


### PR DESCRIPTION
Exchange Online: 
Added a test to check if there a applications/service principals that are not limited by exchange online application access polcies

More Information see here:
https://learn.microsoft.com/graph/auth-limit-mailbox-access

Doku:
website\docs\tests\maester\MT.1058.md

Test:
tests\Maester\Exchange\Test-ExchangeApplicationAccessPolicy.Tests.ps1
