### PR TITLE
Fix GitHub Actions example: add id-token permission for Azure OIDC login

### DIFF
--- a/website/docs/monitoring/github.md
+++ b/website/docs/monitoring/github.md
@@ -94,6 +94,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Run Maester 🔥


### PR DESCRIPTION
This update adds the `permissions` block to the GitHub Actions example so Azure OIDC login works as expected.

Without `id-token: write`, the workflow doesn’t have permission to generate an OIDC token—so when the Azure login step runs, it just fails because the token isn’t available. I ran into this when setting up Maester in my own repo, and once I added the permissions, everything worked as expected.

This change brings the example in line with GitHub’s current defaults and saves folks from running into that error right out of the gate.

Reference:
- https://github.com/Azure/login#configure-a-workload-identity-federation
