### PR TITLE
Added NotRunCount to MaesterResults

### DIFF
--- a/powershell/assets/ReportTemplate.md
+++ b/powershell/assets/ReportTemplate.md
@@ -6,9 +6,9 @@ This is a summary of the test results from the Maester test run.
 
 **Date:** %TestDate%
 
-| 🔥 <br/> Total Tests | ✅ <br/> Passed  | ❌ <br/> Failed | ❔ <br/> Not Run |
-|:-:|:-:|:-:|:-:|
-| **%TotalCount%** | **%PassedCount%** | **%FailedCount%** |**%NotRunCount%** |
+| 🔥 <br/> Total Tests | ✅ <br/> Passed  | ❌ <br/> Failed | ❔ <br/> Skipped | ❔ <br/> Not Run |
+|:-:|:-:|:-:|:-:|:-:|
+| **%TotalCount%** | **%PassedCount%** | **%FailedCount%** | **%SkippedCount%** |**%NotRunCount%** |
 
 
 ## Test summary

--- a/powershell/internal/ConvertTo-MtMaesterResult.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResult.ps1
@@ -185,6 +185,7 @@ function ConvertTo-MtMaesterResult {
         FailedCount       = $PesterResults.FailedCount
         PassedCount       = $PesterResults.PassedCount
         SkippedCount      = $PesterResults.SkippedCount
+        NotRunCount       = $PesterResults.NotRunCount
         TotalCount        = $PesterResults.TotalCount
         ExecutedAt        = GetFormattedDate($PesterResults.ExecutedAt)
         TotalDuration     = $PesterResults.Duration.ToString($timeSpanFormat)

--- a/powershell/internal/Get-MtMarkdownReport.ps1
+++ b/powershell/internal/Get-MtMarkdownReport.ps1
@@ -101,6 +101,7 @@ function Get-MtMarkdownReport {
     $templateMarkdown = $templateMarkdown -replace '%TotalCount%', $MaesterResults.TotalCount
     $templateMarkdown = $templateMarkdown -replace '%PassedCount%', $MaesterResults.PassedCount
     $templateMarkdown = $templateMarkdown -replace '%FailedCount%', $MaesterResults.FailedCount
+    $templateMarkdown = $templateMarkdown -replace '%SkippedCount%', $MaesterResults.SkippedCount
     $templateMarkdown = $templateMarkdown -replace '%NotRunCount%', $MaesterResults.NotRunCount
 
     $templateMarkdown = $templateMarkdown -replace '%TestSummary%', $textSummary

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -451,7 +451,8 @@ function Invoke-Maester {
             # Show final summary
             Write-Host "`nTests Passed ✅: $($pesterResults.PassedCount), " -NoNewline -ForegroundColor Green
             Write-Host "Failed ❌: $($pesterResults.FailedCount), " -NoNewline -ForegroundColor Red
-            Write-Host "Skipped ⚫: $($pesterResults.SkippedCount)`n" -ForegroundColor DarkGray
+            Write-Host "Skipped ⚫: $($pesterResults.SkippedCount) " -NoNewline -ForegroundColor DarkGray
+            Write-Host "Not Run ⚫: $($pesterResults.NotRunCount)`n" -ForegroundColor DarkGray
         }
 
         if (-not $SkipVersionCheck -and 'Next' -ne $version) {


### PR DESCRIPTION
The value was missing for `Get-MtMarkdownReport.ps1`, which tried to use it. 
Added skippedCount to the markdown template.

Added NotRunCount to `Invoke-Maester` output.