### PR TITLE
Hide empty results in detailed output of Test-MtConnection

### DIFF
--- a/powershell/Maester.Format.ps1xml
+++ b/powershell/Maester.Format.ps1xml
@@ -12,6 +12,11 @@
           <ListEntry>
             <ListItems>
               <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>
+                    $null -ne $_.Azure
+                  </ScriptBlock>
+                </ItemSelectionCondition>
                 <Label>Azure</Label>
                 <ScriptBlock>
                   if ($_.Azure) {
@@ -26,6 +31,11 @@
                 </ScriptBlock>
               </ListItem>
               <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>
+                    $null -ne $_.Graph
+                  </ScriptBlock>
+                </ItemSelectionCondition>
                 <Label>Microsoft Graph</Label>
                 <ScriptBlock>
                   if ($_.Graph) {
@@ -40,6 +50,11 @@
                 </ScriptBlock>
               </ListItem>
               <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>
+                    $null -ne $_.ExchangeOnline
+                  </ScriptBlock>
+                </ItemSelectionCondition>
                 <Label>Exchange Online</Label>
                 <ScriptBlock>
                   if ($_.ExchangeOnline) {
@@ -53,6 +68,11 @@
                 </ScriptBlock>
               </ListItem>
               <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>
+                    $null -ne $_.ExchangeOnlineProtection
+                  </ScriptBlock>
+                </ItemSelectionCondition>
                 <Label>Exchange Online Protection</Label>
                 <ScriptBlock>
                   if ($_.ExchangeOnlineProtection) {
@@ -66,6 +86,11 @@
                 </ScriptBlock>
               </ListItem>
               <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>
+                    $null -ne $_.Teams
+                  </ScriptBlock>
+                </ItemSelectionCondition>
                 <Label>Microsoft Teams</Label>
                 <ScriptBlock>
                   if ($_.Teams) {


### PR DESCRIPTION
Using `Test-MtConnection -Details` outputs a custom formatted list that shows the details of each service connection (Azure, Exo, Eop, Graph, Teams).

Specific service connections can be checked by using the **Service** parameter.

This change to the PowerShell format file for `Maester.Connections` dynamically hides null connections so it doesn't show services that you didn't ask it to test.