### PR TITLE
Add test: MT.1059 Mfa on device registration conflict

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -147,7 +147,7 @@ FunctionsToExport = 'Add-MtTestResultDetail',
     'Test-ORCA227', 'Test-ORCA228', 'Test-ORCA229', 'Test-ORCA230', 'Test-ORCA231', 'Test-ORCA232',
     'Test-ORCA233', 'Test-ORCA233_1', 'Test-ORCA234', 'Test-ORCA235', 'Test-ORCA236', 'Test-ORCA237',
     'Test-ORCA238', 'Test-ORCA239', 'Test-ORCA240', 'Test-ORCA241', 'Test-ORCA242', 'Test-ORCA243',
-    'Test-ORCA244', 'Update-MaesterTests'
+    'Test-ORCA244', 'Update-MaesterTests', 'Test-MtRegistrationMfaConflict'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/powershell/public/maester/entra/Test-MtRegistrationMfaConflict.md
+++ b/powershell/public/maester/entra/Test-MtRegistrationMfaConflict.md
@@ -1,0 +1,9 @@
+This function checks if MFA during device registration is being enforced in Entra ID settings and in conditional access policies.
+
+#### Remediation action
+
+When a Conditional Access policy is configured with the Register or join devices user action, you must set Entra ID > Devices > Overview > Device Settings - Require Multifactor Authentication to register or join devices with Microsoft Entra to No
+
+<!--- Results --->
+
+%TestResult%

--- a/powershell/public/maester/entra/Test-MtRegistrationMfaConflict.ps1
+++ b/powershell/public/maester/entra/Test-MtRegistrationMfaConflict.ps1
@@ -1,0 +1,74 @@
+<#
+.Synopsis
+    This function checks if MFA during device registration is being enforced in Entra ID settings and in conditional access policies.
+
+.Description
+    When MFA is required during device registration in Conditional Access policies, it must be disabled in the Entra ID Device settings.
+    When both are enabled, the conditional access policy with the "Register device" user action will not work as expected. More information
+    can be foun at: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-all-users-device-registration#create-a-conditional-access-policy
+
+.Example
+    Test-MtRegistrationMfaConflict
+
+.LINK
+    https://maester.dev/docs/commands/Test-MtRegistrationMfa
+#>
+
+function Test-MtRegistrationMfaConflict {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param ()
+
+    # Testing conneciton with graph
+    if (-not (Test-MtConnection Graph)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
+        return $null
+    }
+
+    # Initialize the test result variables
+    $testResultMarkdown = ""
+    $misconfigPolicies = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    # Get the enabled conditional access policies
+    $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq "enabled" }
+    Write-Verbose "Retrieved conditional access policies:`n $policies"
+
+    # Get device registration settings in Entra ID
+    $deviceRegSettings = Invoke-MtGraphRequest -RelativeUri "policies/deviceRegistrationPolicy" -apiVersion "beta" -ErrorAction Stop
+    Write-Verbose "Retrieved device registration settings:`n $deviceRegSettings"
+
+    # Check if MFA with Device Registration is required in Entra settings
+    if ($deviceRegSettings.multiFactorAuthConfiguration -ne "notRequired") {
+        foreach ($policy in $policies) {
+            # If there is a conditional access policy requiring controls on register device as well, we found a misconfig
+            if ($policy.conditions.applications.includeUserActions -contains "urn:user:registerdevice") {
+                # Save the policy details to the list
+                Write-Verbose "Found a conditional access policy requiring controls on register device: $($policy.displayName)"
+                $misconfigPolicy = [PSCustomObject]@{
+                    Id          = $policy.id
+                    DisplayName = $policy.displayName
+                }
+                $misconfigPolicies.Add($misconfigPolicy) | Out-Null
+            }
+        }
+    }
+
+    if ($misconfigPolicies.Count -gt 0) {
+        $testResultMarkdown = "Misconfigurations detected in conditional access policies requiring controls on register device:`n`n%TestResult%"
+        $result = "| Policy Display Name | Policy Id |`n"
+        $result += "| --- | --- |`n"
+        foreach ($policy in $misconfigPolicies) {
+            $policyMdLink = "[$($policy.DisplayName)](https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccessPolicyBlade/~/policies/$($policy.Id))"
+            $result += "| $($policyMdLink) | $($policy.Id) |`n"
+            Write-Verbose "Adding policy $($policy.DisplayName) with id $($policy.Id) to markdown table."
+        }
+        $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+        $return = $false
+    } else {
+        $testResultMarkdown = "MFA for device registration is not required in Entra ID settings, meaning no conflicts can exist with conditional access policies."
+        $return = $true
+    }
+
+    Add-MtTestResultDetail -Result $testResultMarkdown
+    return $return
+}

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -71,6 +71,9 @@
     It "MT.1052: At least one Conditional Access policy is targeting the Device Code authentication flow. See https://maester.dev/docs/tests/MT.1052" -Tag "MT.1052" {
         Test-MtCaDeviceCodeFlow | Should -Be $true -Because "there is no policy that targets the device code authentication flow."
     }
