### PR TITLE
Workaround for Microsoft bug in EOP\Get-AdminAuditLogConfig function

### DIFF
--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -213,11 +213,12 @@
                block removes the broken function and re-imports the temporary PSSession module for EXO, which restores
                the working Get-AdminAuditLogConfig function.
             #>
-            if (Get-ConnectionInformation | Where-Object { $_.IsEopSession -eq $true -and $_.State -eq 'Connected'}) {
+            $ExchangeConnectionInformation = Get-ConnectionInformation
+            if ($ExchangeConnectionInformation | Where-Object { $_.IsEopSession -eq $true -and $_.State -eq 'Connected' }) {
                try {
                   # Remove the broken cmdlet and re-import the working EXO one.
                   Remove-Item -Path 'Function:\Get-AdminAuditLogConfig' -Force -ErrorAction SilentlyContinue
-                  Get-ConnectionInformation | Where-Object { $_.IsEopSession -ne $true -and $_.State -eq 'Connected' } |
+                  $ExchangeConnectionInformation | Where-Object { $_.IsEopSession -ne $true -and $_.State -eq 'Connected' } |
                      Select-Object -ExpandProperty ModuleName |
                         Import-Module -Function 'Get-AdminAuditLogConfig' > $null
                } catch {

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -221,7 +221,7 @@
                      Select-Object -ExpandProperty ModuleName |
                         Import-Module -Function 'Get-AdminAuditLogConfig' > $null
                } catch {
-                  $_.Exception.Message
+                  Write-Error "Failed to restore Get-AdminAuditLogConfig cmdlet: $($_.Exception.Message)"
                }
             }
          }

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -207,6 +207,23 @@
                   }
                }
             }
+
+            <# Fix for Get-AdminAuditLogConfig (#1045)
+               Connect-IPPSSession imports a temporary PSSession module that breaks Get-AdminAuditLogConfig. This script
+               block removes the broken function and re-imports the temporary PSSession module for EXO, which restores
+               the working Get-AdminAuditLogConfig function.
+            #>
+            if (Get-ConnectionInformation | Where-Object { $_.IsEopSession -eq $true -and $_.State -eq 'Connected'}) {
+               try {
+                  # Remove the broken cmdlet and re-import the working EXO one.
+                  Remove-Item -Path 'Function:\Get-AdminAuditLogConfig' -Force -ErrorAction SilentlyContinue
+                  Get-ConnectionInformation | Where-Object { $_.IsEopSession -ne $true -and $_.State -eq 'Connected' } |
+                     Select-Object -ExpandProperty ModuleName |
+                        Import-Module -Function 'Get-AdminAuditLogConfig' > $null
+               } catch {
+                  $_.Exception.Message
+               }
+            }
          }
       }
 


### PR DESCRIPTION
This pull request introduces a targeted fix to the `Connect-Maester.ps1` script, addressing an issue where the `Get-AdminAuditLogConfig` cmdlet becomes broken due to a temporary PSSession module imported by `Connect-IPPSSession`. The new logic ensures the correct version of the cmdlet is restored for Exchange Online (EXO) sessions.

Fixes #1045!

**Admin Audit Log Fix:**

* Added a script block that detects when an EOP session is connected, removes the broken `Get-AdminAuditLogConfig` function, and re-imports the correct EXO module to restore functionality.