### PR TITLE
Update azure-devops.md - Get-AzAccessToken is now a secure string

### DIFF
--- a/website/docs/monitoring/azure-devops.md
+++ b/website/docs/monitoring/azure-devops.md
@@ -137,7 +137,7 @@ steps:
       ScriptType: InlineScript
       Inline: |
         # Connect to Microsoft Graph
-        $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token | ConvertTo-SecureString -AsPlainText -Force
+        $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token
         Connect-MgGraph $accessToken
 
         # Install Maester
@@ -227,7 +227,7 @@ jobs:
             import-module /usr/share/microsoft.graph_2.19.0/Microsoft.Graph.Authentication
 
             # Connect to Microsoft Graph
-            $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token | ConvertTo-SecureString -AsPlainText -Force
+            $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token
             Connect-MgGraph $accessToken
 
             # Install Maester
@@ -394,7 +394,7 @@ jobs:
             import-module /usr/share/microsoft.graph_2.19.0/Microsoft.Graph.Authentication
 
             # Connect to Microsoft Graph
-            $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token | ConvertTo-SecureString -AsPlainText -Force
+            $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token
             Connect-MgGraph $accessToken
 
             # Install Maester


### PR DESCRIPTION
Get-AzAccessToken now returns as a Securestring, not secure string so no need to convert - see https://learn.microsoft.com/en-us/powershell/module/az.accounts/get-azaccesstoken?view=azps-14.0.0