+    It "MT.1059: MFA during device registration should not be set in Entra ID settings when Conditional Access policies require MFA for device registration. See https://maester.dev/docs/tests/MT.1059" -Tag "MT.1059" {
+        Test-MtRegistrationMfaConflict | Should -Be $true -Because "there is a conflict between Entra ID settings and Conditional Access policies regarding MFA during device registration"
+    }
     Context "Maester/Entra" -Tag "Entra", "License" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {
             $LicenseReport = Test-MtCaLicenseUtilization -License "P1"

--- a/website/docs/commands/Test-MtRegistrationMfaConflict.mdx
+++ b/website/docs/commands/Test-MtRegistrationMfaConflict.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_class_name: hidden
+description: Check if there is a conflict for MFA on device registration between Entra settings and conditional access
+id: Test-MtRegistrationMfaConflict
+title: Test-MtRegistrationMfaConflict
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: https://github.com/maester365/maester/blob/main/powershell/public/Test-MtRegistrationMfaConflict.ps1
+---
+
+## SYNOPSIS
+
+Check if MFA during device registration is being enforced in Entra ID settings and in conditional access policies.
+
+## SYNTAX
+
+```powershell
+Test-MtRegistrationMfaConflict [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+When MFA is required during device registration in Conditional Access policies, it must be disabled in the Entra ID Device settings.
+When both are enabled, the conditional access policy with the "Register device" user action will not work as expected. More information
+can be foun at: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-all-users-device-registration#create-a-conditional-access-policy
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Test-MtRegistrationMfaConflict
+```
+
+Returns true if no conflict was found, otherwise returns false.
+
+## PARAMETERS
+
+### -ProgressAction
+
+\{\{ Fill ProgressAction Description \}\}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Boolean
+
+## NOTES
+
+## RELATED LINKS
+
+[https://maester.dev/docs/commands/Test-MtRegistrationMfaConflict](https://maester.dev/docs/commands/Test-MtRegistrationMfaConflict)

--- a/website/docs/commands/docusaurus.sidebar.js
+++ b/website/docs/commands/docusaurus.sidebar.js
@@ -72,6 +72,7 @@ module.exports = [
     'commands/Test-MtCaRequirePasswordChangeForHighUserRisk',
     'commands/Test-MtCaSecureSecurityInfoRegistration',
     'commands/Test-MtCaWIFBlockLegacyAuthentication',
+    'commands/Test-MtRegistrationMfaConflict',
     'commands/Test-MtCis365PublicGroup',
     'commands/Test-MtCisaActivationNotification',
     'commands/Test-MtCisaAntiSpamAllowList',


### PR DESCRIPTION
Hi all, 

I wrote a new test to spot MFA on device registration conflict by checking if MFA is enforced in Entra ID device settings and in conditional access policies together. It is basically a test for the warning documented here: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-all-users-device-registration#create-a-conditional-access-policy.

The output looks as following

Test ok:
![image](https://github.com/user-attachments/assets/83b99e3b-2bdc-49ec-8fd0-7cce3a170a80)

Test not ok:
![image](https://github.com/user-attachments/assets/23007671-e668-452d-b8c8-ffb19e1db044)

Happy to hear the feedback.

Kind regards
Robbe