### PR TITLE
Avoid dependency DLL version conflicts automatically

### DIFF
--- a/powershell/internal/Get-ModuleImportOrder.ps1
+++ b/powershell/internal/Get-ModuleImportOrder.ps1
@@ -224,5 +224,3 @@ function Get-ModuleImportOrder {
     } # end begin block
 
 } # end function
-
-Get-ModuleImportOrder

--- a/powershell/internal/Get-ModuleImportOrder.ps1
+++ b/powershell/internal/Get-ModuleImportOrder.ps1
@@ -1,0 +1,228 @@
+function Get-ModuleImportOrder {
+    <#
+    .SYNOPSIS
+    Evaluates the import order of specified modules based on their versions and the location in PSModulePath.
+
+    .DESCRIPTION
+    This function evaluates the import order of specified modules based on their versions and the location in PSModulePath.
+    It uses Get-ModuleImportCandidate to determine which version of each module would be imported by Import-Module,
+    and then sorts them by the version of 'Microsoft.Identity.Client.dll' that is packaged with each module.
+
+    .PARAMETER Name
+    A list of module names to evaluate for proper import order. Wildcards are allowed.
+
+    .EXAMPLE
+    Get-ModuleImportOrder -Name 'Az.Accounts','ExchangeOnlineManagement'
+
+    Returns a list of modules ordered by the version of 'Microsoft.Identity.Client.dll' they contain.
+
+    #>
+    [CmdletBinding()]
+    param(
+        # A list of module names to evaluate for proper import order.
+        [Parameter(
+            Position = 0,
+            ValueFromPipelineByPropertyName,
+            HelpMessage = 'Enter a list of names to evaluate. Wildcards are allowed.'
+        )]
+        [string[]]$Name = @(
+            'Az.Accounts',
+            'ExchangeOnlineManagement',
+            'Microsoft.Graph.Authentication',
+            'MicrosoftTeams'
+        )
+    )
+
+    process {
+        $ModulesWithVersionSortedIdentityClient = Get-ModulesWithVersionSortedIdentityClient -Name $Name
+        $ModulesWithVersionSortedIdentityClient
+    } # end process block
+
+    begin {
+
+        #region EmbeddedFunctions
+        function Get-ModuleImportCandidate {
+            <#
+            .SYNOPSIS
+            Returns module information for the specific instance of a module that Import-Module would load.
+
+            .DESCRIPTION
+            Get-ModuleImportCandidate is a cross-platform function that reliably determines which module version would be
+            selected by Import-Module when multiple versions of the same module are available in multiple installation scopes.
+
+            When importing modules, PSModulePath is the primary factor in determining which module version is loaded,
+            and the order of the paths in PSModulePath is important. The CurrentUser paths generally appear first in PSModulePath,
+            followed by the AllUsers scope paths. The function takes into account the following rules:
+
+            Location takes precedence over version:
+            - A lower version in a higher-priority location will be loaded before a higher version in a lower-priority location.
+            - Within a location, higher versions are loaded first.
+
+            .PARAMETER Name
+            The name of the module[s] to check. This can be a single module name or an array of module names.
+
+            .EXAMPLE
+            Get-ModuleImportCandidate -Name 'Az.Accounts'
+
+            Returns a PSModuleInfo object for the version of the 'Az.Accounts' module that would be imported by Import-Module.
+
+            .EXAMPLE
+            Get-ModuleImportCandidate -Name 'Pester','Maester'
+
+            Returns PSModuleInfo objects for the versions of the 'Pester' and 'Maester' modules that would be imported by Import-Module.
+
+            .EXAMPLE
+            'Az.Accounts','ExchangeOnlineManagement','Microsoft.Graph.Authentication','MicrosoftTeams' | Get-ModuleImportCandidate
+
+            Returns PSModuleInfo objects for the specified modules that would be imported by Import-Module.
+
+            .NOTES
+            Author: Sam Erde
+            Version: 1.0.0
+            Date: 2025-06-05
+            #>
+
+            [CmdletBinding()]
+            param(
+                # The name of the module[s] to check. This can be a single module name or an array of module names.
+                [Parameter(
+                    Position = 0,
+                    ValueFromPipeline,
+                    ValueFromPipelineByPropertyName,
+                    HelpMessage = 'Enter a module name or a list of names. Wildcards are allowed.'
+                )]
+                [string[]]$Name = @(
+                    'Az.Accounts',
+                    'ExchangeOnlineManagement',
+                    'Microsoft.Graph.Authentication',
+                    'MicrosoftTeams'
+                )
+            )
+
+            begin {
+                # Get PSModulePath entries in order (defaults to the 'Process' environment variable target which includes users and computer values, in that order).
+                $PSModulePathEntries = $env:PSModulePath -split [System.IO.Path]::PathSeparator |
+                    # Filter out empty entries and resolve the full path to account for symbolic links or variables.
+                    Where-Object { $_ } | ForEach-Object { [System.IO.Path]::GetFullPath($_) }
+            } # end begin block
+
+            process {
+                # Process each module name (handles both array input and pipeline input)
+                foreach ($ModuleName in $Name) {
+                    # Get all available modules with this name
+                    $AllModules = Get-Module -Name $ModuleName -ListAvailable
+
+                    # Skip and warn if no modules were found for this name.
+                    if (-not $AllModules) {
+                        Write-Warning "No module named '$ModuleName' found in PSModulePath."
+                        continue
+                    }
+
+                    # Use a script block to group modules by their base path and find the highest version in each grouped location.
+                    $ModulesByLocation = $AllModules | Group-Object {
+
+                        # Get the module's root directory (usually Modules folder)
+                        $ModulePath = [System.IO.Path]::GetFullPath($_.ModuleBase)
+
+                        # Find which PSModulePath entry this module's path begins with.
+                        foreach ($PathEntry in $PSModulePathEntries) {
+                            # Normalize the path to account for symbolic links or variables within the environment variable.
+                            $NormalizedPathEntry = [System.IO.Path]::GetFullPath($PathEntry)
+                            if ($ModulePath.StartsWith($NormalizedPathEntry, [System.StringComparison]::OrdinalIgnoreCase)) {
+                                # If the module path starts with this PSModulePath entry, return it as the grouping key.
+                                return $NormalizedPathEntry
+                            }
+                        }
+
+                    } # end of Group-Object script block
+
+                    # Find the highest version module from the first location in PSModulePath order.
+                    # Initialize the variable at its max value to ensure it is always greater than any valid index.
+                    $BestLocationIndex = [int]::MaxValue
+                    $CandidateModule = $null
+
+                    foreach ($LocationGroup in $ModulesByLocation) {
+                        # Get the highest version module from this location
+                        $HighestVersionInLocation = $LocationGroup.Group | Sort-Object Version -Descending | Select-Object -First 1
+
+                        # Find this location's index in PSModulePath (initialize at max value as best practice).
+                        $LocationIndex = [int]::MaxValue
+                        $LocationPath = $LocationGroup.Name
+
+                        for ($i = 0; $i -lt $PSModulePathEntries.Count; $i++) {
+                            # Perform a case-insensitive comparison to find the index of this location in PSModulePath.
+                            if ($LocationPath.StartsWith($PSModulePathEntries[$i], [System.StringComparison]::OrdinalIgnoreCase)) {
+                                $LocationIndex = $i
+                                break
+                            }
+                        }
+
+                        # Use this module if it's from an earlier location in PSModulePath.
+                        if ($LocationIndex -lt $BestLocationIndex) {
+                            $BestLocationIndex = $LocationIndex
+                            $CandidateModule = $HighestVersionInLocation
+                        }
+                    }
+
+                    # Output the candidate module for this module name
+                    $CandidateModule
+                }
+            } # end process block
+        } # end Get-ModuleImportCandidate function
+
+        function Get-ModulesWithVersionSortedIdentityClient {
+            [CmdletBinding()]
+            param(
+                # A list of module names to evaluate for proper import order.
+                [Parameter(
+                    Position = 0,
+                    ValueFromPipelineByPropertyName,
+                    HelpMessage = 'Enter a list of names to evaluate. Wildcards are allowed.'
+                )]
+                [string[]]$Name
+            )
+
+            begin {
+                $ModulesWithVersionSortedIdentityClient = [System.Collections.Generic.List[PSCustomobject]]::new()
+            } # end begin block
+
+            process {
+
+                # Call the function to determine the path and version of each module.
+                $ModuleInfo = Get-ModuleImportCandidate -Name $Name
+
+                # Find the version of 'Microsoft.Identity.Client.dll' that is packaged with each module.
+                foreach ($Module in $ModuleInfo) {
+                    $DllVersion = Get-ChildItem -Path $Module.ModuleBase -File -Include 'Microsoft.Identity.Client.dll' -Recurse -Force |
+                        Sort-Object -Property { $_.VersionInfo.FileVersion } -Descending |
+                            Select-Object -First 1 -Property @{Name = 'DLLVersion'; Expression = { [version]($_.VersionInfo.FileVersion) } }
+
+                    if (-not $DllVersion) {
+                        Write-Verbose "No 'Microsoft.Identity.Client.dll' found in $($Module.ModuleBase)."
+                        continue
+                    }
+
+                    # Store the module and DLL information in a custom object.
+                    $ThisModule = [PSCustomObject]@{
+                        Name          = $Module.Name
+                        ModuleBase    = $Module.ModuleBase
+                        ModuleVersion = $Module.Version
+                        DLLVersion    = $DllVersion.DLLVersion
+                    }
+
+                    # Add the module information to the ordered list.
+                    $ModulesWithVersionSortedIdentityClient.Add($ThisModule)
+                }
+
+                # Sort the modules by DLL version in descending order.
+                $ModulesWithVersionSortedIdentityClient = $ModulesWithVersionSortedIdentityClient | Sort-Object -Property DLLVersion -Descending
+                $ModulesWithVersionSortedIdentityClient
+            } # end process block
+        } # end Get-ModulesWithVersionSortedIdentityClient function
+        #endregion EmbeddedFunctions
+
+    } # end begin block
+
+} # end function
+
+Get-ModuleImportOrder

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -114,7 +114,7 @@
    $__MtSession.Connections = $Service
 
    $OrderedImport = Get-ModuleImportOrder -Name @('Az.Accounts', 'ExchangeOnlineManagement', 'Microsoft.Graph.Authentication', 'MicrosoftTeams')
