### PR TITLE
Added new test: MT.1070 - Migrate approved client app to application protection policy in Conditional Access.

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaApprovedClientApp.md
+++ b/powershell/public/maester/entra/Test-MtCaApprovedClientApp.md
@@ -1,0 +1,11 @@
+Checks if the tenant has no conditional access policy that requires an approved client app.
+
+The approved client app grant is retiring in early March 2026. Organizations must transition all current Conditional Access policies that use only the Require Approved Client App grant control to Require Approved Client App or Application Protection Policy by March 2026. Additionally, for any new Conditional Access policy, only apply the Require application protection policy grant.
+
+After March 2026, Microsoft will stop enforcing require approved client app control, and it will be as if this grant isn't selected. Use the following steps before March 2026 to protect your organization’s data.
+
+## Learn more
+- [Migrate approved client app to application protection policy in Conditional Access](https://learn.microsoft.com/en-us/entra/identity/conditional-access/migrate-approved-client-app)
+
+<!--- Results --->
+%TestResult%

--- a/powershell/public/maester/entra/Test-MtCaApprovedClientApp.ps1
+++ b/powershell/public/maester/entra/Test-MtCaApprovedClientApp.ps1
@@ -1,0 +1,42 @@
+<#
+ .Synopsis
+    Checks if the tenant has no conditional access policy that requires an approved client app.
+
+ .Description
+    The approved client app grant is retiring in early March 2026. 
+    Organizations must transition all current Conditional Access policies that use only the require approved Client App grant control to Require Approved Client App or Application Protection Policy by March 2026. 
+    Additionally, for any new Conditional Access policy, only apply the Require application protection policy grant.
+    After March 2026, Microsoft will stop enforcing require approved client app control, and it will be as if this grant isn't selected. Use the following steps before March 2026 to protect your organization’s data.
+    Learn more:
+    https://learn.microsoft.com/en-us/entra/identity/conditional-access/migrate-approved-client-app
+ 
+  .Example
+    Test-MtCaApprovedClientApp
+
+.LINK
+    https://maester.dev/docs/commands/Test-MtCaApprovedClientApp
+#>
+function Test-MtCaApprovedClientApp {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param ()
+
+    $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq "enabled" }
+    $policiesResult = New-Object System.Collections.ArrayList
+    $result = $false
+
+    foreach ($policy in $policies) {
+        if ( "approvedApplication" -in ($policy.grantControls.builtInControls) ) {
+            $result = $true
+            $policiesResult.Add($policy) | Out-Null
+        }
+    }
+    if (($policiesResult | Measure-Object).Count -eq 0) {
+        $testResult = "Well done! No conditional access policies that requires an approved client app."
+        Add-MtTestResultDetail -Result $testResult
+    } else {
+        $testResult = "The following conditional access policies are requiring atleast an approved client app:`n`n%TestResult%"
+        Add-MtTestResultDetail -Result $testResult -GraphObjects $policiesResult -GraphObjectType ConditionalAccess
+    }
+    return $result
+}

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -77,6 +77,9 @@
     It "MT.1066: Conditional Access policies should not reference non-existent users, groups, or roles. See https://maester.dev/docs/tests/MT.1066" -Tag "MT.1066", "Warning" {
         Test-MtCaReferencedObjectsExist | Should -Be $true -Because "all referenced users, groups, or roles should exist."
     }
+    It "MT.1070: At least one Conditional Access policy is configured to require an approved client app. See https://maester.dev/docs/tests/MT.1070" -Tag "MT.1070", "Warning" {
+        Test-MtCaApprovedClientApp | Should -Be $true -Because "no policy requires an approved client app."
+    }
     Context "Maester/Entra" -Tag "Entra", "License" {
         It "MT.1022: All users utilizing a P1 license should be licensed. See https://maester.dev/docs/tests/MT.1022" -Tag "MT.1022" {
             $LicenseReport = Test-MtCaLicenseUtilization -License "P1"

--- a/website/docs/tests/maester/MT.1070.md
+++ b/website/docs/tests/maester/MT.1070.md
@@ -1,0 +1,17 @@
+---
+title: MT.1070 - No conditional access policy should require an approved client app.
+description: This test checks if there are any Conditional Access policies that require an approved client app.
+slug: /tests/MT.1070
+sidebar_class_name: hidden
+---
+
+## Description
+
+Checks if the tenant has no conditional access policy that requires an approved client app.
+
+The approved client app grant is retiring in early March 2026. Organizations must transition all current Conditional Access policies that use only the Require Approved Client App grant control to Require Approved Client App or Application Protection Policy by March 2026. Additionally, for any new Conditional Access policy, only apply the Require application protection policy grant.
+
+After March 2026, Microsoft will stop enforcing require approved client app control, and it will be as if this grant isn't selected. Use the following steps before March 2026 to protect your organization’s data.
+
+## Learn more
+- [Migrate approved client app to application protection policy in Conditional Access](https://learn.microsoft.com/en-us/entra/identity/conditional-access/migrate-approved-client-app)


### PR DESCRIPTION
The approved client app grant is retiring in early March 2026. Organizations must transition all current Conditional Access policies that use only the Require Approved Client App grant control to Require Approved Client App or Application Protection Policy by March 2026. Additionally, for any new Conditional Access policy, only apply the Require application protection policy grant.

After March 2026, Microsoft will stop enforcing require approved client app control, and it will be as if this grant isn't selected. Use the following steps before March 2026 to protect your organization’s data.