### PR TITLE
Update EOP License check in Test-MtCisaEmailFilterAlternative.ps1

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaEmailFilterAlternative.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaEmailFilterAlternative.ps1
@@ -24,8 +24,8 @@ function Test-MtCisaEmailFilterAlternative {
     } elseif (!(Test-MtConnection SecurityCompliance)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedSecurityCompliance
         return $null
-    } elseif("Eop" -in (Get-MtLicenseInformation -Product Eop)) {
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Tenant is licensed for Exchange Online Protection, an alternative mail filter is not needed."
+    } elseif ( 'Eop' -in (Get-MtLicenseInformation -Product Eop) -or 'Eop' -in (Get-MtLicenseInformation -Product MdoV2) ) {
+        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Tenant is licensed for Exchange Online Protection; an alternative mail filter is not needed."
         return $null
     } else {
         Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Tenant is not licensed for Exchange Online Protection and there is no implementation to check for alternate mail filters available."


### PR DESCRIPTION
Added check for `Eop` in `MdoV2` license. This resolves #1010.

- [x] Tested