### PR TITLE
fix: store tenantValue variable as integer for proper test outcome with comparison operator

### DIFF
--- a/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.ps1
@@ -27,7 +27,7 @@ function Test-MtEidscaPR05 {
     }
     $result = Invoke-MtGraphRequest -RelativeUri "settings" -ApiVersion beta
 
-    [string]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value
+    [int]$tenantValue = $result.values | where-object name -eq 'LockoutDurationInSeconds' | select-object -expand value
     $testResult = $tenantValue -ge '60'
     $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and '60' -notlike '*$null*'
 


### PR DESCRIPTION
The [`Test-MtEidscaPR05.ps1`](https://github.com/maester365/maester/blob/main/powershell/internal/eidsca/Test-MtEidscaPR05.ps1) is storing the Password `LockoutDurationInSeconds` value as a string.

This resulted in incorrect test results as the tenant value was tested with the greaterThanOrEqual (`-ge`) comparison operator as a string instead of numeric value.

For example, in my tenant I had a `LockoutDurationInSeconds` value of `300`

When comparing this with the current Maester function module 1.1.0, I get the following results

> Test result ❗ 
>
> Your tenant is configured as 300.
>
> The recommended value is greater than or equal to '60' for settings

This is because in string comparison a value that starts with a 3 will always be lower than 6, so 300 is lower than 60 in a string comparison.

Results with on my tenant with the old function

```powershell
> (Test-MtEidscaPR05) -ge 60
False
```

With the modified function

```powershell
> (Test-MtEidscaPR05) -ge 60
True
```

## Environment

Tested module version: Maester 1.1.0
