### PR TITLE
Fix: Policy matching in Test-MtCaDeviceCodeFlow

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaDeviceCodeFlow.ps1
+++ b/powershell/public/maester/entra/Test-MtCaDeviceCodeFlow.ps1
@@ -22,7 +22,7 @@ function Test-MtCaDeviceCodeFlow {
     param ()
 
     try {
-        $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq 'enabled' -and $_.conditions.authenticationFlows.transferMethods -contains 'deviceCodeFlow' }
+        $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq 'enabled' -and $_.conditions.authenticationFlows.transferMethods -match 'deviceCodeFlow' }
         $policiesResult = New-Object System.Collections.ArrayList
         $result = $false
 


### PR DESCRIPTION
Use "match" instead of "contains" operator for $_.conditions.authenticationFlows.transferMethods, since it is a string, not a collection.

Fixes #1008 