### PR TITLE
Handle SPF records that include themselves; prevent an infinite loop

### DIFF
--- a/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
+++ b/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
@@ -146,7 +146,11 @@ function Resolve-SPFRecord {
                         }
                         '^include:.*$' {
                             # Follow the include and resolve the include
-                            Resolve-SPFRecord -Name ( $SPFDirective -replace "^include:" ) -Server $Server -Referrer $Name
+                            $IncludeTarget = ( $SPFDirective -replace "^include:" )
+                            # Check for SPF records that include themselves, it will lead to an infinite loop => ** explosion **
+                            if ( $Name -ne $IncludeTarget ) {
+                                Resolve-SPFRecord -Name $IncludeTarget -Server $Server -Referrer $Name
+                            }
                         }
                         '^ip[46]:.*$' {
                             Write-Verbose "[IP]`tSPF entry: $SPFDirective"


### PR DESCRIPTION
When running the MS.EXO.2.2 (SPF) test against a domain that has a recursive loop in the SPF records (i.e. it includes itself) , the test fails to identify the misconfiguration and goes into an infinite loop, ultimately resulting in a stack overflow. This results in the execution aborting and other tests not being run.

This PR adds a simple check in the Resolve-SPFRecord function to prevent this

https://github.com/maester365/maester/issues/1069