### PR TITLE
Reverted Connect-Maester to Graph as default (instead of All)

### DIFF
--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -100,7 +100,7 @@
 
       # The services to connect to such as Azure and EXO. Default is Graph.
       [ValidateSet('All', 'Azure', 'ExchangeOnline', 'Graph', 'SecurityCompliance', 'Teams')]
-      [string[]]$Service = 'All',
+      [string[]]$Service = 'Graph',
 
       # The Tenant ID to connect to, if not specified the sign-in user's default tenant is used.
       [string]$TenantId

--- a/powershell/public/core/Test-MtConnection.ps1
+++ b/powershell/public/core/Test-MtConnection.ps1
@@ -37,7 +37,7 @@
         # Checks if the current session is connected to the specified service
         [ValidateSet('All', 'Azure', 'ExchangeOnline', 'EOP', 'Graph', 'SecurityCompliance', 'Teams')]
         [Parameter(Position = 0)]
-        [string[]]$Service = 'All',
+        [string[]]$Service = 'Graph',
 
         # Return the full details of the connections
         [Parameter()]


### PR DESCRIPTION
Connecting to all services was introduced a couple of months ago.

Historically, we defaulted to Graph and other services as optional. 

This keeps the initial experience simple and avoids new users running into connection related issues and extended onboarding steps.