### PR TITLE
handle multiple CAP covering LegacyAuth

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.ps1
@@ -31,12 +31,22 @@ function Test-MtCisaBlockLegacyAuth {
 
     $result = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq "enabled" }
 
-    $blockPolicies = $result | Where-Object {`
-            $_.grantControls.builtInControls -contains "block" -and `
-            $_.conditions.clientAppTypes -contains "exchangeActiveSync" -and `
-            $_.conditions.clientAppTypes -contains "other" -and `
-            $_.conditions.users.includeUsers -contains "All" }
+    $blockOther = $result | Where-Object {
+        $_.grantControls.builtInControls -contains "block" -and `
+        $_.conditions.clientAppTypes -contains "other" -and `
+        $_.conditions.users.includeUsers -contains "All"
+    }
 
+    $blockExchangeActiveSync = $result | Where-Object {
+        $_.grantControls.builtInControls -contains "block" -and `
+        $_.conditions.clientAppTypes -contains "exchangeActiveSync" -and `
+        $_.conditions.users.includeUsers -contains "All"
+    }
+
+    if (($blockOther | Measure-Object).Count -ge 1 -and ($blockExchangeActiveSync | Measure-Object).Count -ge 1) {
+        $blockPolicies = @($blockOther) + @($blockExchangeActiveSync)  | Sort-Object id -Unique
+    }
+    
     $testResult = ($blockPolicies|Measure-Object).Count -ge 1
 
     if ($testResult) {


### PR DESCRIPTION
The current Where-Object expects that both AppTypes ("other" and "exchangeActiveSync") are set in the same Conditional Access Policy (CAP). With the new logic, it will also handle situations where the AppTypes are split across more than one CAP.