### PR TITLE
Update all files where %TestResult% was used to %testResult%. 

### DIFF
--- a/powershell/internal/eidsca/@template.md
+++ b/powershell/internal/eidsca/@template.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/%ApiVersion%/%RelativeUri%
 %PortalDeepLinkMarkdown%
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAF01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAF01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAF02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAF02.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAF03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAF03.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAF04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAF04.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAF05.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAF05.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAF06.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAF06.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAG01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAG01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAG02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAG02.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AuthMethodsSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAG03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAG03.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AuthMethodsSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM02.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM03.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM04.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM06.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM06.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM07.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM07.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM09.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM09.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAM10.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAM10.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/PasswordResetMenuBlade/~/AdminPasswordResetPolicy)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP04.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AllowlistPolicyBlade)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP05.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP05.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP06.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP06.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP07.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP07.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AllowlistPolicyBlade)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP08.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP08.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserManagementMenuBlade/~/UserSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP09.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP09.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP10.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP10.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserManagementMenuBlade/~/UserSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAP14.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAP14.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authorizationPolicy
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAS04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAS04.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAT01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAT01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAT02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAT02.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaAV01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaAV01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authentica
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCP01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCP01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCP03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCP03.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCP04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCP04.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR02.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR03.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaCR04.md
+++ b/powershell/internal/eidsca/Test-MtEidscaCR04.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/policies/adminConsentRequestPolicy
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/AdminConsentSettings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR01.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR01.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR02.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR02.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR03.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR03.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR05.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR05.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaPR06.md
+++ b/powershell/internal/eidsca/Test-MtEidscaPR06.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 - [View in Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/PasswordProtection)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaST08.md
+++ b/powershell/internal/eidsca/Test-MtEidscaST08.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/internal/eidsca/Test-MtEidscaST09.md
+++ b/powershell/internal/eidsca/Test-MtEidscaST09.md
@@ -15,4 +15,4 @@ https://graph.microsoft.com/beta/settings
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/Add-MtTestResultDetail.ps1
+++ b/powershell/public/Add-MtTestResultDetail.ps1
@@ -44,12 +44,12 @@ function Add-MtTestResultDetail {
         # Detailed information of the test result to provide additional context to the user.
         # This can be a summary of the items that caused the test to fail (e.g. list of user names, conditional access policies, etc.).
         # Markdown is supported.
-        # If the test result contains a placeholder %TestResult%, it will be replaced with the values from the $GraphResult
+        # If the test result contains a placeholder %testResult%, it will be replaced with the values from the $GraphResult
         [Parameter(Mandatory = $false)]
         [string] $Result,
 
         # Collection of Graph objects to display in the test results report.
-        # This will be inserted into the contents of Result parameter if the result contains a placeholder %TestResult%.
+        # This will be inserted into the contents of Result parameter if the result contains a placeholder %testResult%.
         [Object[]] $GraphObjects,
 
         # The type of graph object, this will be used to show the right deep-link to the test results report.
@@ -127,8 +127,8 @@ function Add-MtTestResultDetail {
                 if (![string]::IsNullOrEmpty($Result)) {
                     # If a result was provided in the parameter insert it into the markdown content
                     try {
-                        if ($mdResult -match "%TestResult%") {
-                            $mdResult = $mdResult -replace "%TestResult%", $Result
+                        if ($mdResult -match "%testResult%") {
+                            $mdResult = $mdResult -replace "%testResult%", $Result
                         } else {
                             $mdResult = $Result
                         }
@@ -150,7 +150,7 @@ function Add-MtTestResultDetail {
     if ($hasGraphResults) {
         try {
             $graphResultMarkdown = Get-GraphObjectMarkdown -GraphObjects $GraphObjects -GraphObjectType $GraphObjectType
-            $Result = $Result -replace "%TestResult%", $graphResultMarkdown
+            $Result = $Result -replace "%testResult%", $graphResultMarkdown
         } catch {
             Write-Warning "Failed to generate graph object markdown: $($_.Exception.Message)"
             # Continue with original result without graph object markdown

--- a/powershell/public/cis/Test-MtCis365PublicGroup.md
+++ b/powershell/public/cis/Test-MtCis365PublicGroup.md
@@ -19,4 +19,4 @@ To enable only organizationally managed/approved public groups exist:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 36](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCis365PublicGroup.ps1
+++ b/powershell/public/cis/Test-MtCis365PublicGroup.ps1
@@ -34,9 +34,9 @@ function Test-MtCis365PublicGroup {
         $testResult = ($result | Measure-Object).Count -eq 0
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has no public 365 groups:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has no public 365 groups:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant has $(($result | Measure-Object).Count) public 365 groups:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant has $(($result | Measure-Object).Count) public 365 groups:`n`n%testResult%"
         }
         # $itemCount is used to limit the number of returned results shown in the table
         $itemCount = 0
@@ -55,7 +55,7 @@ function Test-MtCis365PublicGroup {
             $resultMd += "Results limited to 50`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisAttachmentFilter.md
+++ b/powershell/public/cis/Test-MtCisAttachmentFilter.md
@@ -19,4 +19,4 @@ To enable the Common Attachment Types Filter:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 74](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisAttachmentFilter.ps1
+++ b/powershell/public/cis/Test-MtCisAttachmentFilter.ps1
@@ -45,10 +45,10 @@ function Test-MtCisAttachmentFilter {
         $portalLink = "https://security.microsoft.com/presetSecurityPolicies"
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenants default malware filter policy has the common attachment file filter enabled ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenants default malware filter policy has the common attachment file filter enabled ($portalLink).`n`n%testResult%"
         }
         else {
-            $testResultMarkdown = "Your tenants default malware filter policy does not have the common attachment file filter enabled ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Your tenants default malware filter policy does not have the common attachment file filter enabled ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Policy | Result |`n"
@@ -63,7 +63,7 @@ function Test-MtCisAttachmentFilter {
 
         $resultMd += "| EnableFileFilter | $Result |`n"
 
-        $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisAttachmentFilterComprehensive.md
+++ b/powershell/public/cis/Test-MtCisAttachmentFilterComprehensive.md
@@ -65,4 +65,4 @@ New-MalwareFilterRule @Rule
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 109](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisAttachmentFilterComprehensive.ps1
+++ b/powershell/public/cis/Test-MtCisAttachmentFilterComprehensive.ps1
@@ -80,9 +80,9 @@ function Test-MtCisAttachmentFilterComprehensive {
 
         $testResult = ($missingExtensionList | Measure-Object).Count -eq 0
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant covers all CIS recommended file attachment extensions:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant covers all CIS recommended file attachment extensions:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant does not cover all CIS recommended file attachment extensions:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant does not cover all CIS recommended file attachment extensions:`n`n%testResult%"
         }
 
         $resultMd = "| Extension Name | Result |`n"
@@ -92,7 +92,7 @@ function Test-MtCisAttachmentFilterComprehensive {
             $resultMd += "| $($item) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisAuditLogSearch.md
+++ b/powershell/public/cis/Test-MtCisAuditLogSearch.md
@@ -17,4 +17,4 @@ To enable audit log search:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 143](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisAuditLogSearch.ps1
+++ b/powershell/public/cis/Test-MtCisAuditLogSearch.ps1
@@ -34,9 +34,9 @@ function Test-MtCisAuditLogSearch {
         $testResult = ($result | Measure-Object).Count -eq 0
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has audit log search enabled:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has audit log search enabled:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant does not have audit log search enabled:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant does not have audit log search enabled:`n`n%testResult%"
         }
 
         $resultMd = "| Audit Log Search |`n"
@@ -49,7 +49,7 @@ function Test-MtCisAuditLogSearch {
             $resultMd += "| $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisCalendarSharing.md
+++ b/powershell/public/cis/Test-MtCisCalendarSharing.md
@@ -18,4 +18,4 @@ your organization who have Office 365 or Exchange**.
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 52](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisCalendarSharing.ps1
+++ b/powershell/public/cis/Test-MtCisCalendarSharing.ps1
@@ -35,9 +35,9 @@ function Test-MtCisCalendarSharing {
 
         $testResult = ($resultPolicies | Measure-Object).Count -eq 0
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant does not allow uncontrolled calendar sharing.`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant does not allow uncontrolled calendar sharing.`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant allows uncontrolled calendar sharing.`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant allows uncontrolled calendar sharing.`n`n%testResult%"
         }
 
         $result = "| Policy Name | Test Result |`n"
@@ -50,7 +50,7 @@ function Test-MtCisCalendarSharing {
             }
             $result += "| [$($item.Name)]($portalLink) | $($itemResult) |`n"
         }
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisCloudAdmin.md
+++ b/powershell/public/cis/Test-MtCisCloudAdmin.md
@@ -22,4 +22,4 @@ appropriate role then click **Next**.
 * [CIS Microsoft 365 Foundations Benchmark v 4.0.0 - Page 20](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisCloudAdmin.ps1
+++ b/powershell/public/cis/Test-MtCisCloudAdmin.ps1
@@ -58,9 +58,9 @@ function Test-MtCisCloudAdmin {
         }
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has no hybrid Global Administrators:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has no hybrid Global Administrators:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant has 1 or more hybrid Global Administrators:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant has 1 or more hybrid Global Administrators:`n`n%testResult%"
         }
 
         $resultMd = "| Display Name | Cloud Only |`n"
@@ -72,7 +72,7 @@ function Test-MtCisCloudAdmin {
             }
             $resultMd += "| $($item.displayName) | $($itemResult) |`n"
         }
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisCommunicateWithUnmanagedTeamsUsers.md
+++ b/powershell/public/cis/Test-MtCisCommunicateWithUnmanagedTeamsUsers.md
@@ -46,4 +46,4 @@ Set-CsTenantFederationConfiguration -AllowTeamsConsumerInbound $false
 * [GIFShell Attack Lets Hackers Create Reverse Shell through Microsoft Teams GIFs](https://www.bitdefender.com/en-us/blog/hotforsecurity/gifshell-attack-lets-hackers-create-reverse-shell-through-microsoft-teams-gifs)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisConnectionFilterSafeList.md
+++ b/powershell/public/cis/Test-MtCisConnectionFilterSafeList.md
@@ -18,4 +18,4 @@ To remove IPs from the allow list:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 116](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisCustomerLockBox.md
+++ b/powershell/public/cis/Test-MtCisCustomerLockBox.md
@@ -20,4 +20,4 @@ To enable the Customer Lockbox feature:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 60](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisCustomerLockBox.ps1
+++ b/powershell/public/cis/Test-MtCisCustomerLockBox.ps1
@@ -34,9 +34,9 @@ function Test-MtCisCustomerLockBox {
         # Set the result to true and pass if no tenants are found with the customer lockbox feature disabled.
         $testResult = ($result | Measure-Object).Count -eq 0
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has the customer lockbox enabled:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has the customer lockbox enabled:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant does not have the customer lockbox enabled:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant does not have the customer lockbox enabled:`n`n%testResult%"
         }
 
         # Prepare the markdown result table if the test fails (testResult is false).
@@ -52,7 +52,7 @@ function Test-MtCisCustomerLockBox {
             }
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisDkim.md
+++ b/powershell/public/cis/Test-MtCisDkim.md
@@ -19,4 +19,4 @@ To enable DKIM:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 98](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisDkim.ps1
+++ b/powershell/public/cis/Test-MtCisDkim.ps1
@@ -95,9 +95,9 @@ function Test-MtCisDkim {
         $portalLink = 'https://security.microsoft.com/authentication?viewid=DKIM'
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant's domains have DKIM configured and valid records exist.`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant's domains have DKIM configured and valid records exist.`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant's domains do not have DKIM fully deployed. Review [EXO configuration]($portalLink) and DNS records.`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant's domains do not have DKIM fully deployed. Review [EXO configuration]($portalLink) and DNS records.`n`n%testResult%"
         }
 
         $passResult = '✅ Pass'
@@ -114,7 +114,7 @@ function Test-MtCisDkim {
             $result += "| $($item.domain) | $($itemResult) | $($item.reason) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisGlobalAdminCount.md
+++ b/powershell/public/cis/Test-MtCisGlobalAdminCount.md
@@ -28,4 +28,4 @@ To remove Global Admins:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 28](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisGlobalAdminCount.ps1
+++ b/powershell/public/cis/Test-MtCisGlobalAdminCount.ps1
@@ -47,7 +47,7 @@ function Test-MtCisGlobalAdminCount {
 
         $testResult = ($globalAdministrators | Measure-Object).Count -ge 2 -and ($globalAdministrators | Measure-Object).Count -le 4
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has two or more and four or fewer Global Administrators:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has two or more and four or fewer Global Administrators:`n`n%testResult%"
         } else {
             $testResultMarkdown = 'Your tenant does not have the appropriate number of Global Administrators.'
         }

--- a/powershell/public/cis/Test-MtCisHostedConnectionFilterPolicy.md
+++ b/powershell/public/cis/Test-MtCisHostedConnectionFilterPolicy.md
@@ -20,4 +20,4 @@ To remove IPs from the allow list:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 113](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisInternalMalwareNotification.md
+++ b/powershell/public/cis/Test-MtCisInternalMalwareNotification.md
@@ -20,4 +20,4 @@ To enable notifications for internal users sending malware:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 77](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisInternalMalwareNotification.ps1
+++ b/powershell/public/cis/Test-MtCisInternalMalwareNotification.ps1
@@ -48,9 +48,9 @@ function Test-MtCisInternalMalwareNotification {
         $portalLink = 'https://security.microsoft.com/antimalwarev2'
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenants default anti malware policy has recommended internal malware notifications configured ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenants default anti malware policy has recommended internal malware notifications configured ($portalLink).`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenants default anti malware policy does not have the recommended internal malware notifications configured ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Your tenants default anti malware policy does not have the recommended internal malware notifications configured ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Policy | Result |`n"
@@ -71,7 +71,7 @@ function Test-MtCisInternalMalwareNotification {
         $resultMd += "| EnableInternalSenderAdminNotification | $enableInternalSenderAdminNotificationResult |`n"
         $resultMd += "| InternalSenderAdminAddress | $internalSenderAdminAddressResult |`n"
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.md
+++ b/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.md
@@ -21,4 +21,4 @@ To set the Exchange Online Spam Policies:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 86](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.ps1
@@ -64,9 +64,9 @@ function Test-MtCisOutboundSpamFilterPolicy {
         $portalLink = 'https://security.microsoft.com/antispam'
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenants default Exchange Online Spam policy set to notify administrators ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenants default Exchange Online Spam policy set to notify administrators ($portalLink).`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenants default Exchange Online Spam policy is not set to notify administrators ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Your tenants default Exchange Online Spam policy is not set to notify administrators ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Check Name | Result |`n"
@@ -79,7 +79,7 @@ function Test-MtCisOutboundSpamFilterPolicy {
             $resultMd += "| $($item.CheckName) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisPasswordExpiry.md
+++ b/powershell/public/cis/Test-MtCisPasswordExpiry.md
@@ -17,4 +17,4 @@ To set Office 365 passwords are set to never expire:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 43](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisPasswordExpiry.ps1
+++ b/powershell/public/cis/Test-MtCisPasswordExpiry.ps1
@@ -34,9 +34,9 @@ function Test-MtCisPasswordExpiry {
         $testResult = ($result | Measure-Object).Count -eq 0
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant passwords are not set to expire:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant passwords are not set to expire:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant has 1 or more domains which expire passwords:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant has 1 or more domains which expire passwords:`n`n%testResult%"
         }
 
         $resultMd = "| Display Name | Domain |`n"
@@ -49,7 +49,7 @@ function Test-MtCisPasswordExpiry {
             $resultMd += "| $($item.Id) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisSafeAntiPhishingPolicy.md
+++ b/powershell/public/cis/Test-MtCisSafeAntiPhishingPolicy.md
@@ -19,4 +19,4 @@ To enable Safe Attachments for SharePoint, OneDrive, and Microsoft Teams:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 91](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisSafeAntiPhishingPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisSafeAntiPhishingPolicy.ps1
@@ -91,9 +91,9 @@ function Test-MtCisSafeAntiPhishingPolicy {
         $portalLink = 'https://security.microsoft.com/antiphishing'
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenants default anti-phishing policy matches CIS recommendations($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenants default anti-phishing policy matches CIS recommendations($portalLink).`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenants default anti-phishing policy does not match CIS recommendations ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Your tenants default anti-phishing policy does not match CIS recommendations ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Check Name | Result |`n"
@@ -106,7 +106,7 @@ function Test-MtCisSafeAntiPhishingPolicy {
             $resultMd += "| $($item.CheckName) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisSafeAttachment.md
+++ b/powershell/public/cis/Test-MtCisSafeAttachment.md
@@ -24,4 +24,4 @@ To enable the Safe Attachments policy:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 80](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisSafeAttachment.ps1
+++ b/powershell/public/cis/Test-MtCisSafeAttachment.ps1
@@ -73,9 +73,9 @@ function Test-MtCisSafeAttachment {
         $portalLink = 'https://security.microsoft.com/safeattachmentv2'
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenants default safe attachments policy matches CIS recommendations ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenants default safe attachments policy matches CIS recommendations ($portalLink).`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenants default safe attachments policy does not match CIS recommendations ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Your tenants default safe attachments policy does not match CIS recommendations ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Check Name | Result |`n"
@@ -88,7 +88,7 @@ function Test-MtCisSafeAttachment {
             $resultMd += "| $($item.CheckName) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisSafeAttachmentsAtpPolicy.md
+++ b/powershell/public/cis/Test-MtCisSafeAttachmentsAtpPolicy.md
@@ -21,4 +21,4 @@ To enable Safe Attachments for SharePoint, OneDrive, and Microsoft Teams:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 83](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisSafeAttachmentsAtpPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisSafeAttachmentsAtpPolicy.ps1
@@ -69,9 +69,9 @@ function Test-MtCisSafeAttachmentsAtpPolicy {
         $portalLink = 'https://security.microsoft.com/safeattachmentv2'
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has Safe Attachments for SharePoint, OneDrive, and Microsoft Teams enabled ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has Safe Attachments for SharePoint, OneDrive, and Microsoft Teams enabled ($portalLink).`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant does not have Safe Attachments for SharePoint, OneDrive, and Microsoft Teams enabled ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant does not have Safe Attachments for SharePoint, OneDrive, and Microsoft Teams enabled ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Check Name | Result |`n"
@@ -84,7 +84,7 @@ function Test-MtCisSafeAttachmentsAtpPolicy {
             $resultMd += "| $($item.CheckName) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisSafeLink.md
+++ b/powershell/public/cis/Test-MtCisSafeLink.md
@@ -39,4 +39,4 @@ To create a Safe Links policy:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 70](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisSafeLink.ps1
+++ b/powershell/public/cis/Test-MtCisSafeLink.ps1
@@ -110,9 +110,9 @@ function Test-MtCisSafeLink {
         $portalLink = 'https://security.microsoft.com/presetSecurityPolicies'
 
         if ($testResult) {
-            $testResultMarkdown = 'Well done. Safe link policy' + $priority0Policy.Name + " (Priority 0 policy) matches CIS recommendations ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = 'Well done. Safe link policy' + $priority0Policy.Name + " (Priority 0 policy) matches CIS recommendations ($portalLink).`n`n%testResult%"
         } else {
-            $testResultMarkdown = 'Safe link policy' + $priority0Policy.Name + " (Priority 0 policy) does not match CIS recommendations ($portalLink).`n`n%TestResult%"
+            $testResultMarkdown = 'Safe link policy' + $priority0Policy.Name + " (Priority 0 policy) does not match CIS recommendations ($portalLink).`n`n%testResult%"
         }
 
         $resultMd = "| Check Name | Result |`n"
@@ -125,7 +125,7 @@ function Test-MtCisSafeLink {
             $resultMd += "| $($item.CheckName) | $($itemResult) |`n"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisSharedMailboxSignIn.md
+++ b/powershell/public/cis/Test-MtCisSharedMailboxSignIn.md
@@ -19,4 +19,4 @@ Block sign-in to shared mailboxes in the UI:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 39](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisSharedMailboxSignIn.ps1
+++ b/powershell/public/cis/Test-MtCisSharedMailboxSignIn.ps1
@@ -61,9 +61,9 @@ function Test-MtCisSharedMailboxSignIn {
 
         $testResult = if ($resultCount -eq 0) { $true } else { $false }
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has no shared mailboxes with sign-in enabled:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has no shared mailboxes with sign-in enabled:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant has $(($result | Measure-Object).Count) shared mailboxes with sign-in enabled:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant has $(($result | Measure-Object).Count) shared mailboxes with sign-in enabled:`n`n%testResult%"
         }
 
         $resultMd = "| Shared Mailbox | Sign-in Disabled |`n"
@@ -75,7 +75,7 @@ function Test-MtCisSharedMailboxSignIn {
             }
             $resultMd += "| $($item.displayName) | $($itemResult) |`n"
         }
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cis/Test-MtCisTeamsLobbyBypass.md
+++ b/powershell/public/cis/Test-MtCisTeamsLobbyBypass.md
@@ -33,4 +33,4 @@ Set-CsTeamsMeetingPolicy -Identity Global -AutoAdmittedUsers "EveryoneInCompanyE
 * [CISA MS.TEAMS.1.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/teams.md#msteams14v1)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisTeamsReportSecurityConcerns.md
+++ b/powershell/public/cis/Test-MtCisTeamsReportSecurityConcerns.md
@@ -61,4 +61,4 @@ New-ReportSubmissionRule -Name DefaultReportSubmissionRule -ReportSubmissionPoli
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 420](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisTeamsReportSecurityConcerns.ps1
+++ b/powershell/public/cis/Test-MtCisTeamsReportSecurityConcerns.ps1
@@ -94,12 +94,12 @@ function Test-MtCisTeamsReportSecurityConcerns {
             $result += "| ReportChatMessageToCustomizedAddressEnabled | $($MicrosoftReportPolicy.ReportChatMessageToCustomizedAddressEnabled) | $passResult |`n"
         }
         if ($return) {
-            $testResultMarkdown = "Well done. All report submission policies are configured properly.`n`n%TestResult%"
+            $testResultMarkdown = "Well done. All report submission policies are configured properly.`n`n%testResult%"
         } else {
-            $testResultMarkdown = "All or specific report submission policies are missing proper configuration.`n`n%TestResult%"
+            $testResultMarkdown = "All or specific report submission policies are missing proper configuration.`n`n%testResult%"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $return
     } catch {

--- a/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.md
+++ b/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.md
@@ -44,4 +44,4 @@ To change app permission policies using the UI:
 * [CISA MS.TEAMS.5.3v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/teams.md#msteams53v1)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
+++ b/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
@@ -77,12 +77,12 @@ function Test-MtCisThirdPartyAndCustomApps {
         }
 
         if ($return) {
-            $testResultMarkdown = "Well done. All or a majority of third-party and custom apps are blocked.`n`n%TestResult%"
+            $testResultMarkdown = "Well done. All or a majority of third-party and custom apps are blocked.`n`n%testResult%"
         } else {
-            $testResultMarkdown = "All or a majority of third-party or custom apps are allowed.`n`n%TestResult%"
+            $testResultMarkdown = "All or a majority of third-party or custom apps are allowed.`n`n%testResult%"
         }
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $return
     } catch {

--- a/powershell/public/cis/Test-MtCisThirdPartyFileSharing.md
+++ b/powershell/public/cis/Test-MtCisThirdPartyFileSharing.md
@@ -41,4 +41,4 @@ Set-CsTeamsClientConfiguration @storageParams
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 369](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisThirdPartyFileSharing.ps1
+++ b/powershell/public/cis/Test-MtCisThirdPartyFileSharing.ps1
@@ -46,11 +46,11 @@ function Test-MtCisThirdPartyFileSharing {
         }
 
         if ($return) {
-            $testResultMarkdown = "Well done. All third-party cloud services are disabled.`n`n%TestResult%"
+            $testResultMarkdown = "Well done. All third-party cloud services are disabled.`n`n%testResult%"
         } else {
-            $testResultMarkdown = "All or specific third-party cloud services are enabled.`n`n%TestResult%"
+            $testResultMarkdown = "All or specific third-party cloud services are enabled.`n`n%testResult%"
         }
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $return

--- a/powershell/public/cis/Test-MtCisZAP.md
+++ b/powershell/public/cis/Test-MtCisZAP.md
@@ -16,4 +16,4 @@ To enable Zero-hour auto purge for Microsoft Teams:
 * [CIS Microsoft 365 Foundations Benchmark v5.0.0 - Page 138](https://www.cisecurity.org/benchmark/microsoft_365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cis/Test-MtCisZAP.ps1
+++ b/powershell/public/cis/Test-MtCisZAP.ps1
@@ -33,9 +33,9 @@ function Test-MtCisZAP {
 
         $testResult = ($result | Measure-Object).Count -eq 0
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant has Zero-hour auto purge (ZAP) enabled for Microsoft Teams:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant has Zero-hour auto purge (ZAP) enabled for Microsoft Teams:`n`n%testResult%"
         } else {
-            $testResultMarkdown = "Your tenant does not have Zero-hour auto purge (ZAP) enabled for Microsoft Teams:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant does not have Zero-hour auto purge (ZAP) enabled for Microsoft Teams:`n`n%testResult%"
         }
 
         $resultMd = "| Zero-hour auto purge (ZAP) |`n"
@@ -47,7 +47,7 @@ function Test-MtCisZAP {
         }
         $resultMd += "| $($itemResult) |`n"
 
-        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $resultMd
+        $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $resultMd
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $testResult

--- a/powershell/public/cisa/@template.md
+++ b/powershell/public/cisa/@template.md
@@ -12,4 +12,4 @@ Rationale: ...
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/...rego#)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/@templateps1.txt
+++ b/powershell/public/cisa/@templateps1.txt
@@ -22,7 +22,7 @@ function FunctionName {
     $testResult = $false
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has notifications for role activations:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has notifications for role activations:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have notifications on role activations."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaActivationNotification.md
+++ b/powershell/public/cisa/entra/Test-MtCisaActivationNotification.md
@@ -30,4 +30,4 @@ Rationale: Closely monitor activation of high-risk roles for signs of compromise
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L1057)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaActivationNotification.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaActivationNotification.ps1
@@ -92,9 +92,9 @@ function Test-MtCisaActivationNotification {
     $resultPass = "✅ Pass"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has notifications for [role activations]($link).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has notifications for [role activations]($link).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have notifications on [role activations]($link).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have notifications on [role activations]($link).`n`n%testResult%"
     }
 
     $result = "| Role Name | Result |`n"
@@ -107,7 +107,7 @@ function Test-MtCisaActivationNotification {
         }
         $result += "| $($item.role) | $($itemResult) |`n"
     }
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaAppAdminConsent.md
+++ b/powershell/public/cisa/entra/Test-MtCisaAppAdminConsent.md
@@ -19,4 +19,4 @@ Rationale: Configuring an admin consent workflow reduces the risk of the previou
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L613)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaAppGroupOwnerConsent.md
+++ b/powershell/public/cisa/entra/Test-MtCisaAppGroupOwnerConsent.md
@@ -17,4 +17,4 @@ Rationale: In M365, group owners and team owners can consent to applications acc
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L665)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaAppRegistration.md
+++ b/powershell/public/cisa/entra/Test-MtCisaAppRegistration.md
@@ -15,4 +15,4 @@ Rationale: Application access for the tenant presents a heightened security risk
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L542)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaAppUserConsent.md
+++ b/powershell/public/cisa/entra/Test-MtCisaAppUserConsent.md
@@ -17,4 +17,4 @@ Rationale: Limiting applications consent to only specific privileged users reduc
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L575)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaAssignmentNotification.md
+++ b/powershell/public/cisa/entra/Test-MtCisaAssignmentNotification.md
@@ -25,4 +25,4 @@ Rationale: Closely monitor assignment of the highest privileged roles for signs 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L974)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaAssignmentNotification.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaAssignmentNotification.ps1
@@ -70,7 +70,7 @@ function Test-MtCisaAssignmentNotification {
     $testResult = ($misconfigured|Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has notifications for any highly privileged role assisngments:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has notifications for any highly privileged role assisngments:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant has highly privileged roles without notifications."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaAuthenticatorContext.md
+++ b/powershell/public/cisa/entra/Test-MtCisaAuthenticatorContext.md
@@ -19,4 +19,4 @@ If phishing-resistant MFA has not been deployed yet and Microsoft Authenticator 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L254)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaAuthenticatorContext.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaAuthenticatorContext.ps1
@@ -48,9 +48,9 @@ function Test-MtCisaAuthenticatorContext {
     $link = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods/fromNav/Identity"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has the [Authentication Methods]($link) policy for Microsoft Authenticator set appropriately.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has the [Authentication Methods]($link) policy for Microsoft Authenticator set appropriately.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have the [Authentication Methods]($link) policy for Microsoft Authenticator set appropriately or migration to Authentication Methods is not complete.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have the [Authentication Methods]($link) policy for Microsoft Authenticator set appropriately or migration to Authentication Methods is not complete.`n`n%testResult%"
     }
 
     $resultFail = "❌ Fail"
@@ -61,7 +61,7 @@ function Test-MtCisaAuthenticatorContext {
         $migrationResult = $resultFail
     }
     $result = "[Authentication Methods]($link) Migration Complete: $migrationResult"
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskSignIn.md
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskSignIn.md
@@ -19,4 +19,4 @@ Note: While CISA recommends blocking, the [Microsoft recommendation](https://lea
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L138)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskSignIn.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskSignIn.ps1
@@ -40,7 +40,7 @@ function Test-MtCisaBlockHighRiskSignIn {
     $testResult = ($blockPolicies|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that block high risk sign-ins:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that block high risk sign-ins:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that block high risk sign-ins."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskUser.md
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskUser.md
@@ -19,4 +19,4 @@ Note: While CISA recommends blocking, the [Microsoft recommendation](https://lea
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L85)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskUser.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockHighRiskUser.ps1
@@ -40,7 +40,7 @@ function Test-MtCisaBlockHighRiskUser {
     $testResult = ($blockPolicies|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that block high risk users :`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that block high risk users :`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that block high risk users."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.md
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.md
@@ -14,4 +14,4 @@ Follow the guide below to create a conditional access policy that blocks legacy 
 - [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L47)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaBlockLegacyAuth.ps1
@@ -50,7 +50,7 @@ function Test-MtCisaBlockLegacyAuth {
     $testResult = ($blockPolicies|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Your tenant has one or more policies that block legacy authentication:`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant has one or more policies that block legacy authentication:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant lacks sufficient conditional access policies that block legacy authentication."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.md
+++ b/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.md
@@ -15,4 +15,4 @@ Rationale: Many privileged administrative users do not need unfettered access to
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L833)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaCloudGlobalAdmin.ps1
@@ -52,7 +52,7 @@ function Test-MtCisaCloudGlobalAdmin {
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant has no hybrid Global Administrators."
     } else {
-        $testResultMarkdown = "Your tenant has 1 or more hybrid Global Administrators:`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant has 1 or more hybrid Global Administrators:`n`n%testResult%"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown -GraphObjectType UserRole -GraphObjects $result
 

--- a/powershell/public/cisa/entra/Test-MtCisaCrossTenantInboundDefault.md
+++ b/powershell/public/cisa/entra/Test-MtCisaCrossTenantInboundDefault.md
@@ -20,4 +20,4 @@ Rationale: Limiting which domains can be invited to create guest accounts in the
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L1190)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaCrossTenantInboundDefault.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaCrossTenantInboundDefault.ps1
@@ -31,9 +31,9 @@ function Test-MtCisaCrossTenantInboundDefault {
     }|Measure-Object).Count -eq 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant's default cross-tenant inbound access policy is set to block:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's default cross-tenant inbound access policy is set to block:`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant's default cross-tenant inbound access policy is not set to block:`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's default cross-tenant inbound access policy is not set to block:`n`n%testResult%"
     }
 
     $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/InboundAccessSettings.ReactView/isDefault~/true/name//id/"
@@ -47,7 +47,7 @@ function Test-MtCisaCrossTenantInboundDefault {
         $applications = "[✅ Pass]($portalLink)"
     }
     $result += "| $usersAndGroups | $applications |`n"
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaDiagnosticSettings.md
+++ b/powershell/public/cisa/entra/Test-MtCisaDiagnosticSettings.md
@@ -16,4 +16,4 @@ Follow the configuration instructions unique to the products and integration pat
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L523)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaDiagnosticSettings.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaDiagnosticSettings.ps1
@@ -98,7 +98,7 @@ function Test-MtCisaDiagnosticSettings {
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant has [diagnostic settings]($link) configured for all logs."
     } else {
-        $testResultMarkdown = "Your tenant does not have [diagnostic settings]($link) configured for all logs:`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [diagnostic settings]($link) configured for all logs:`n`n%testResult%"
     }
 
     $result = "| Log Name | Result |`n"
@@ -113,7 +113,7 @@ function Test-MtCisaDiagnosticSettings {
         }
         $result += "| $($item.Log) | $($itemResult) |`n"
     }
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.md
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.md
@@ -21,4 +21,4 @@ When counting the number of users assigned to the Global Administrator role, **c
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L761)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
@@ -42,7 +42,7 @@ function Test-MtCisaGlobalAdminCount {
     $testResult = ($globalAdministrators|Measure-Object).Count -ge 2 -and ($globalAdministrators|Measure-Object).Count -le 8
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has two or more and eight or fewer Global Administrators:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has two or more and eight or fewer Global Administrators:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have the appropriate number of Global Administrators."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminRatio.md
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminRatio.md
@@ -18,4 +18,4 @@ This policy is based on the ratio below:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L792)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminRatio.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminRatio.ps1
@@ -65,13 +65,13 @@ function Test-MtCisaGlobalAdminRatio {
     $link = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/RolesManagementMenuBlade/~/AllRoles"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has more granular [role assignments]($link) than global admin assignments.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has more granular [role assignments]($link) than global admin assignments.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have enough granular [role assignments]($link).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have enough granular [role assignments]($link).`n`n%testResult%"
     }
     $result = "Current Ratio: $([System.Math]::Round($ratio,2)) = $($globalAdministrators.Count) / $($otherAssignments.Count)`n`n"
     $result += "Ratio >= 1 - $($ratio -ge 1)"
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaGuestInvitation.md
+++ b/powershell/public/cisa/entra/Test-MtCisaGuestInvitation.md
@@ -16,4 +16,4 @@ Rationale: By only allowing an authorized group of individuals to invite externa
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L1157)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaGuestUserAccess.md
+++ b/powershell/public/cisa/entra/Test-MtCisaGuestUserAccess.md
@@ -15,4 +15,4 @@ Rationale: Limiting the amount of object information available to guest users in
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L1100)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaManagedDevice.md
+++ b/powershell/public/cisa/entra/Test-MtCisaManagedDevice.md
@@ -21,4 +21,4 @@ Create a conditional access policy requiring a user's device to be either Micros
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L397)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaManagedDevice.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaManagedDevice.ps1
@@ -51,9 +51,9 @@ function Test-MtCisaManagedDevice {
     $testResult = ($policies|Measure-Object).Count -ge 1
 
     if ($testResult -and $SkipHybridJoinCheck) {
-        $testResultMarkdown = "Well done, your security posture is more than CISA's recommended control. Your tenant has one or more policies that require a compliant device:`n`n%TestResult%"
+        $testResultMarkdown = "Well done, your security posture is more than CISA's recommended control. Your tenant has one or more policies that require a compliant device:`n`n%testResult%"
     } elseif ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that require managed devices."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaManagedDeviceRegistration.md
+++ b/powershell/public/cisa/entra/Test-MtCisaManagedDeviceRegistration.md
@@ -21,4 +21,4 @@ Create a conditional access policy requiring a user to be on a managed device wh
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L431)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaManagedDeviceRegistration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaManagedDeviceRegistration.ps1
@@ -51,9 +51,9 @@ function Test-MtCisaManagedDeviceRegistration {
     $testResult = ($policies|Measure-Object).Count -ge 1
 
     if ($testResult -and $SkipHybridJoinCheck) {
-        $testResultMarkdown = "Well done, your security posture is more than CISA's recommended control. Your tenant has one or more policies that require a compliant device for registration:`n`n%TestResult%"
+        $testResultMarkdown = "Well done, your security posture is more than CISA's recommended control. Your tenant has one or more policies that require a compliant device for registration:`n`n%testResult%"
     } elseif ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device for registration:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require a compliant or domain joined device for registration:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that require managed devices for registration."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaMethodsMigration.md
+++ b/powershell/public/cisa/entra/Test-MtCisaMethodsMigration.md
@@ -15,4 +15,4 @@ If phishing-resistant MFA has not been enforced for all users yet, create a cond
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L284)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaMfa.md
+++ b/powershell/public/cisa/entra/Test-MtCisaMfa.md
@@ -16,4 +16,4 @@ If phishing-resistant MFA has not been enforced for all users yet, create a cond
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L214)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaMfa.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaMfa.ps1
@@ -42,7 +42,7 @@ function Test-MtCisaMfa {
     $testResult = ($policies|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require MFA:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require MFA:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that require MFA."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaNotifyHighRisk.md
+++ b/powershell/public/cisa/entra/Test-MtCisaNotifyHighRisk.md
@@ -14,4 +14,4 @@ Follow the guide below to configure Entra ID Protection to send a regularly moni
 - [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L122)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaNotifyHighRisk.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaNotifyHighRisk.ps1
@@ -42,7 +42,7 @@ function Test-MtCisaNotifyHighRisk {
     $testResult = ($notficationRecipients|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more recipients for notifications of risky user logins:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more recipients for notifications of risky user logins:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any recipients for notifications of risky user logins."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.md
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.md
@@ -17,4 +17,4 @@ Configure password policies to set passwords to never expire.
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L723)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPasswordExpiration.ps1
@@ -43,9 +43,9 @@ function Test-MtCisaPasswordExpiration {
     $testResult = ($managedDomains | Measure-Object).Count - ($compliantDomains | Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant password expiration policy is set to never expire.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have password expiration set to never expire.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have password expiration set to never expire.`n`n%testResult%"
     }
 
     $pass = "✅ Pass"
@@ -79,7 +79,7 @@ function Test-MtCisaPasswordExpiration {
         $resultDetails += "| $isDefault | $isVerified | $($domain.authenticationType) | $testValue |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $resultDetails
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $resultDetails
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaPermanentRoleAssignment.md
+++ b/powershell/public/cisa/entra/Test-MtCisaPermanentRoleAssignment.md
@@ -23,4 +23,4 @@ Note: Exceptions to this policy are:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L856)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaPermanentRoleAssignment.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPermanentRoleAssignment.ps1
@@ -58,7 +58,7 @@ function Test-MtCisaPermanentRoleAssignment {
     $testResult = ($roleAssignments.principal|Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has no active assignments without expiration to privileged roles:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has no active assignments without expiration to privileged roles:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant has active assignments without expiration to privileged roles."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaPhishResistant.md
+++ b/powershell/public/cisa/entra/Test-MtCisaPhishResistant.md
@@ -16,4 +16,4 @@ Create a conditional access policy enforcing phishing-resistant MFA for all user
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L181)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaPhishResistant.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPhishResistant.ps1
@@ -39,7 +39,7 @@ function Test-MtCisaPhishResistant {
     $testResult = ($policies|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require Phishing Resistant Authentication Strengths :`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require Phishing Resistant Authentication Strengths :`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that require Phishing Resistant Authentication Strengths."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaPrivilegedPhishResistant.md
+++ b/powershell/public/cisa/entra/Test-MtCisaPrivilegedPhishResistant.md
@@ -22,4 +22,4 @@ Create a conditional access policy enforcing phishing-resistant MFA for highly p
 * [CISA ScubaGear Highly Privileged Roles](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#highly-privileged-roles)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaPrivilegedPhishResistant.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaPrivilegedPhishResistant.ps1
@@ -42,7 +42,7 @@ function Test-MtCisaPrivilegedPhishResistant {
     $testResult = ($policies|Measure-Object).Count -ge 1
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has one or more policies that require phishing resistant MFA for highly privileged users:`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has one or more policies that require phishing resistant MFA for highly privileged users:`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not have any conditional access policies that require phishing resistant MFA for highly privileged users."
     }

--- a/powershell/public/cisa/entra/Test-MtCisaRequireActivationApproval.md
+++ b/powershell/public/cisa/entra/Test-MtCisaRequireActivationApproval.md
@@ -21,4 +21,4 @@ Rationale: Requiring approval for a user to activate Global Administrator, which
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L938)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaUnmanagedRoleAssignment.md
+++ b/powershell/public/cisa/entra/Test-MtCisaUnmanagedRoleAssignment.md
@@ -19,4 +19,4 @@ Rationale: Provisioning users to privileged roles within a PAM system enables en
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L907)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaUnmanagedRoleAssignment.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaUnmanagedRoleAssignment.ps1
@@ -61,7 +61,7 @@ function Test-MtCisaUnmanagedRoleAssignment {
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant has no unmanaged active role assignments."
     } else {
-        $testResultMarkdown = "Your tenant has active assignments without a start date:`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant has active assignments without a start date:`n`n%testResult%"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/entra/Test-MtCisaWeakFactor.md
+++ b/powershell/public/cisa/entra/Test-MtCisaWeakFactor.md
@@ -16,4 +16,4 @@ If phishing-resistant MFA has not been deployed yet and Microsoft Authenticator 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/AADConfig.rego#L307)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/entra/Test-MtCisaWeakFactor.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaWeakFactor.ps1
@@ -44,9 +44,9 @@ function Test-MtCisaWeakFactor {
     $testResult = (($enabledWeakMethods|Measure-Object).Count -eq 0)
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. All weak authentication methods are disabled in your tenant.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. All weak authentication methods are disabled in your tenant.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "One or more weak methods are enabled in your tenant, or migration to Authentication Methods is incomplete.`n`n%TestResult%"
+        $testResultMarkdown = "One or more weak methods are enabled in your tenant, or migration to Authentication Methods is incomplete.`n`n%testResult%"
     }
 
     # Auth method does not support deep links.
@@ -61,7 +61,7 @@ function Test-MtCisaWeakFactor {
         }
         $result += "| [$($item.id)]($authMethodsLink) | $($item.state) | $($methodResult) |`n"
     }
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaAntiSpamAllowList.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAntiSpamAllowList.md
@@ -20,4 +20,4 @@ To modify the connection filters, follow the instructions found in Use the Micro
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L683)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAntiSpamAllowList.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAntiSpamAllowList.ps1
@@ -36,7 +36,7 @@ function Test-MtCisaAntiSpamAllowList {
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant does not have any [Anti-spam IP allow lists]($portalLink)."
     } else {
-        $testResultMarkdown = "Your tenant has [Anti-spam IP allow lists]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant has [Anti-spam IP allow lists]($portalLink).`n`n%testResult%"
         $resultPolicy | ForEach-Object {
             $result = "* $($_.Name)`n"
             $_.IPAllowList | ForEach-Object {`
@@ -45,7 +45,7 @@ function Test-MtCisaAntiSpamAllowList {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaAntiSpamSafeList.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAntiSpamSafeList.md
@@ -20,4 +20,4 @@ To modify the connection filters, follow the instructions found in Use the Micro
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L710)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAntiSpamSafeList.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAntiSpamSafeList.ps1
@@ -39,7 +39,7 @@ function Test-MtCisaAntiSpamSafeList {
         $testResultMarkdown = "[Safe List]($portalLink) is enabled in your tenant."
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaAttachmentFileType.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAttachmentFileType.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - True type matching in the common attachments filter](https://learn.microsoft.com/en-us/defender-office-365/anti-malware-protection-about#true-type-matching-in-the-common-attachments-filter)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAttachmentFileType.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAttachmentFileType.ps1
@@ -47,9 +47,9 @@ function Test-MtCisaAttachmentFileType {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -75,7 +75,7 @@ function Test-MtCisaAttachmentFileType {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaAttachmentFilter.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAttachmentFilter.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Common attachments filter in anti-malware policies](https://learn.microsoft.com/en-us/defender-office-365/anti-malware-protection-about#common-attachments-filter-in-anti-malware-policies)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAttachmentFilter.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAttachmentFilter.ps1
@@ -48,9 +48,9 @@ function Test-MtCisaAttachmentFilter {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -78,7 +78,7 @@ function Test-MtCisaAttachmentFilter {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaAuditLog.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAuditLog.md
@@ -17,4 +17,4 @@ To enable auditing via the Microsoft Purview compliance portal:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L898)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAuditLogPremium.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAuditLogPremium.md
@@ -15,4 +15,4 @@ To set up Microsoft Purview Audit (Premium), see [Set up Microsoft Purview Audit
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L913)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAuditLogPremium.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAuditLogPremium.ps1
@@ -46,9 +46,9 @@ function Test-MtCisaAuditLogPremium {
     # $failResult = "❌ Fail"
 
     # if ($testResult) {
-    #     $testResultMarkdown = "Well done. Your tenant has [SearchQueryInitiated audit log enabled]($portalLink).`n`n%TestResult%"
+    #     $testResultMarkdown = "Well done. Your tenant has [SearchQueryInitiated audit log enabled]($portalLink).`n`n%testResult%"
     # } else {
-    #     $testResultMarkdown = "Your tenant does not have [SearchQueryInitiated audit log enabled]($portalLink).`n`n%TestResult%"
+    #     $testResultMarkdown = "Your tenant does not have [SearchQueryInitiated audit log enabled]($portalLink).`n`n%testResult%"
     # }
 
     # $result = "| Mailbox | SearchQueryInitiated |`n"
@@ -61,7 +61,7 @@ function Test-MtCisaAuditLogPremium {
     #     }
     # }
 
-    # $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    # $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     # Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaAuditLogRetention.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAuditLogRetention.md
@@ -13,4 +13,4 @@ To create one or more custom audit retention policies, if the default retention 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L928)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAutoExternalForwarding.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaAutoExternalForwarding.md
@@ -20,4 +20,4 @@ To disable automatic forwarding to external domains:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L28)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaAutoExternalForwarding.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaAutoExternalForwarding.ps1
@@ -32,9 +32,9 @@ function Test-MtCisaAutoExternalForwarding {
     $testResult = ($forwardingDomains | Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [automatic forwarding](https://admin.exchange.microsoft.com/#/remotedomains) disabled for all domains.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [automatic forwarding](https://admin.exchange.microsoft.com/#/remotedomains) disabled for all domains.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [automatic forwarding](https://admin.exchange.microsoft.com/#/remotedomains) disabled for all domains.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [automatic forwarding](https://admin.exchange.microsoft.com/#/remotedomains) disabled for all domains.`n`n%testResult%"
     }
 
     # Remote domain does not support deep link
@@ -50,7 +50,7 @@ function Test-MtCisaAutoExternalForwarding {
         }
         $result += "| [$($item.Name)]($portalLink) | $($item.DomainName) | $($itemState) | $($itemResult) |`n"
     }
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaBlockExecutable.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaBlockExecutable.md
@@ -20,4 +20,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L547)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaBlockExecutable.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaBlockExecutable.ps1
@@ -70,9 +70,9 @@ function Test-MtCisaBlockExecutable {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -99,7 +99,7 @@ function Test-MtCisaBlockExecutable {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaBlockFileType.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaBlockFileType.md
@@ -20,4 +20,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L517)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaCalendarSharing.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaCalendarSharing.md
@@ -19,4 +19,4 @@ To restrict sharing with all domains:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L368)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaCalendarSharing.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaCalendarSharing.ps1
@@ -34,9 +34,9 @@ function Test-MtCisaCalendarSharing {
     $testResult = ($resultPolicies|Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant does not allow uncontrolled calendar sharing.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant does not allow uncontrolled calendar sharing.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant allows uncontrolled calendar sharing.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant allows uncontrolled calendar sharing.`n`n%testResult%"
     }
 
     $result = "| Policy Name | Test Result |`n"
@@ -49,7 +49,7 @@ function Test-MtCisaCalendarSharing {
         }
         $result += "| [$($item.Name)]($portalLink) | $($itemResult) |`n"
     }
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaContactSharing.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaContactSharing.md
@@ -18,4 +18,4 @@ To restrict sharing with all domains:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L335)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaContactSharing.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaContactSharing.ps1
@@ -34,9 +34,9 @@ function Test-MtCisaContactSharing {
     $testResult = ($resultPolicies|Measure-Object).Count -eq 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant does not allow uncontrolled contact sharing.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant does not allow uncontrolled contact sharing.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant allows uncontrolled contact sharing.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant allows uncontrolled contact sharing.`n`n%testResult%"
     }
 
     $result = "| Policy Name | Test Result |`n"
@@ -49,7 +49,7 @@ function Test-MtCisaContactSharing {
         }
         $result += "| [$($item.Name)]($portalLink) | $($itemResult) |`n"
     }
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDkim.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDkim.md
@@ -13,4 +13,4 @@ To enable DKIM, follow the instructions listed on [Steps to Create, enable and d
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L107)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
@@ -88,9 +88,9 @@ function Test-MtCisaDkim {
     $portalLink = "https://security.microsoft.com/authentication?viewid=DKIM"
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's domains have DKIM configured and valid records exist.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's domains have DKIM configured and valid records exist.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's domains do not have DKIM fully deployed. Review [EXO configuration]($portalLink) and DNS records.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's domains do not have DKIM fully deployed. Review [EXO configuration]($portalLink) and DNS records.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -107,7 +107,7 @@ function Test-MtCisaDkim {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDlp.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlp.md
@@ -41,4 +41,4 @@ Rationale: Users may inadvertently disclose sensitive information to unauthorize
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L439)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDlp.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlp.ps1
@@ -42,9 +42,9 @@ function Test-MtCisaDlp {
     $portalLink = "https://purview.microsoft.com/datalossprevention/policies"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [Purview Data Loss Prevention Policies]($portalLink) enabled.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [Purview Data Loss Prevention Policies]($portalLink) enabled.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [Purview Data Loss Prevention Policies]($portalLink) enabled.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [Purview Data Loss Prevention Policies]($portalLink) enabled.`n`n%testResult%"
     }
 
     if ($policies) {
@@ -61,7 +61,7 @@ function Test-MtCisaDlp {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDlpAlternate.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlpAlternate.md
@@ -11,4 +11,4 @@ Rationale: Any alternative DLP solution should be able to detect sensitive infor
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L453)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDlpBaselineRule.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlpBaselineRule.md
@@ -43,4 +43,4 @@ Rationale: Users may inadvertently share sensitive information with others who s
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L468)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDlpBaselineRule.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlpBaselineRule.ps1
@@ -69,9 +69,9 @@ function Test-MtCisaDlpBaselineRule {
     $portalLink = "https://purview.microsoft.com/datalossprevention/policies"
 
     if ($resultComposite) {
-        $testResultMarkdown = "Well done. Your tenant has [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -91,7 +91,7 @@ function Test-MtCisaDlpBaselineRule {
         $result += "| $($itemResult) | $($item.ParentPolicyName) | $($item.Name) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDlpPii.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlpPii.md
@@ -43,4 +43,4 @@ Rationale: Users may inadvertently share sensitive information with others who s
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L438)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDlpPii.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDlpPii.ps1
@@ -56,9 +56,9 @@ function Test-MtCisaDlpPii {
     $portalLink = "https://purview.microsoft.com/datalossprevention/policies"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of All Full Names.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of All Full Names.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of All Full Names.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [Purview Data Loss Prevention Policies]($portalLink) enabled with the Sensitive Info Type of All Full Names.`n`n%testResult%"
     }
 
     if ($rules) {
@@ -75,7 +75,7 @@ function Test-MtCisaDlpPii {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcAggregateCisa.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcAggregateCisa.md
@@ -18,4 +18,4 @@ Rationale: Email spoofing attempts are not inherently visible to domain owners. 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L207)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcAggregateCisa.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcAggregateCisa.ps1
@@ -106,9 +106,9 @@ function Test-MtCisaDmarcAggregateCisa {
     }
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's domains have DMARC aggregate reports sent to CISA.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's domains have DMARC aggregate reports sent to CISA.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's domains do not have DMARC aggregate reports sent to CISA.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's domains do not have DMARC aggregate reports sent to CISA.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -132,7 +132,7 @@ function Test-MtCisaDmarcAggregateCisa {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) | $($aggregates) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordExist.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordExist.md
@@ -21,4 +21,4 @@ If DMARC is configured, a response resembling `v=DMARC1; p=reject; pct=100; rua=
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L147)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordExist.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordExist.ps1
@@ -93,9 +93,9 @@ function Test-MtCisaDmarcRecordExist {
     }
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's second level domains have a DMARC record. Review report targets.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's second level domains have a DMARC record. Review report targets.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's second level domains do not have a DMARC record.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's second level domains do not have a DMARC record.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -136,7 +136,7 @@ function Test-MtCisaDmarcRecordExist {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) | Forensic Reports: $($forensics) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.md
@@ -14,4 +14,4 @@ Rationale: Of the three policy options (i.e., none, quarantine, and reject), rej
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L176)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
@@ -88,9 +88,9 @@ function Test-MtCisaDmarcRecordReject {
     }
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's domains have a DMARC record with reject policy. Review report targets.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's domains have a DMARC record with reject policy. Review report targets.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's domains do not have a DMARC record with reject policy.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's domains do not have a DMARC record with reject policy.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -106,7 +106,7 @@ function Test-MtCisaDmarcRecordReject {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) | $($item.dmarcRecord.policy) | $($item.dmarcRecord.policySubdomain) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcReport.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcReport.md
@@ -17,4 +17,4 @@ See MS.EXO.4.1v1 Instructions for an overview of how to publish and check a DMAR
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L252)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcReport.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcReport.ps1
@@ -91,9 +91,9 @@ function Test-MtCisaDmarcReport {
     }
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's domains have in domain report targets. Review report targets.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's domains have in domain report targets. Review report targets.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's second level domains do not have in domain report targets.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's second level domains do not have in domain report targets.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -126,7 +126,7 @@ function Test-MtCisaDmarcReport {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) | Forensic Reports: $($forensics) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaEmailFilterAlternative.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaEmailFilterAlternative.md
@@ -22,4 +22,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L532)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaExoAlert.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaExoAlert.md
@@ -32,4 +32,4 @@ Rationale: Potentially malicious or service impacting events may go undetected w
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L863)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaExoAlert.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaExoAlert.ps1
@@ -55,9 +55,9 @@ function Test-MtCisaExoAlert {
     $failResult = '❌ Fail'
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [alerts configured]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [alerts configured]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have all [alerts configured]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have all [alerts configured]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Alert Name | Alert Result |`n"
@@ -70,7 +70,7 @@ function Test-MtCisaExoAlert {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+    $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaExoAlertSiem.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaExoAlertSiem.md
@@ -20,4 +20,4 @@ Rationale: Suspicious or malicious events, if not resolved promptly, may have a 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L878)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaExternalSenderWarning.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaExternalSenderWarning.md
@@ -45,4 +45,4 @@ To create a mail flow rule to produce external sender warnings:
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L405)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaExternalSenderWarning.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaExternalSenderWarning.ps1
@@ -43,9 +43,9 @@ function Test-MtCisaExternalSenderWarning {
     }
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has an external sender warning.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has an external sender warning.`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have an external sender warning.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have an external sender warning.`n`n%testResult%"
     }
 
     if ($rules) {
@@ -75,7 +75,7 @@ function Test-MtCisaExternalSenderWarning {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaImpersonation.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaImpersonation.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Impersonation settings in anti-phishing policies in Microsoft Defender for Office 365](https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about#impersonation-settings-in-anti-phishing-policies-in-microsoft-defender-for-office-365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaImpersonation.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaImpersonation.ps1
@@ -54,9 +54,9 @@ function Test-MtCisaImpersonation {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -82,7 +82,7 @@ function Test-MtCisaImpersonation {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaImpersonationTip.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaImpersonationTip.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Impersonation settings in anti-phishing policies in Microsoft Defender for Office 365](https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about#impersonation-settings-in-anti-phishing-policies-in-microsoft-defender-for-office-365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaImpersonationTip.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaImpersonationTip.ps1
@@ -53,9 +53,9 @@ function Test-MtCisaImpersonationTip {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -81,7 +81,7 @@ function Test-MtCisaImpersonationTip {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaMailboxAuditing.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaMailboxAuditing.md
@@ -17,4 +17,4 @@ Mailbox auditing can be managed from the [Exchange Online PowerShell module](htt
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L741)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaMailboxAuditing.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaMailboxAuditing.ps1
@@ -28,14 +28,14 @@ function Test-MtCisaMailboxAuditing {
     $testResult = (-not $config.AuditDisabled)
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has mailbox auditing enabled.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has mailbox auditing enabled.`n`n%testResult%"
         $result = "✅ Pass"
     } else {
-        $testResultMarkdown = "Your tenant does not have mailbox auditing enabled.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have mailbox auditing enabled.`n`n%testResult%"
         $result = "❌ Fail"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaMailboxIntelligence.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaMailboxIntelligence.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Mailbox intelligence impersonation protection](https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about#mailbox-intelligence-impersonation-protection)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaMailboxIntelligence.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaMailboxIntelligence.ps1
@@ -52,9 +52,9 @@ function Test-MtCisaMailboxIntelligence {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -80,7 +80,7 @@ function Test-MtCisaMailboxIntelligence {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaMalwareAction.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaMalwareAction.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Anatomy of a quarantine policy](https://learn.microsoft.com/en-us/defender-office-365/quarantine-policies#anatomy-of-a-quarantine-policy)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaMalwareAction.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaMalwareAction.ps1
@@ -47,9 +47,9 @@ function Test-MtCisaMalwareAction {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -75,7 +75,7 @@ function Test-MtCisaMalwareAction {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaMalwareScan.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaMalwareScan.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Common attachments filter in anti-malware policies](https://learn.microsoft.com/en-us/defender-office-365/anti-malware-protection-about#common-attachments-filter-in-anti-malware-policies)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaMalwareZap.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaMalwareZap.md
@@ -21,4 +21,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [Microsoft Learn - Zero-hour auto purge (ZAP) for malware](https://learn.microsoft.com/en-us/defender-office-365/zero-hour-auto-purge#zero-hour-auto-purge-zap-for-email-messages)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaMalwareZap.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaMalwareZap.ps1
@@ -47,9 +47,9 @@ function Test-MtCisaMalwareZap {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies for the common file filter]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies enabled]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -75,7 +75,7 @@ function Test-MtCisaMalwareZap {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSafeLink.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSafeLink.md
@@ -22,4 +22,4 @@ Rationale: Users may be directed to malicious websites via links in email. Block
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L813)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSafeLink.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSafeLink.ps1
@@ -50,9 +50,9 @@ function Test-MtCisaSafeLink {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -78,7 +78,7 @@ function Test-MtCisaSafeLink {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSafeLinkClickTracking.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSafeLinkClickTracking.md
@@ -22,4 +22,4 @@ Rationale: Users may click on malicious links in emails, leading to compromise o
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L843)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSafeLinkClickTracking.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSafeLinkClickTracking.ps1
@@ -50,9 +50,9 @@ function Test-MtCisaSafeLinkClickTracking {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -78,7 +78,7 @@ function Test-MtCisaSafeLinkClickTracking {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSafeLinkDownloadScan.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSafeLinkDownloadScan.md
@@ -22,4 +22,4 @@ Rationale: URLs in emails may direct users to download and run malware. Scanning
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L828)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSafeLinkDownloadScan.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSafeLinkDownloadScan.ps1
@@ -50,9 +50,9 @@ function Test-MtCisaSafeLinkDownloadScan {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -78,7 +78,7 @@ function Test-MtCisaSafeLinkDownloadScan {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSmtpAuthentication.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSmtpAuthentication.md
@@ -16,4 +16,4 @@ Rationale: SMTP AUTH is not used or needed by modern email clients. Therefore, d
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L306)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamAction.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamAction.md
@@ -20,4 +20,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L768)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamAction.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamAction.ps1
@@ -48,9 +48,9 @@ function Test-MtCisaSpamAction {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -82,7 +82,7 @@ function Test-MtCisaSpamAction {
         $result += "| $($item.Identity) | $resultSpamAction | $resultHighConfidenceSpamAction |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamAlternative.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamAlternative.md
@@ -20,4 +20,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L794)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamBypass.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamBypass.md
@@ -20,4 +20,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L783)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamBypass.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamBypass.ps1
@@ -47,9 +47,9 @@ function Test-MtCisaSpamBypass {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -75,7 +75,7 @@ function Test-MtCisaSpamBypass {
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamFilter.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamFilter.md
@@ -20,4 +20,4 @@ Note: If the toggle slider in step 5 is grayed out, click on **Manage protection
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L753)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpamFilter.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpamFilter.ps1
@@ -43,9 +43,9 @@ function Test-MtCisaSpamFilter {
     $failResult = "❌ Fail"
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant has [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     } else {
-        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not have [standard and strict preset security policies]($portalLink).`n`n%testResult%"
     }
 
     $result = "| Policy | Status |`n"
@@ -67,7 +67,7 @@ function Test-MtCisaSpamFilter {
         $result += "| $($item.Identity) | $($item.SpamAction) | $($item.HighConfidenceSpamAction) | $($item.BulkSpamAction) | $($item.PhishSpamAction) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.md
@@ -22,4 +22,4 @@ If SPF is configured, you will see a response resembling `v=spf1 include:spf.pro
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L75)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfDirective.ps1
@@ -79,9 +79,9 @@ function Test-MtCisaSpfDirective {
     }
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's domains have at least 1 directives with specific mechanism targets, review authorized senders for accuracy.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's domains have at least 1 directives with specific mechanism targets, review authorized senders for accuracy.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's domains do not restrict authorized senders with SPF fully. Ensure authorized senders are specified.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's domains do not restrict authorized senders with SPF fully. Ensure authorized senders are specified.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -119,7 +119,7 @@ function Test-MtCisaSpfDirective {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) | $($itemList) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfRestriction.md
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfRestriction.md
@@ -15,4 +15,4 @@ Rationale: Failing to maintain an accurate list of authorized IP addresses may r
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/EXOConfig.rego#L58)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/exchange/Test-MtCisaSpfRestriction.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaSpfRestriction.ps1
@@ -67,9 +67,9 @@ function Test-MtCisaSpfRestriction {
     }
 
     if($testResult){
-        $testResultMarkdown = "Well done. Your tenant's domains have a restricted SPF, review authorized senders for accuracy.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant's domains have a restricted SPF, review authorized senders for accuracy.`n`n%testResult%"
     }else{
-        $testResultMarkdown = "Your tenant's domains do not restrict authorized senders with SPF fully. Ensure all domain's SPF records end in '-all'.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant's domains do not restrict authorized senders with SPF fully. Ensure all domain's SPF records end in '-all'.`n`n%testResult%"
     }
 
     $passResult = "✅ Pass"
@@ -104,7 +104,7 @@ function Test-MtCisaSpfRestriction {
         $result += "| $($item.domain) | $($itemResult) | $($item.reason) | $($itemAddressList) |`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/spo/Test-MtCisaSpoSharing.md
+++ b/powershell/public/cisa/spo/Test-MtCisaSpoSharing.md
@@ -18,4 +18,4 @@ Rationale: Sharing information outside the organization via SharePoint increases
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/SharepointConfig.rego#L68)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/spo/Test-MtCisaSpoSharing.ps1
+++ b/powershell/public/cisa/spo/Test-MtCisaSpoSharing.ps1
@@ -29,14 +29,14 @@ function Test-MtCisaSpoSharing {
     if ($testResult) {
         $testResultMarkdown = "Well done. Your tenant restricts SharePoint Online sharing."
     } else {
-        $testResultMarkdown = "Your tenant does not restrict SharePoint Online sharing.`n`n%TestResult%"
+        $testResultMarkdown = "Your tenant does not restrict SharePoint Online sharing.`n`n%testResult%"
         $policy | ForEach-Object {
             $result = "* $($_.sharingCapability)`n"
             $result | Out-Null
         }
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/cisa/spo/Test-MtCisaSpoSharingAllowedDomain.md
+++ b/powershell/public/cisa/spo/Test-MtCisaSpoSharingAllowedDomain.md
@@ -21,4 +21,4 @@ This policy is only applicable if the external sharing slider on the admin page 
 * [CISA ScubaGear Rego Reference](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Rego/SharepointConfig.rego#L130)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/cisa/spo/Test-MtCisaSpoSharingAllowedDomain.ps1
+++ b/powershell/public/cisa/spo/Test-MtCisaSpoSharingAllowedDomain.ps1
@@ -30,7 +30,7 @@ function Test-MtCisaSpoSharingAllowedDomain {
     $testResult = ($resultPolicy | Measure-Object).Count -gt 0
 
     if ($testResult) {
-        $testResultMarkdown = "Well done. Your tenant restricts SharePoint Online sharing to specific domains.`n`n%TestResult%"
+        $testResultMarkdown = "Well done. Your tenant restricts SharePoint Online sharing to specific domains.`n`n%testResult%"
     } else {
         $testResultMarkdown = "Your tenant does not restrict SharePoint Online sharing to specific domains."
     }
@@ -40,7 +40,7 @@ function Test-MtCisaSpoSharingAllowedDomain {
         $result | Out-Null
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $result
+    $testResultMarkdown = $testResultMarkdown -replace "%testResult%", $result
 
     Add-MtTestResultDetail -Result $testResultMarkdown
 

--- a/powershell/public/maester/azure/Test-MtManagementGroupWriteRequirement.md
+++ b/powershell/public/maester/azure/Test-MtManagementGroupWriteRequirement.md
@@ -18,4 +18,4 @@ To enable the requirement for write permissions:
 * [Organize your resources with management groups](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview)
 
 <!--- Results --->  
-%TestResult%
+%testResult%

--- a/powershell/public/maester/azure/Test-MtUserAccessAdmin.md
+++ b/powershell/public/maester/azure/Test-MtUserAccessAdmin.md
@@ -26,4 +26,4 @@ az role assignment delete --role "User Access Administrator" --assignee adminnam
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtAppRegistrationOwnersWithoutMFA.md
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationOwnersWithoutMFA.md
@@ -19,4 +19,4 @@ App registration owners have powerful permissions that attackers actively target
 Register MFA for all app registration owners listed. Use conditional access policies to enforce MFA for all application owners.
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.md
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.md
@@ -6,4 +6,4 @@ Open all app registrations below and remove the secrets.
 
 <!--- Results --->
 
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
+++ b/powershell/public/maester/entra/Test-MtAppRegistrationsWithSecrets.ps1
@@ -33,7 +33,7 @@ function Test-MtAppRegistrationsWithSecrets {
         if ($return) {
             $testResultMarkdown = 'Well done. No app registrations using secrets.'
         } else {
-            $testResultMarkdown = "You have $($apps.Count) app registrations that still use secrets.`n`n%TestResult%"
+            $testResultMarkdown = "You have $($apps.Count) app registrations that still use secrets.`n`n%testResult%"
 
             Write-Verbose "Found $($apps.Count) app registrations using secrets."
             Write-Verbose 'Creating markdown table for app registrations using secrets.'
@@ -45,7 +45,7 @@ function Test-MtAppRegistrationsWithSecrets {
                 $result += "| $($appMdLink) | $($app.appId) |`n"
                 Write-Verbose "Adding app registration $($app.displayName) with id $($app.appId) to markdown table."
             }
-            $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+            $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
         }
 
         Add-MtTestResultDetail -Result $testResultMarkdown

--- a/powershell/public/maester/entra/Test-MtCaDeviceCodeFlow.md
+++ b/powershell/public/maester/entra/Test-MtCaDeviceCodeFlow.md
@@ -15,4 +15,4 @@ Configure a Conditional Access policy to block the Device Code authentication fl
 
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaDeviceCodeFlow.ps1
+++ b/powershell/public/maester/entra/Test-MtCaDeviceCodeFlow.ps1
@@ -43,10 +43,10 @@ function Test-MtCaDeviceCodeFlow {
         }
 
         if ( $result ) {
-            $testResult = "Well done! The following conditional access policies sufficiently cover Device Code authentication flow:`n`n%TestResult%"
+            $testResult = "Well done! The following conditional access policies sufficiently cover Device Code authentication flow:`n`n%testResult%"
         } elseif ( $policies ) {
             $policiesResult = $policies
-            $testResult = "None of the following conditional access policies sufficiently cover Device Code authentication flow:`n`n%TestResult%"
+            $testResult = "None of the following conditional access policies sufficiently cover Device Code authentication flow:`n`n%testResult%"
         } else {
             $testResult = 'No conditional access policy found that targets the Device Code authentication flow.'
         }

--- a/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.md
+++ b/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.md
@@ -4,4 +4,4 @@ This allows for emergency access to the tenant in case of a misconfiguration or 
 See [Manage emergency access accounts in Microsoft Entra ID - Microsoft Learn](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
+++ b/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
@@ -70,7 +70,7 @@ function Test-MtCaEmergencyAccessExists {
             }
         }
 
-        $testResult += "These conditional access policies don't have the emergency access $EmergencyAccessUUIDType excluded:`n`n%TestResult%"
+        $testResult += "These conditional access policies don't have the emergency access $EmergencyAccessUUIDType excluded:`n`n%testResult%"
         Add-MtTestResultDetail -GraphObjects $policiesWithoutEmergency -GraphObjectType ConditionalAccess -Result $testResult
         return $result
     } catch {

--- a/powershell/public/maester/entra/Test-MtCaMfaForAdmin.md
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAdmin.md
@@ -20,4 +20,4 @@ See [Require MFA for administrators - Microsoft Learn](https://learn.microsoft.c
 
 <!--- Results --->
 
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaMfaForAdmin.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAdmin.ps1
@@ -76,7 +76,7 @@ function Test-MtCaMfaForAdmin {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies require multi-factor authentication for admins:`n`n%TestResult%"
+            $testResult = "The following conditional access policies require multi-factor authentication for admins:`n`n%testResult%"
         } else {
             $testResult = 'No conditional access policy requires multi-factor authentication for all admin roles.'
         }

--- a/powershell/public/maester/entra/Test-MtCaMfaForAdminManagement.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAdminManagement.ps1
@@ -76,7 +76,7 @@ See [Require MFA for administrators - Microsoft Learn](https://learn.microsoft.c
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies require multi-factor authentication for azure management:`n`n%TestResult%"
+            $testResult = "The following conditional access policies require multi-factor authentication for azure management:`n`n%testResult%"
         } else {
             $testResult = 'No conditional access policy requires multi-factor authentication for azure management resources.'
         }

--- a/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.md
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.md
@@ -2,4 +2,4 @@ This test checks if the tenant has at least one conditional access policy requir
 
 See [Require MFA for all users - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-all-users-mfa)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.ps1
@@ -52,7 +52,7 @@ function Test-MtCaMfaForAllUsers {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies require multi-factor authentication for all users:`n`n%TestResult%"
+            $testResult = "The following conditional access policies require multi-factor authentication for all users:`n`n%testResult%"
         } else {
             $testResult = 'No conditional access policy requires multi-factor authentication for all users.'
         }

--- a/powershell/public/maester/entra/Test-MtCaMfaForGuest.md
+++ b/powershell/public/maester/entra/Test-MtCaMfaForGuest.md
@@ -2,4 +2,4 @@ This check verifies if there is at least one conditional access policy that requ
 
 See [Require multifactor authentication for guest access - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-policy-guest-mfa)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaMfaForGuest.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForGuest.ps1
@@ -61,7 +61,7 @@ function Test-MtCaMfaForGuest {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies require multi-factor authentication for guest accounts:`n`n%TestResult%"
+            $testResult = "The following conditional access policies require multi-factor authentication for guest accounts:`n`n%testResult%"
         } else {
             $testResult = "No conditional access policy requires multi-factor authentication for guest accounts."
         }

--- a/powershell/public/maester/entra/Test-MtCaMfaForRiskySignIn.md
+++ b/powershell/public/maester/entra/Test-MtCaMfaForRiskySignIn.md
@@ -2,4 +2,4 @@ Checks if the tenant has at least one conditional access policy requiring multif
 
 See [Sign-in risk-based multifactor authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-risk)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaMfaForRiskySignIn.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForRiskySignIn.ps1
@@ -52,7 +52,7 @@ function Test-MtCaMfaForRiskySignIn {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies require multi-factor authentication for risky sign-ins`n`n%TestResult%"
+            $testResult = "The following conditional access policies require multi-factor authentication for risky sign-ins`n`n%testResult%"
         } else {
             $testResult = "No conditional access policy requires multi-factor authentication for risky sign-ins."
         }

--- a/powershell/public/maester/entra/Test-MtCaMisconfiguredIDProtection.md
+++ b/powershell/public/maester/entra/Test-MtCaMisconfiguredIDProtection.md
@@ -7,4 +7,4 @@ This means if only one type of risk is present (eg Sign-in risk = High, User ris
 
 See [Sign-in risk-based multifactor authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-risk)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaMisconfiguredIDProtection.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMisconfiguredIDProtection.ps1
@@ -52,7 +52,7 @@ function Test-MtCaMisconfiguredIDProtection {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies have both sign-in risk and user risk controls configured:`n`n%TestResult%"
+            $testResult = "The following conditional access policies have both sign-in risk and user risk controls configured:`n`n%testResult%"
         } else {
             $testResult = 'Well done! No conditional access policies detected where sign-in risk and user risk are combined.'
         }

--- a/powershell/public/maester/entra/Test-MtCaReferencedGroupsExist.md
+++ b/powershell/public/maester/entra/Test-MtCaReferencedGroupsExist.md
@@ -12,4 +12,4 @@ To fix this issue:
 
 <!--- Results --->
 
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaRequirePasswordChangeForHighUserRisk.md
+++ b/powershell/public/maester/entra/Test-MtCaRequirePasswordChangeForHighUserRisk.md
@@ -2,4 +2,4 @@ Checks if the tenant has at least one conditional access policy requiring passwo
 
 See [User risk-based password change - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-risk-user)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaRequirePasswordChangeForHighUserRisk.ps1
+++ b/powershell/public/maester/entra/Test-MtCaRequirePasswordChangeForHighUserRisk.ps1
@@ -48,7 +48,7 @@ function Test-MtCaRequirePasswordChangeForHighUserRisk {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies require password change for risky users`n`n%TestResult%"
+            $testResult = "The following conditional access policies require password change for risky users`n`n%testResult%"
         } else {
             $testResult = 'No conditional access policy requires a password change for risky users.'
         }

--- a/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.md
+++ b/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.md
@@ -2,4 +2,4 @@ Checks if the tenant has at least one conditional access policy securing securit
 
 See [Securing security info registration - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-registration)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.ps1
+++ b/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.ps1
@@ -49,7 +49,7 @@ function Test-MtCaSecureSecurityInfoRegistration {
         }
 
         if ( $result ) {
-            $testResult = "The following conditional access policies secure security info registration.`n`n%TestResult%"
+            $testResult = "The following conditional access policies secure security info registration.`n`n%testResult%"
         } else {
             $testResult = "No conditional access policy securing security info registration."
         }

--- a/powershell/public/maester/entra/Test-MtCaWIFBlockLegacyAuthentication.md
+++ b/powershell/public/maester/entra/Test-MtCaWIFBlockLegacyAuthentication.md
@@ -2,4 +2,4 @@ Checks if the Conditional Access Policies for blocking legacy authentication is 
 
 See [Block legacy authentication - Microsoft Learn](https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy)
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtCaWIFBlockLegacyAuthentication.ps1
+++ b/powershell/public/maester/entra/Test-MtCaWIFBlockLegacyAuthentication.ps1
@@ -31,7 +31,7 @@ function Test-MtCaWIFBlockLegacyAuthentication {
     try {
         $policiesResult = Test-MtConditionalAccessWhatIf -UserId $UserId -IncludeApplications "00000002-0000-0ff1-ce00-000000000000" -ClientAppType exchangeActiveSync
         if ( $null -ne $policiesResult ) {
-            $testResult = "Well done. The following conditional access policies are currently blocking legacy authentication.`n`n%TestResult%"
+            $testResult = "Well done. The following conditional access policies are currently blocking legacy authentication.`n`n%testResult%"
             $Result = $true
         } else {
             $testResult = "No conditional access policy found that blocks legacy authentication."

--- a/powershell/public/maester/entra/Test-MtDeviceRegistrationMfaConflict.md
+++ b/powershell/public/maester/entra/Test-MtDeviceRegistrationMfaConflict.md
@@ -16,4 +16,4 @@ Otherwise, Conditional Access policies with this user action aren't properly enf
 
 <!--- Results --->
 
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtDeviceRegistrationMfaConflict.ps1
+++ b/powershell/public/maester/entra/Test-MtDeviceRegistrationMfaConflict.ps1
@@ -51,7 +51,7 @@ function Test-MtDeviceRegistrationMfaConflict {
             # If MFA is required for device registration in Entra ID settings, we need to check if there are any policies that conflict with this
             if ($deviceRegPoliciesCount -gt 0) {
                 Write-Verbose "Found conditional access policies that require MFA for device registration: $($deviceRegPolicies.Count)"
-                $testResultMarkdown = "Device registration controls are enforced in both conditional access and [Entra - Device Settings](https://entra.microsoft.com/#view/Microsoft_AAD_Devices/DevicesMenuBlade/~/DeviceSettings/menuId/Devices). Disable the tenant wide setting and enforce through conditional access.`n`n%TestResult%"
+                $testResultMarkdown = "Device registration controls are enforced in both conditional access and [Entra - Device Settings](https://entra.microsoft.com/#view/Microsoft_AAD_Devices/DevicesMenuBlade/~/DeviceSettings/menuId/Devices). Disable the tenant wide setting and enforce through conditional access.`n`n%testResult%"
                 $return = $false
             } else {
                 Write-Verbose "No conditional access policies requiring MFA for device registration were found."
@@ -64,11 +64,11 @@ function Test-MtDeviceRegistrationMfaConflict {
             # If MFA is not required for device registration in Entra ID settings, we need to check if there are any policies that require controls on register device
             if ($deviceRegPoliciesCount -gt 0) {
                 Write-Verbose "Found conditional access policies that require controls on register device: $($deviceRegPolicies.Count)"
-                $testResultMarkdown = "Well done. Requiring controls for device registration is enforced with conditional access policies.`n`n%TestResult%"
+                $testResultMarkdown = "Well done. Requiring controls for device registration is enforced with conditional access policies.`n`n%testResult%"
                 $return = $true
             } else {
                 Write-Verbose "No controls were found for registering devices in conditional access policies."
-                $testResultMarkdown = "No conditional access policies nor device registration settings were found that conflict with each other. However it is recommended to enforce MFA for device registration. `n`n%TestResult%"
+                $testResultMarkdown = "No conditional access policies nor device registration settings were found that conflict with each other. However it is recommended to enforce MFA for device registration. `n`n%testResult%"
                 $return = $true
             }
         }

--- a/powershell/public/maester/entra/Test-MtGroupCreationRestricted.md
+++ b/powershell/public/maester/entra/Test-MtGroupCreationRestricted.md
@@ -16,4 +16,4 @@ Follow the link below to restrict Microsoft 365 Group creation to approved users
 
 <!--- Results --->
 
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtHighRiskAppPermissions.md
+++ b/powershell/public/maester/entra/Test-MtHighRiskAppPermissions.md
@@ -58,4 +58,4 @@ To check the applications permissions:
 * [Microsoft Learn - Graph permissions](https://learn.microsoft.com/en-us/graph/permissions-reference)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/entra/Test-MtHighRiskAppPermissions.ps1
+++ b/powershell/public/maester/entra/Test-MtHighRiskAppPermissions.ps1
@@ -459,7 +459,7 @@ function Test-MtHighRiskAppPermissions {
         if ($return) {
             $testResultMarkdown = "Well done. No application has graph permissions with a risk of having a $($attackPathStr) path to Global Admin and full tenant takeover."
         } else {
-            $testResultMarkdown = "At least one application has graph permissions with a risk of having a $($attackPathStr) path to Global Admin and full tenant takeover.`n`n%TestResult%"
+            $testResultMarkdown = "At least one application has graph permissions with a risk of having a $($attackPathStr) path to Global Admin and full tenant takeover.`n`n%testResult%"
 
             $result = "| ApplicationName | ApplicationId | PermissionName | PermissionType | AttackPath |`n"
             $result += "| --- | --- | --- | --- | --- |`n"
@@ -467,7 +467,7 @@ function Test-MtHighRiskAppPermissions {
                 $appMdLink = "[$($assignedCriticalPermission.ApplicationName)]($($assignedCriticalPermission.ApplicationUrl))"
                 $result += "| $($appMdLink) | $($assignedCriticalPermission.ApplicationId) | $($assignedCriticalPermission.PermissionName) | $($assignedCriticalPermission.PermissionType) | $($assignedCriticalPermission.AttackPath) |`n"
             }
-            $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $result
+            $testResultMarkdown = $testResultMarkdown -replace '%testResult%', $result
         }
 
         Add-MtTestResultDetail -Result $testResultMarkdown

--- a/powershell/public/maester/entra/Test-MtSpExchangeAppAccessPolicy.md
+++ b/powershell/public/maester/entra/Test-MtSpExchangeAppAccessPolicy.md
@@ -72,4 +72,4 @@ Test-ApplicationAccessPolicy -Identity user@contoso.com -AppId $AppID
 ```
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/exchange/Test-MtExoAdditionalStorageProvider.md
+++ b/powershell/public/maester/exchange/Test-MtExoAdditionalStorageProvider.md
@@ -32,4 +32,4 @@ The result should be `False`.
 * [Microsoft Secure Score - Restrict third-party storage services](https://security.microsoft.com/securescore)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/exchange/Test-MtExoMailTip.md
+++ b/powershell/public/maester/exchange/Test-MtExoMailTip.md
@@ -26,4 +26,4 @@ The result should be `True`.
 * [Microsoft Secure Score - Enable MailTips](https://security.microsoft.com/securescore)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/exchange/Test-MtExoModernAuth.md
+++ b/powershell/public/maester/exchange/Test-MtExoModernAuth.md
@@ -27,4 +27,4 @@ The result should be `True`.
 * [Microsoft Secure Score - Enable modern authentication](https://security.microsoft.com/securescore)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/exchange/Test-MtExoOutlookAddin.md
+++ b/powershell/public/maester/exchange/Test-MtExoOutlookAddin.md
@@ -39,4 +39,4 @@ The result should return no assignments.
 * [Microsoft Secure Score - Restrict user consent to applications](https://security.microsoft.com/securescore)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/exchange/Test-MtExoRejectDirectSend.md
+++ b/powershell/public/maester/exchange/Test-MtExoRejectDirectSend.md
@@ -26,4 +26,4 @@ The result should be `True`.
 * [Direct Send: Send mail directly from your device or application to Microsoft 365](https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-microsoft-365-or-office-365#direct-send-send-mail-directly-from-your-device-or-application-to-microsoft-365-or-office-365)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/exchange/Test-MtExoSetScl.md
+++ b/powershell/public/maester/exchange/Test-MtExoSetScl.md
@@ -32,4 +32,4 @@ The result should return no rules.
 * [Microsoft Secure Score - Set SCL to 0 or higher for domains](https://security.microsoft.com/securescore)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/intune/Test-MtDeviceComplianceSettings.md
+++ b/powershell/public/maester/intune/Test-MtDeviceComplianceSettings.md
@@ -19,4 +19,4 @@ To change the built-in device compliance policy:
 * [Compliance policy settings](https://learn.microsoft.com/de-de/mem/intune/protect/device-compliance-get-started#compliance-policy-settings)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/intune/Test-MtManagedDeviceCleanupSettings.md
+++ b/powershell/public/maester/intune/Test-MtManagedDeviceCleanupSettings.md
@@ -20,4 +20,4 @@ To enable device clean-up rules:
 * [Microsoft Intune - Device clean-up rules](https://intune.microsoft.com/?ref=AdminCenter#view/Microsoft_Intune_DeviceSettings/DevicesMenu/~/deviceCleanUp)
 
 <!--- Results --->
-%TestResult%
+%testResult%

--- a/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.md
+++ b/powershell/public/maester/teams/Test-MtTeamsRestrictParticipantGiveRequestControl.md
@@ -20,4 +20,4 @@ To prevent standard attendees from sharing content during Teams meetings:
 
 <!--- Results --->
 
-%TestResult%
+%testResult%

--- a/website/docs/commands/Add-MtTestResultDetail.mdx
+++ b/website/docs/commands/Add-MtTestResultDetail.mdx
@@ -80,7 +80,7 @@ Detailed information of the test result to provide additional context to the use
 This can be a summary of the items that caused the test to fail (e.g.
 list of user names, conditional access policies, etc.).
 Markdown is supported.
-If the test result contains a placeholder %TestResult%, it will be replaced with the values from the $GraphResult
+If the test result contains a placeholder %testResult%, it will be replaced with the values from the $GraphResult
 
 ```yaml
 Type: String
@@ -97,7 +97,7 @@ Accept wildcard characters: False
 ### -GraphObjects
 
 Collection of Graph objects to display in the test results report.
-This will be inserted into the contents of Result parameter if the result contains a placeholder %TestResult%.
+This will be inserted into the contents of Result parameter if the result contains a placeholder %testResult%.
 
 ```yaml
 Type: Object[]

--- a/website/docs/writing-tests/advanced-concepts.md
+++ b/website/docs/writing-tests/advanced-concepts.md
@@ -131,7 +131,7 @@ function Test-ContosoUsersMissingManagers {
         if ($result) {
             $TestResults = "Well done! There were no users with out managers assigned."
         } else {
-            $TestResults += "No managers are assigned for the following users.`n%TestResult%"
+            $TestResults += "No managers are assigned for the following users.`n%testResult%"
         }
 
         Add-MtTestResultDetail -Result $TestResults -GraphObjects $usersWithoutManager -GraphObjectType Users
@@ -180,7 +180,7 @@ Contoso's company policy requires that all users have a manager assigned to them
 
 <!--- Results --->
 
-%TestResult%
+%testResult%
 
 ```
 

--- a/website/docs/writing-tests/formatting-test-results.md
+++ b/website/docs/writing-tests/formatting-test-results.md
@@ -89,9 +89,9 @@ The `-GraphObjects` and `-GraphObjectType` parameters in `Add-MtTestResultDetail
 The test results can then display the names of the objects and also provide a deep link to the object in the Microsoft admin portal.
 
 :::note
-When using `-GraphObjects` the `-Result` string parameter needs to include `%TestResult%` at the position where the object names will be inserted.
+When using `-GraphObjects` the `-Result` string parameter needs to include `%testResult%` at the position where the object names will be inserted.
 
-The `%TestResult%` placeholder will be replaced with the names of the objects in the test results.
+The `%testResult%` placeholder will be replaced with the names of the objects in the test results.
 :::
 
 The current list of supported object types includes Users, Groups, Devices, ConditionalAccess, AuthenticationMethod, AuthorizationPolicy, ConsentPolicy, Domains, IdentityProtection and UserRole.
@@ -109,7 +109,7 @@ Describe "ContosoEntraConfig" -Tag "Privilege", "Contoso" {
 
             $testDescription = "Checks if the disabled policies have the reason for being disabled."
             if ($disabledWithoutReason.Count -gt 0) {
-                $result = "There are $($disabledWithoutReason.Count) disabled policies without a reason for being disabled.`n`n%TestResult%"
+                $result = "There are $($disabledWithoutReason.Count) disabled policies without a reason for being disabled.`n`n%testResult%"
                 Add-MtTestResultDetail -Description $testDescription -Result $result -GraphObjects $disabledWithoutReason -GraphObjectType ConditionalAccess
             } else {
                 Add-MtTestResultDetail -Description $testDescription -Result "Well done. All disabled policies have a reason for being disabled."


### PR DESCRIPTION
When running Maester in a non Windows (case-sensitive) OS, the placeholder %TestResults% is not being replaced. Tests do set $testResult and not $TestResult
Updated all files including documentation and example webpages