### PR TITLE
Fix tests CIS.M365.3.1.1 and CIS.M365.2.1.12

### DIFF
--- a/powershell/public/cis/Test-MtCisAuditLogSearch.ps1
+++ b/powershell/public/cis/Test-MtCisAuditLogSearch.ps1
@@ -26,7 +26,7 @@ function Test-MtCisAuditLogSearch {
 
     try {
         Write-Verbose 'Get audit log search status'
-        $auditLogSearch = Get-AdminAuditLogConfig | Select-Object UnifiedAuditLogIngestionEnabled
+        $auditLogSearch = Get-AdminAuditLogConfig
 
         Write-Verbose 'Check audit log search is enabled'
         $result = $auditLogSearch | Where-Object { $_.UnifiedAuditLogIngestionEnabled -ne 'True' }

--- a/powershell/public/cis/Test-MtCisHostedConnectionFilterPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisHostedConnectionFilterPolicy.ps1
@@ -29,7 +29,7 @@ function Test-MtCisHostedConnectionFilterPolicy {
         $connectionFilterIPAllowList = Get-HostedConnectionFilterPolicy -Identity Default | Select-Object IPAllowList
 
         Write-Verbose 'Check if the Connection Filter IP allow list is empty'
-        $result = $connectionFilterIPAllowList | Where-Object { $connectionFilterIPAllowList.Count -ne 0 }
+        $result = $connectionFilterIPAllowList | Where-Object { $_.IPAllowList.Count -ne 0 }
 
         $testResult = ($result | Measure-Object).Count -eq 0
         if ($testResult) {


### PR DESCRIPTION
**Test: CIS.M365.3.1.1**
Remove selection of property to not lose any other properties used in the foreach loop later (e.g. id).

**Test: CIS.M365.2.1.12**
Switch from the name of the variable to the automatic variable which contains the pipeline object and add the arraylist name via dot-sourcing in the conditional expression to properly read the count. Without adding the name of the arraylist, the count would always show 1 because the IPAllowList does count as one item as well)