### PR TITLE
Refactor Connect-MgGraph to support optional GraphApplicationId

### DIFF
--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -63,9 +63,9 @@
    Connects to China environments for Microsoft Graph, Azure, and Exchange Online.
 
 .EXAMPLE
-Connect-Maester -TenantId "4e285730-281f-42a2-bdfd-e766394e85d0" -GraphClientId "f45ec3ad-32f0-4c06-8b69-47682afe0216"
+   Connect-Maester -GraphClientId 'f45ec3ad-32f0-4c06-8b69-47682afe0216'
 
-Connects to the tenant 4e285730-281f-42a2-bdfd-e766394e85d0 using app registration with client ID f45ec3ad-32f0-4c06-8b69-47682afe0216
+   Connects using a custom application with client ID f45ec3ad-32f0-4c06-8b69-47682afe0216
 
 .LINK
    https://maester.dev/docs/commands/Connect-Maester
@@ -224,13 +224,15 @@ Connects to the tenant 4e285730-281f-42a2-bdfd-e766394e85d0 using app registrati
                   Environment   = $Environment
                }
 
-               if ($GraphApplicationId) {
+               if ($GraphClientId) {
                   $connectParams['ClientId'] = $GraphClientId
                }
                if ($TenantId) {
                   $connectParams['TenantId'] = $TenantId
                }
 
+               Write-Verbose "🦒 Connecting to Microsoft Graph with parameters:"
+               Write-Verbose ($connectParams | ConvertTo-Json -Depth 5)
                Connect-MgGraph @connectParams
 
                #ensure TenantId

--- a/website/docs/connect-maester/readme.md
+++ b/website/docs/connect-maester/readme.md
@@ -123,6 +123,12 @@ Connect-Maester -Environment China -AzureEnvironment AzureChinaCloud -ExchangeEn
 Connect-Maester -Environment Germany
 ```
 
-### Connect using a custom Graph Client ID
+### Connect using a custom application
 
-`Connect-Maester` also provides the option to connect to Graph using a custom client ID. For technical details on this, please see [Use delegated access with a custom application for Microsoft Graph PowerShell](https://learn.microsoft.com/en-us/powershell/microsoftgraph/authentication-commands?view=graph-powershell-1.0#use-delegated-access-with-a-custom-application-for-microsoft-graph-powershell).
+You can use `Connect-Maester` to connect to Microsoft Graph using a custom application by specifying the `-GraphClientId` parameter. This is useful if you wish to use a custom application for Maester instead of using the default Graph PowerShell application.
+
+```powershell
+Connect-Maester -GraphClientId 'f45ec3ad-32f0-4c06-8b69-47682afe0216'
+```
+
+To learn more about how to create a custom application for Microsoft Graph PowerShell see [Use delegated access with a custom application for Microsoft Graph PowerShell](https://learn.microsoft.com/en-us/powershell/microsoftgraph/authentication-commands?view=graph-powershell-1.0#use-delegated-access-with-a-custom-application-for-microsoft-graph-powershell).


### PR DESCRIPTION
The change allows users to create a custom app for Graph connection and avoid the OOB Graph CLI app, which can become over-privileged. 

1. Added [string]$GraphClientId param to Connect-Maester
2. Made graph connection logic more DRY while incorporating $GraphClientId

