### PR TITLE
MT.1073: Ensure soft and hard matching for on-premises synchronization objects is blocked

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -157,7 +157,7 @@ FunctionsToExport = 'Add-MtTestResultDetail',
     'Test-ORCA244', 'Update-MaesterTests', 'Test-MtAppRegistrationOwnersWithoutMFA',
     'Test-MtManagementGroupWriteRequirement', 'Test-MtDeviceRegistrationMfaConflict', 'Test-MtVaultSoftDelete',
     'Test-MtTenantCreationRestricted', 'Test-MtEntraDeviceJoinRestricted', 'Test-MtSecurityGroupCreationRestricted',
-    'Test-MtCaApprovedClientApp', 'Test-MtCaAzureDevOps'
+    'Test-MtCaApprovedClientApp', 'Test-MtCaAzureDevOps', 'Test-MtDirSyncSoftHardMatching'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/powershell/internal/Get-MtSkippedReason.ps1
+++ b/powershell/internal/Get-MtSkippedReason.ps1
@@ -27,6 +27,7 @@ function Get-MtSkippedReason {
         "NotLicensedAdvAudit" { "This test is for tenants that are licensed for Advanced Audit. See [Learn about auditing solutions in Microsoft Purview](https://learn.microsoft.com/en-us/purview/audit-solutions-overview#licensing-requirements)"; break}
         "LicensedEntraIDPremium" { "This test is for tenants that are not licensed for any Entra ID Premium license. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)"; break}
         "NotSupported" { "This test relies on capabilities not currently available (e.g., cmdlets that are not available on all platforms, Resolve-DnsName)"; break}
+        "NotSupportedAppPermission" { "This test relies on Graph APIs that don't support application permissions. Re-run Maester with a user signed in to view the results for this test."; break}
         default { $SkippedBecause; break}
     }
 }

