### PR TITLE
Clarify results of Customer Lockbox check

### DIFF
--- a/powershell/public/cis/Test-MtCisCustomerLockBox.ps1
+++ b/powershell/public/cis/Test-MtCisCustomerLockBox.ps1
@@ -24,40 +24,14 @@ function Test-MtCisCustomerLockBox {
         return $null
     }
 
-    Write-Verbose "Requesting secure scores to get the customer lockbox setting"
-    $customerLockbox = Get-MtExo -Request OrganizationConfig | Select-Object CustomerLockBoxEnabled
-
-    Write-Verbose "Checking if the customer lockbox feature is enabled"
-    $result = $customerLockbox | Where-Object { $_.CustomerLockBoxEnabled -ne "True" }
-
-    # Set the result to true and pass if no tenants are found with the customer lockbox feature disabled.
-    $testResult = ($result | Measure-Object).Count -eq 0
-
-    if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has the customer lockbox enabled.`n`n%TestResult%"
-    } else {
-        $testResultMarkdown = "Your tenant does not have the customer lockbox enabled:`n`n%TestResult%"
-    }
-
-    # Prepare the markdown result table if the test fails (testResult is false).
-    if ($testResult -eq $false) {
-        $resultMd = "| Customer Lockbox |`n"
-        $resultMd += "| --- |`n"
-        foreach ($item in $customerLockbox) {
-            $itemResult = "❌ Fail"
-            if ($item.id -notin $result.id) {
-                $itemResult = "✅ Pass"
-            }
-            $resultMd += "| $($itemResult) |`n"
-        }
-    }
     try {
         Write-Verbose 'Requesting secure scores to get the customer lockbox setting'
         $customerLockbox = Get-MtExo -Request OrganizationConfig | Select-Object CustomerLockBoxEnabled
 
-        Write-Verbose 'Get domains where passwords are set to expire'
+        Write-Verbose 'Checking if the customer lockbox feature is enabled'
         $result = $customerLockbox | Where-Object { $_.CustomerLockBoxEnabled -ne 'True' }
 
+        # Set the result to true and pass if no tenants are found with the customer lockbox feature disabled.
         $testResult = ($result | Measure-Object).Count -eq 0
         if ($testResult) {
             $testResultMarkdown = "Well done. Your tenant has the customer lockbox enabled:`n`n%TestResult%"
@@ -65,14 +39,17 @@ function Test-MtCisCustomerLockBox {
             $testResultMarkdown = "Your tenant does not have the customer lockbox enabled:`n`n%TestResult%"
         }
 
-        $resultMd = "| Customer Lockbox |`n"
-        $resultMd += "| --- |`n"
-        foreach ($item in $customerLockbox) {
-            $itemResult = '❌ Fail'
-            if ($item.id -notin $result.id) {
-                $itemResult = '✅ Pass'
+        # Prepare the markdown result table if the test fails (testResult is false).
+        if ($testResult -eq $false) {
+            $resultMd = "| Customer Lockbox |`n"
+            $resultMd += "| --- |`n"
+            foreach ($item in $customerLockbox) {
+                $itemResult = "❌ Fail"
+                if ($item.id -notin $result.id) {
+                    $itemResult = "✅ Pass"
+                }
+                $resultMd += "| $($itemResult) |`n"
             }
-            $resultMd += "| $($itemResult) |`n"
         }
 
         $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd


### PR DESCRIPTION
Clarify test results by only showing the failed results details if the test actually fails.  Fixes #998.