### PR TITLE
Fixed bug with Windows PowerShell Join-Path

### DIFF
--- a/powershell/internal/Get-MtMaesterConfig.ps1
+++ b/powershell/internal/Get-MtMaesterConfig.ps1
@@ -82,7 +82,7 @@ function Get-MtMaesterConfig {
     }
 
     # Read the custom config file if it exists
-    $customConfigPath = Join-Path -Path (Split-Path -Path $ConfigFilePath -Parent) 'custom' 'maester-config.json'
+    $customConfigPath = Join-Path -Path (Split-Path -Path $ConfigFilePath -Parent) -ChildPath 'custom' | Join-Path -ChildPath 'maester-config.json'
     if (Test-Path $customConfigPath) {
         Write-Verbose "Custom config file found at $customConfigPath. Merging with main config."
         $customConfig = Get-Content -Path $customConfigPath -Raw | ConvertFrom-Json


### PR DESCRIPTION
Added -ChildPath to support Windows PowerShell which requires explicit parameter name

Fixes #982 