### PR TITLE
Fix manifest required module version

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -57,7 +57,7 @@ PowerShellVersion = '5.1'
     if necessary by Install-MaesterTests.
 #>
 
-RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; MinimumVersion = '2.27.0'; }
+RequiredModules = @( @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.27.0'; }
                      @{ModuleName = 'Pester'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71'; ModuleVersion = '0.0.0'; } )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
https://github.com/maester365/maester/actions/runs/15813200285/job/44567504608#step:5:1

I mistakenly used Minimum Version instead of Module Version

This fixes the manifest and the publish preview workflow.