### PR TITLE
fix&improve MtCisaAuditLogPremium Test

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaAuditLogPremium.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAuditLogPremium.ps1
@@ -30,25 +30,26 @@ function Test-MtCisaAuditLogPremium {
     }
 
     Write-Verbose "In tenants with a substantial number of mailboxes this test may take time"
-    $mailboxes = Get-EXOMailbox -Properties AuditOwner
+    $mailboxes = Get-EXOMailbox -ResultSize Unlimited -PropertySets Audit
 
     $resultMailboxes = $mailboxes | Where-Object { `
         $_.AuditOwner -notcontains "SearchQueryInitiated"
     }
 
-    $testResult = ($resultMailboxes|Measure-Object).Count -ge 1
+    $testResult = ($resultMailboxes|Measure-Object).Count -eq 0
 
     $portalLink = "https://purview.microsoft.com/audit/auditsearch"
     $passResult = "✅ Pass"
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [SearchQueryInitiated audit log enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [SearchQueryInitiated audit log]($portalLink) enabled for all users.`n`n%TestResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [SearchQueryInitiated audit log enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [SearchQueryInitiated audit log]($portalLink) enabled for all users.`n`n%TestResult%"
     }
 
-    $result = "| Mailbox | SearchQueryInitiated |`n"
+    $result = "$passResult ($(($mailboxes.count - $resultMailboxes.count)) of $($mailboxes.count)) $failResult ($($resultMailboxes.count) of $($mailboxes.count)). Showing first 100.`n`n"
+    $result += "| Mailbox | SearchQueryInitiated |`n"
     $result += "| --- | --- |`n"
     foreach($item in $mailboxes | Sort-Object -Property UserPrincipalName){
         if($item.Guid -notin $resultMailboxes.Guid){


### PR DESCRIPTION
This PR fix and improves the CisaAuditLogPremium Test

- Fetch all actual mailboxes
- Pass correct results to $testResult (if 0 results, its a pass)
- Show some quick info on how many has passed or not
- Limit results view to 100