### PR TITLE
💫 Update vscode settings to ensure UTF-8 with BOM encoding for PowerShell files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[powershell]": {
+    "files.encoding": "utf8bom"
+  },
   "editor.formatOnSave": false,
   "powershell.codeFormatting.autoCorrectAliases": true,
   "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
@@ -10,5 +13,6 @@
   "cSpell.words": [
     "Contoso",
     "Maester"
-  ]
+  ],
+  "files.encoding": "utf8"
 }


### PR DESCRIPTION
This pull request updates the `.vscode/settings.json` configuration to improve file encoding settings and maintain consistent formatting preferences for PowerShell files.

File encoding configuration:

* Added a specific encoding setting for PowerShell files to use `utf8bom` (`[powershell]`), ensuring compatibility with tools that require a BOM in UTF-8 files.
* Set the global `files.encoding` to `utf8` for all other files, providing a consistent default encoding across the project.