--- a/powershell/public/Add-MtTestResultDetail.ps1
+++ b/powershell/public/Add-MtTestResultDetail.ps1
@@ -71,7 +71,7 @@ function Add-MtTestResultDetail {
         [Parameter(Mandatory = $false)]
         [ValidateSet('NotConnectedAzure', 'NotConnectedExchange', 'NotConnectedGraph', 'NotDotGovDomain', 'NotLicensedEntraIDP1', 'NotConnectedSecurityCompliance', 'NotConnectedTeams',
             'NotLicensedEntraIDP2', 'NotLicensedEntraIDGovernance', 'NotLicensedEntraWorkloadID', 'NotLicensedExoDlp', "LicensedEntraIDPremium", 'NotSupported', 'Custom',
-            'NotLicensedMdo', 'NotLicensedMdoP2', 'NotLicensedMdoP1', 'NotLicensedAdvAudit', 'NotLicensedEop', 'Error'
+            'NotLicensedMdo', 'NotLicensedMdoP2', 'NotLicensedMdoP1', 'NotLicensedAdvAudit', 'NotLicensedEop', 'Error', 'NotSupportedAppPermission'
         )]
         [string] $SkippedBecause,
 

--- a/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.md
+++ b/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.md
@@ -1,0 +1,34 @@
+﻿Ensure soft and hard matching for on-premises synchronization objects is blocked
+
+When you start synchronizing with Microsoft Entra Connect, the Microsoft Entra service API checks every new incoming object and tries to find an existing object to match. There are three attributes used for this process: userPrincipalName, proxyAddresses, and sourceAnchor/immutableID. A match on userPrincipalName or proxyAddresses is known as a "soft-match." A match on sourceAnchor is known as "hard-match." For the proxyAddresses attribute, only the value with SMTP:, that is the primary email address, is used for the evaluation.
+Both, the hard-match and soft-match, tries to match objects already present and managed in Microsoft Entra ID with the new incoming objects being added that represent the same on-premises entity. If Microsoft Entra ID isn't able to find a hard-match or soft-match for the incoming object, it provisions a new object in Microsoft Entra ID directory.
+
+The match is only evaluated for new objects coming from on-premises AD. If you change an existing object so it matches any of these attributes, then you see an error instead.
+
+If Microsoft Entra ID finds an object where the attribute values are the same as the new incoming object from Microsoft Entra Connect, then it takes over the object in Microsoft Entra ID and the previously cloud-managed object is converted to on-premises managed. All attributes in Microsoft Entra ID with a value in on-premises AD are overwritten with the respective on-premises value.
+
+Matching existing Entra objects with newly synchronized on-premises active directory objects can lead to unintended consequences, such as mismatching user data or allowing users to access data, of for example colleagues with the same name, they should not have access to.
+
+#### Remediation action:
+
+To block soft- and hard-match from on-premises directory synchronization using Graph PowerShell:
+1. Connect to Graph using **Connect-MgGraph -Scopes "OnPremDirectorySynchronization.ReadWrite.All"**.
+2. Run following PowerShell Command:
+```
+$onPremisesSynchronization = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/directory/onPremisesSynchronization" -OutputType PSObject | Select-Object -ExpandProperty value
+$params = @{
+	features = @{
+		BlockCloudObjectTakeoverThroughHardMatchEnabled = $true
+        BlockSoftMatchEnabled = $true
+	}
+}
+Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/directory/onPremisesSynchronization/$($onPremisesSynchronization.id)" -Body $params
+```
+
+#### Related links
+
+* [Microsoft Entra Connect: When you have an existing tenant | Microsoft Learn](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-install-existing-tenant)
+* [Update-MgDirectoryOnPremiseSynchronization | Microsoft Learn - Graph PowerShell v1.0](https://learn.microsoft.com/de-de/powershell/module/microsoft.graph.identity.directorymanagement/update-mgdirectoryonpremisesynchronization?view=graph-powershell-1.0)
+
+<!--- Results --->
+%TestResult%

--- a/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.ps1
+++ b/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.ps1
@@ -26,8 +26,12 @@ function Test-MtDirSyncSoftHardMatching {
     $return = $true
 
     Write-Verbose "Checking if on-premises directory synchronization soft- and hard-match is blocked..."
+    # requires delegated (no app) permissions: OnPremDirectorySynchronization.Read.All
+    if (((Get-MgContext).AuthType) -ne "Delegated") {
+        Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'This test requires delegated permissions.'
+        return $null
+    }
 
-    # required permissions: Directory.Read.All or dedicated OnPremDirectorySynchronization.Read.All
     $organizationConfig = Invoke-MtGraphRequest -RelativeUri "organization"
     if ($organizationConfig.onPremisesSyncEnabled -ne $true) {
         Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'OnPremisesSynchronization is not configured'

--- a/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.ps1
+++ b/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.ps1
@@ -28,7 +28,7 @@ function Test-MtDirSyncSoftHardMatching {
     Write-Verbose "Checking if on-premises directory synchronization soft- and hard-match is blocked..."
     # requires delegated (no app) permissions: OnPremDirectorySynchronization.Read.All
     if (((Get-MgContext).AuthType) -ne "Delegated") {
-        Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'This test requires delegated permissions.'
+        Add-MtTestResultDetail -SkippedBecause 'NotSupportedAppPermission'
         return $null
     }
 

--- a/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.ps1
+++ b/powershell/public/maester/entra/Test-MtDirSyncSoftHardMatching.ps1
@@ -1,0 +1,65 @@
+﻿<#
+.SYNOPSIS
+    Ensure soft and hard matching for on-premises synchronization objects is blocked
+
+.DESCRIPTION
+    Soft and hard matching for on-premises synchronization objects is a feature that allows Entra ID to match users based on their userprincipalname, email address or other attributes.
+    This can lead to unintended consequences, such as mismatching user data.
+
+.EXAMPLE
+    Test-MtDirSyncSoftHardMatching
+
+    Returns true if soft and hard matching is blocked / disabled
+
+.LINK
+    https://maester.dev/docs/commands/Test-MtDirSyncSoftHardMatching
+#>
+function Test-MtDirSyncSoftHardMatching {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (-not (Test-MtConnection Graph)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
+        return $null
+    }
+    $return = $true
+
+    Write-Verbose "Checking if on-premises directory synchronization soft- and hard-match is blocked..."
+
+    # required permissions: Directory.Read.All or dedicated OnPremDirectorySynchronization.Read.All
+    $organizationConfig = Invoke-MtGraphRequest -RelativeUri "organization"
+    if ($organizationConfig.onPremisesSyncEnabled -ne $true) {
+        Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'OnPremisesSynchronization is not configured'
+        return $null
+    }
+    $onPremisesSynchronizationConfig = Invoke-MtGraphRequest -RelativeUri "directory/onPremisesSynchronization"
+
+    $passResult = "✅ Pass"
+    $failResult = "❌ Fail"
+
+    $result = "| Policy | Value | Status |`n"
+    $result += "| --- | --- | --- |`n"
+
+    if ($onPremisesSynchronizationConfig.features.blockSoftMatchEnabled -eq $false) {
+        $result += "| Block soft-match | $($onPremisesSynchronizationConfig.features.blockSoftMatchEnabled) | $failResult |`n"
+        $return = $false
+    } else {
+        $result += "| Block soft-match | $($onPremisesSynchronizationConfig.features.blockSoftMatchEnabled) | $passResult |`n"
+    }
+    if ($onPremisesSynchronizationConfig.features.blockCloudObjectTakeoverThroughHardMatchEnabled -eq $false) {
+        $result += "| Block hard-match | $($onPremisesSynchronizationConfig.features.blockCloudObjectTakeoverThroughHardMatchEnabled) | $failResult |`n"
+        $return = $false
+    } else {
+        $result += "| Block hard-match | $($onPremisesSynchronizationConfig.features.blockCloudObjectTakeoverThroughHardMatchEnabled) | $passResult |`n"
+    }
+
+    if ($return) {
+        $testResult = "Well done. On-premises directory synchronization soft- and hard-match is blocked.`n`n$($result)"
+        Add-MtTestResultDetail -Result $testResult
+    } else {
+        $testResult = "On-premises directory synchronization soft-match and / or hard-match is allowed.`n`n$($result)"
+        Add-MtTestResultDetail -Result $testResult
+    }
+    return $return
+}

--- a/tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1
+++ b/tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1
@@ -1,0 +1,5 @@
+Describe "Maester/Entra" -Tag "Maester", "DirSync", "Security", "Full", "Entra", "Graph" {
+    It "MT.1073: Soft- and hard-matching of synchronized objects should be blocked. See https://maester.dev/docs/tests/MT.1073" -Tag "MT.1073" {
+        Test-MtDirSyncSoftHardMatching | Should -Be $true -Because "on-premises directory synchronization soft- and hard-match is blocked"
+    }
+}

--- a/tests/maester-config.json
+++ b/tests/maester-config.json
@@ -1140,6 +1140,11 @@
       "Severity": "High",
       "Title": "Conditional access policies should not use the deprecated Approved Client App grant."
     },
+{
+      "Id": "MT.1073",
+      "Severity": "Medium",
+      "Title": "Soft- and hard-matching of synchronized objects should be blocked."
+    },
     {
       "Id": "ORCA.100",
       "Severity": "Medium",

--- a/website/docs/tests/maester/MT.1073.md
+++ b/website/docs/tests/maester/MT.1073.md
@@ -1,0 +1,39 @@
+---
+title: MT.1073 - Soft- and hard-matching of synchronized objects should be blocked.
+description: This test checks if soft- and hard-matching of synchronized objects is blocked.
+slug: /tests/MT.1073
+sidebar_class_name: hidden
+---
+
+## Description
+
+Ensure soft and hard matching for on-premises synchronization objects is blocked
+
+When you start synchronizing with Microsoft Entra Connect, the Microsoft Entra service API checks every new incoming object and tries to find an existing object to match. There are three attributes used for this process: userPrincipalName, proxyAddresses, and sourceAnchor/immutableID. A match on userPrincipalName or proxyAddresses is known as a "soft-match." A match on sourceAnchor is known as "hard-match." For the proxyAddresses attribute, only the value with SMTP:, that is the primary email address, is used for the evaluation.
+Both, the hard-match and soft-match, tries to match objects already present and managed in Microsoft Entra ID with the new incoming objects being added that represent the same on-premises entity. If Microsoft Entra ID isn't able to find a hard-match or soft-match for the incoming object, it provisions a new object in Microsoft Entra ID directory.
+
+The match is only evaluated for new objects coming from on-premises AD. If you change an existing object so it matches any of these attributes, then you see an error instead.
+
+If Microsoft Entra ID finds an object where the attribute values are the same as the new incoming object from Microsoft Entra Connect, then it takes over the object in Microsoft Entra ID and the previously cloud-managed object is converted to on-premises managed. All attributes in Microsoft Entra ID with a value in on-premises AD are overwritten with the respective on-premises value.
+
+Matching existing Entra objects with newly synchronized on-premises active directory objects can lead to unintended consequences, such as mismatching user data or allowing users to access data, of for example colleagues with the same name, they should not have access to.
+## Remediation action:
+
+To block soft- and hard-match from on-premises directory synchronization using Graph PowerShell:
+1. Connect to Graph using **Connect-MgGraph -Scopes "OnPremDirectorySynchronization.ReadWrite.All"**.
+2. Run following PowerShell Command:
+```
+$onPremisesSynchronization = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/directory/onPremisesSynchronization" -OutputType PSObject | Select-Object -ExpandProperty value
+$params = @{
+	features = @{
+		BlockCloudObjectTakeoverThroughHardMatchEnabled = $true
+        BlockSoftMatchEnabled = $true
+	}
+}
+Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/directory/onPremisesSynchronization/$($onPremisesSynchronization.id)" -Body $params
+```
+
+## Learn more
+
+* [Microsoft Entra Connect: When you have an existing tenant | Microsoft Learn](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-install-existing-tenant)
+* [Update-MgDirectoryOnPremiseSynchronization | Microsoft Learn - Graph PowerShell v1.0](https://learn.microsoft.com/de-de/powershell/module/microsoft.graph.identity.directorymanagement/update-mgdirectoryonpremisesynchronization?view=graph-powershell-1.0)

--- a/website/docs/writing-tests/advanced-concepts.md
+++ b/website/docs/writing-tests/advanced-concepts.md
@@ -155,6 +155,18 @@ Always include your main code within a try catch block. In the catch block, use 
 Do not call `Add-MtTestResultDetail` with a `-SkippedBecause` parameter within the try block. This will result in the test being reported as an error instead of skipped. To avoid this, close the try block before calling `Add-MtTestResultDetail` with the `-SkippedBecause` parameter and then start a new try block to continue the main test logic. This is the way Pester handles skipped tests and errors.
 :::
 
+##### Tests that don't support application permissions
+
+Some tests may rely on Graph APIs that don't support application permissions. In these cases, you can use the `Add-MtTestResultDetail -SkippedBecause 'NotSupportedAppPermission'` to indicate that the test was skipped due to this limitation.
+
+Use this code block to perform the check.
+
+```powershell
+if (((Get-MgContext).AuthType) -ne "Delegated") {
+    Add-MtTestResultDetail -SkippedBecause 'NotSupportedAppPermission'
+    return $null
+}
+```
 
 ### Step 3: Create the markdown file
 


### PR DESCRIPTION
@merill Just worked on this test. After finalization, I noticed that the graph endpoint “directory/onPremisesSynchronization” does not support application permissions and I still had an active login with my ga. 
According to the documentation: [Update onPremisesDirectorySynchronization
](https://learn.microsoft.com/en-us/graph/api/onpremisesdirectorysynchronization-update?view=graph-rest-1.0&tabs=http)
In order not to lose the work, I wanted to add it anyway. Perhaps you have any idea on how to fix / workaround on this. Otherwise we'll need to drop this one.

Best regards
Henrik