-   switch ($OrderedImport) {
+   switch ($OrderedImport.Name) {
 
       'Az.Accounts' {
          if ($Service -contains 'Azure' -or $Service -contains 'All') {

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -113,111 +113,122 @@
 
    $__MtSession.Connections = $Service
 
-   if ($Service -contains 'Graph' -or $Service -contains 'All') {
-      Write-Verbose 'Connecting to Microsoft Graph'
-      try {
-         if ($TenantId) {
-            Connect-MgGraph -Scopes (Get-MtGraphScope -SendMail:$SendMail -SendTeamsMessage:$SendTeamsMessage -Privileged:$Privileged) -NoWelcome -UseDeviceCode:$UseDeviceCode -Environment $Environment -TenantId $TenantId
-         } else {
-            Connect-MgGraph -Scopes (Get-MtGraphScope -SendMail:$SendMail -SendTeamsMessage:$SendTeamsMessage -Privileged:$Privileged) -NoWelcome -UseDeviceCode:$UseDeviceCode -Environment $Environment
-            $TenantId = (Get-MgContext).TenantId
-         }
-      } catch [Management.Automation.CommandNotFoundException] {
-         Write-Host "`nThe Graph PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/powershell/microsoftgraph/installation" -ForegroundColor Red
-         Write-Host "`Install-Module Microsoft.Graph.Authentication -Scope CurrentUser`n" -ForegroundColor Yellow
-      }
-   }
+   $OrderedImport = Get-ModuleImportOrder -Name @('Az.Accounts', 'ExchangeOnlineManagement', 'Microsoft.Graph.Authentication', 'MicrosoftTeams')
+   switch ($OrderedImport) {
 
-   if ($Service -contains 'Azure' -or $Service -contains 'All') {
-      Write-Verbose 'Connecting to Microsoft Azure'
-      try {
-         if($TenantId){
-            Connect-AzAccount -SkipContextPopulation -UseDeviceAuthentication:$UseDeviceCode -Environment $AzureEnvironment -Tenant $TenantId
-         }
-         else {
-            Connect-AzAccount -SkipContextPopulation -UseDeviceAuthentication:$UseDeviceCode -Environment $AzureEnvironment
-         }
-
-      } catch [Management.Automation.CommandNotFoundException] {
-         Write-Host "`nThe Azure PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/powershell/azure/install-azure-powershell" -ForegroundColor Red
-         Write-Host "`Install-Module Az.Accounts -Scope CurrentUser`n" -ForegroundColor Yellow
-      }
-   }
-
-   $ExchangeModuleNotInstalledWarningShown = $false
-   if ($Service -contains 'ExchangeOnline' -or $Service -contains 'All') {
-      Write-Verbose 'Connecting to Microsoft Exchange Online'
-      try {
-         if ($UseDeviceCode -and $PSVersionTable.PSEdition -eq 'Desktop') {
-            Write-Host "The Exchange Online module in Windows PowerShell does not support device code flow authentication." -ForegroundColor Red
-            Write-Host "💡Please use the Exchange Online module in PowerShell Core." -ForegroundColor Yellow
-         } elseif ( $UseDeviceCode ) {
-            Connect-ExchangeOnline -ShowBanner:$false -Device:$UseDeviceCode -ExchangeEnvironmentName $ExchangeEnvironmentName
-         } else {
-            Connect-ExchangeOnline -ShowBanner:$false -ExchangeEnvironmentName $ExchangeEnvironmentName
-         }
-      } catch [Management.Automation.CommandNotFoundException] {
-         Write-Host "`nThe Exchange Online module is not installed. Please install the module using the following command.`nFor more information see https://learn.microsoft.com/powershell/exchange/exchange-online-powershell-v2" -ForegroundColor Red
-         Write-Host "`nInstall-Module ExchangeOnlineManagement -Scope CurrentUser`n" -ForegroundColor Yellow
-         $ExchangeModuleNotInstalledWarningShown = $true
-      }
-   }
-
-   if ($Service -contains 'SecurityCompliance' -or $Service -contains 'All') {
-      $Environments = @{
-         O365China        = @{
-            ConnectionUri    = 'https://ps.compliance.protection.partner.outlook.cn/powershell-liveid'
-            AuthZEndpointUri = 'https://login.chinacloudapi.cn/common'
-         }
-         O365GermanyCloud = @{
-            ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
-            AuthZEndpointUri = 'https://login.microsoftonline.com/common'
-         }
-         O365Default      = @{
-            ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
-            AuthZEndpointUri = 'https://login.microsoftonline.com/common'
-         }
-         O365USGovGCCHigh = @{
-            ConnectionUri    = 'https://ps.compliance.protection.office365.us/powershell-liveid/'
-            AuthZEndpointUri = 'https://login.microsoftonline.us/common'
-         }
-         O365USGovDoD     = @{
-            ConnectionUri    = 'https://l5.ps.compliance.protection.office365.us/powershell-liveid/'
-            AuthZEndpointUri = 'https://login.microsoftonline.us/common'
-         }
-      }
-      Write-Verbose 'Connecting to Microsoft Security & Compliance PowerShell'
-      if ($Service -notcontains 'ExchangeOnline' -and $Service -notcontains 'All') {
-         Write-Host "`nThe Security & Compliance module is dependent on the Exchange Online module. Please include ExchangeOnline when specifying the services.`nFor more information see https://learn.microsoft.com/en-us/powershell/exchange/connect-to-scc-powershell" -ForegroundColor Red
-      } else {
-         if ($UseDeviceCode) {
-            Write-Host "`nThe Security & Compliance module does not support device code flow authentication." -ForegroundColor Red
-         } else {
+      'Az.Accounts' {
+         if ($Service -contains 'Azure' -or $Service -contains 'All') {
+            Write-Verbose 'Connecting to Microsoft Azure'
             try {
-               Connect-IPPSSession -BypassMailboxAnchoring -ConnectionUri $Environments[$ExchangeEnvironmentName].ConnectionUri -AzureADAuthorizationEndpointUri $Environments[$ExchangeEnvironmentName].AuthZEndpointUri
+               if ($TenantId) {
+                  Connect-AzAccount -SkipContextPopulation -UseDeviceAuthentication:$UseDeviceCode -Environment $AzureEnvironment -Tenant $TenantId
+               } else {
+                  Connect-AzAccount -SkipContextPopulation -UseDeviceAuthentication:$UseDeviceCode -Environment $AzureEnvironment
+               }
             } catch [Management.Automation.CommandNotFoundException] {
-               if (-not $ExchangeModuleNotInstalledWarningShown) {
-                  Write-Host "`nThe Exchange Online module is not installed. Please install the module using the following command.`nFor more information see https://learn.microsoft.com/powershell/exchange/exchange-online-powershell-v2" -ForegroundColor Red
-                  Write-Host "`nInstall-Module ExchangeOnlineManagement -Scope CurrentUser`n" -ForegroundColor Yellow
+               Write-Host "`nThe Azure PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/powershell/azure/install-azure-powershell" -ForegroundColor Red
+               Write-Host "`Install-Module Az.Accounts -Scope CurrentUser`n" -ForegroundColor Yellow
+            }
+         }
+      }
+
+      'ExchangeOnlineManagement' {
+         $ExchangeModuleNotInstalledWarningShown = $false
+         if ($Service -contains 'ExchangeOnline' -or $Service -contains 'All') {
+            Write-Verbose 'Connecting to Microsoft Exchange Online'
+            try {
+               if ($UseDeviceCode -and $PSVersionTable.PSEdition -eq 'Desktop') {
+                  Write-Host 'The Exchange Online module in Windows PowerShell does not support device code flow authentication.' -ForegroundColor Red
+                  Write-Host '💡Please use the Exchange Online module in PowerShell Core.' -ForegroundColor Yellow
+               } elseif ( $UseDeviceCode ) {
+                  Connect-ExchangeOnline -ShowBanner:$false -Device:$UseDeviceCode -ExchangeEnvironmentName $ExchangeEnvironmentName
+               } else {
+                  Connect-ExchangeOnline -ShowBanner:$false -ExchangeEnvironmentName $ExchangeEnvironmentName
+               }
+            } catch [Management.Automation.CommandNotFoundException] {
+               Write-Host "`nThe Exchange Online module is not installed. Please install the module using the following command.`nFor more information see https://learn.microsoft.com/powershell/exchange/exchange-online-powershell-v2" -ForegroundColor Red
+               Write-Host "`nInstall-Module ExchangeOnlineManagement -Scope CurrentUser`n" -ForegroundColor Yellow
+               $ExchangeModuleNotInstalledWarningShown = $true
+            }
+         }
+
+         if ($Service -contains 'SecurityCompliance' -or $Service -contains 'All') {
+            $Environments = @{
+               O365China        = @{
+                  ConnectionUri    = 'https://ps.compliance.protection.partner.outlook.cn/powershell-liveid'
+                  AuthZEndpointUri = 'https://login.chinacloudapi.cn/common'
+               }
+               O365GermanyCloud = @{
+                  ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
+                  AuthZEndpointUri = 'https://login.microsoftonline.com/common'
+               }
+               O365Default      = @{
+                  ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
+                  AuthZEndpointUri = 'https://login.microsoftonline.com/common'
+               }
+               O365USGovGCCHigh = @{
+                  ConnectionUri    = 'https://ps.compliance.protection.office365.us/powershell-liveid/'
+                  AuthZEndpointUri = 'https://login.microsoftonline.us/common'
+               }
+               O365USGovDoD     = @{
+                  ConnectionUri    = 'https://l5.ps.compliance.protection.office365.us/powershell-liveid/'
+                  AuthZEndpointUri = 'https://login.microsoftonline.us/common'
+               }
+            }
+            Write-Verbose 'Connecting to Microsoft Security & Compliance PowerShell'
+            if ($Service -notcontains 'ExchangeOnline' -and $Service -notcontains 'All') {
+               Write-Host "`nThe Security & Compliance module is dependent on the Exchange Online module. Please include ExchangeOnline when specifying the services.`nFor more information see https://learn.microsoft.com/en-us/powershell/exchange/connect-to-scc-powershell" -ForegroundColor Red
+            } else {
+               if ($UseDeviceCode) {
+                  Write-Host "`nThe Security & Compliance module does not support device code flow authentication." -ForegroundColor Red
+               } else {
+                  try {
+                     Connect-IPPSSession -BypassMailboxAnchoring -ConnectionUri $Environments[$ExchangeEnvironmentName].ConnectionUri -AzureADAuthorizationEndpointUri $Environments[$ExchangeEnvironmentName].AuthZEndpointUri
+                  } catch [Management.Automation.CommandNotFoundException] {
+                     if (-not $ExchangeModuleNotInstalledWarningShown) {
+                        Write-Host "`nThe Exchange Online module is not installed. Please install the module using the following command.`nFor more information see https://learn.microsoft.com/powershell/exchange/exchange-online-powershell-v2" -ForegroundColor Red
+                        Write-Host "`nInstall-Module ExchangeOnlineManagement -Scope CurrentUser`n" -ForegroundColor Yellow
+                     }
+                  }
                }
             }
          }
       }
-   }
 
-   if ($Service -contains 'Teams' -or $Service -contains 'All') {
-      Write-Verbose 'Connecting to Microsoft Teams'
-      try {
-         if ($UseDeviceCode) {
-            Connect-MicrosoftTeams -UseDeviceAuthentication
-         } elseif ($TeamsEnvironmentName) {
-            Connect-MicrosoftTeams -TeamsEnvironmentName $TeamsEnvironmentName | Out-Null
-         } else {
-            Connect-MicrosoftTeams | Out-Null
+      'Microsoft.Graph.Authentication' {
+         if ($Service -contains 'Graph' -or $Service -contains 'All') {
+            Write-Verbose 'Connecting to Microsoft Graph'
+            try {
+               if ($TenantId) {
+                  Connect-MgGraph -Scopes (Get-MtGraphScope -SendMail:$SendMail -SendTeamsMessage:$SendTeamsMessage -Privileged:$Privileged) -NoWelcome -UseDeviceCode:$UseDeviceCode -Environment $Environment -TenantId $TenantId
+               } else {
+                  Connect-MgGraph -Scopes (Get-MtGraphScope -SendMail:$SendMail -SendTeamsMessage:$SendTeamsMessage -Privileged:$Privileged) -NoWelcome -UseDeviceCode:$UseDeviceCode -Environment $Environment
+                  $TenantId = (Get-MgContext).TenantId
+               }
+            } catch [Management.Automation.CommandNotFoundException] {
+               Write-Host "`nThe Graph PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/powershell/microsoftgraph/installation" -ForegroundColor Red
+               Write-Host "`Install-Module Microsoft.Graph.Authentication -Scope CurrentUser`n" -ForegroundColor Yellow
+            }
          }
-      } catch [Management.Automation.CommandNotFoundException] {
-         Write-Host "`nThe Teams PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-install" -ForegroundColor Red
-         Write-Host "`Install-Module MicrosoftTeams -Scope CurrentUser`n" -ForegroundColor Yellow
       }
-   }
-}
+
+      'MicrosoftTeams' {
+         if ($Service -contains 'Teams' -or $Service -contains 'All') {
+            Write-Verbose 'Connecting to Microsoft Teams'
+            try {
+               if ($UseDeviceCode) {
+                  Connect-MicrosoftTeams -UseDeviceAuthentication
+               } elseif ($TeamsEnvironmentName) {
+                  Connect-MicrosoftTeams -TeamsEnvironmentName $TeamsEnvironmentName | Out-Null
+               } else {
+                  Connect-MicrosoftTeams | Out-Null
+               }
+            } catch [Management.Automation.CommandNotFoundException] {
+               Write-Host "`nThe Teams PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-install" -ForegroundColor Red
+               Write-Host "`Install-Module MicrosoftTeams -Scope CurrentUser`n" -ForegroundColor Yellow
+            }
+         }
+      }
+   } # end switch OrderedImport
+
+} # end function Connect-Maester


### PR DESCRIPTION
The goal of this pull request is to avoid common dependency version conflict errors while connecting to Microsoft Azure and Microsoft 365 service APIs.

This should resolve #875 and #876.

The `Az.Accounts`, 'ExchangeOnlineManagement', 'Microsoft.Graph.Authentication', and 'MicrosoftTeams' modules all include different versions of the **Microsoft.Identity.Client** DLL. The newest version of this must be *loaded* first, and other versions in successive order, in order to avoid versions conflict errors that prevent connection attempts. The `Import-Module` lazy-loads DLLs, meaning they are not actually loaded into the session until the `Connect-[ServiceName]` commands are run. Therefore, the order of connection is actually more important than the order of importing these modules.

### Module Import Handling Enhancements:
* **`powershell/internal/Get-ModuleImportOrder.ps1`:** Added the `Get-ModuleImportOrder` function to determine the import order of specified modules based on their versions and PSModulePath location. This includes embedded helper functions `Get-ModuleImportCandidate` and `Get-ModulesWithVersionSortedIdentityClient` to identify the correct module version and sort them by `Microsoft.Identity.Client.dll` version. These functions work cross-platform for Linux, macOS, PowerShell "Core' on Windows, and Windows PowerShell 5.1.

### Refactoring Service Connection Logic:
* **`powershell/public/Connect-Maester.ps1`:** Refactored the service connection logic to use the ordered module import list from `Get-ModuleImportOrder`. Connections to Azure, Exchange Online, Microsoft Graph, and Microsoft Teams are now handled within a `switch` block based on the determined module order. This ensures reliable module loading and improves compatibility across environments. [[1]](diffhunk://#diff-d5fa85d6674508621348d839addffb6bbec661f9f017bdd1f191515d3a7acf44L116-R142) [[2]](diffhunk://#diff-d5fa85d6674508621348d839addffb6bbec661f9f017bdd1f191515d3a7acf44R196-R215) [[3]](diffhunk://#diff-d5fa85d6674508621348d839addffb6bbec661f9f017bdd1f191515d3a7acf44R232-R234)