### PR TITLE
Update the minimum required version of Microsoft.Graph.Authentication

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -57,7 +57,7 @@ PowerShellVersion = '5.1'
     if necessary by Install-MaesterTests.
 #>
 
-RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.25.0'; }
+RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; MinimumVersion = '2.27.0'; }
                      @{ModuleName = 'Pester'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71'; ModuleVersion = '0.0.0'; } )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
Maester was set to require **Microsoft.Graph.Authentication 2.25.0** to stay current with improvements and security in that module. (The previous required version was `0.2.0.`) We required that specific version because `2.26.0` and `2.26.1` had known authentication bugs. Those bugs were resolved in `2.27.0`, and `2.28.0` is now available.

At some point, we should change this to simply require a minimum of `2.27.0` or higher, as we will need to again remain current and supported.

Moving to a newer minimum version will require some users to update, but will also add forward flexibility.