### PR TITLE
Improve Invoke-MtGraphRequest

### DIFF
--- a/powershell/internal/Invoke-MtGraphRequestCache.ps1
+++ b/powershell/internal/Invoke-MtGraphRequestCache.ps1
@@ -41,7 +41,7 @@ function Invoke-MtGraphRequestCache {
             $results = Invoke-MgGraphRequest -Method $Method -Uri $Uri -Headers $Headers -OutputType $OutputType -Body $Body
         }
 
-        if (!$isBatch -and $isMethodGet) {
+        if (!$DisableCache -and !$isBatch -and $isMethodGet) {
             # Update cache
             if ($isInCache) {
                 $__MtSession.GraphCache[$cacheKey] = $results

--- a/powershell/public/Invoke-MtGraphRequest.ps1
+++ b/powershell/public/Invoke-MtGraphRequest.ps1
@@ -99,12 +99,21 @@ function Invoke-MtGraphRequest {
         }
 
         function Complete-Result ($results, $DisablePaging) {
-            if (!$DisablePaging -and $results) {
-                while (Get-ObjectProperty $results '@odata.nextLink') {
-                    $results = Invoke-MtGraphRequestCache -Method GET -Uri $results.'@odata.nextLink' -Headers @{ ConsistencyLevel = $ConsistencyLevel } -OutputType $OutputType -DisableCache:$DisableCache
-                    Format-Result $results $DisablePaging
+            if (!$DisablePaging -and $results -and (Get-ObjectProperty $results '@odata.nextLink')) {
+                # The "skipToken" are in rare cases not unique, so when it is processed, we can end up in a caching loop. By updating the cache with the original uri with the final result, we workaround this issue and have a faster cache.
+                $resultList = New-Object -TypeName System.Collections.ArrayList
+                $resultList.AddRange(@($results.value))
+                do {
+                    $results = Invoke-MtGraphRequestCache -Method GET -Uri $results.'@odata.nextLink' -Headers @{ ConsistencyLevel = $ConsistencyLevel } -OutputType $OutputType -DisableCache # Do not use cache as "skipTokens" is not always unique in large datasets and we may end with a loop
+                    $resultList.AddRange(@($results.value))
+                } while (Get-ObjectProperty $results '@odata.nextLink')
+                $results.value = $resultList
+                # Update the original request cache with the consolidated results
+                if (!$DisableCache) {
+                    $__MtSession.GraphCache[$uriQueryEndpointFinal.Uri.AbsoluteUri] = $results
                 }
             }
+            Format-Result $results $DisablePaging
         }
     }
 
@@ -150,10 +159,7 @@ function Invoke-MtGraphRequest {
                     }
                     $listRequests.Add($request)
                 } else {
-
                     $results = Invoke-MtGraphRequestCache -Method GET -Uri $uriQueryEndpointFinal.Uri.AbsoluteUri -Headers @{ ConsistencyLevel = $ConsistencyLevel } -OutputType $OutputType -DisableCache:$DisableCache
-
-                    Format-Result $results $DisablePaging
                     Complete-Result $results $DisablePaging
                 }
             }
@@ -172,7 +178,6 @@ function Invoke-MtGraphRequest {
                 $resultsBatch = $resultsBatch.responses | Sort-Object -Property id
 
                 foreach ($results in ($resultsBatch.body)) {
-                    Format-Result $results $DisablePaging
                     Complete-Result $results $DisablePaging
                 }
             }


### PR DESCRIPTION
On a customer tenant with a large group, the Get-MtGroupMember went into a loop because the "SkipToken" in the Microsoft Graph "nextdata" was not unique after enough paging, meaning that Invoke-MtGraphRequest would find the "next page" in the cache, which 1) includes already collected members and 2) contain a previous "SkipToken". This would result in a loop, because that previous SkipToken URI was also in the cache etc.

@merill any idea why the "SkipToken" wouldn't be unique in a large call? The group has approximately 3700 users.

I've fixed it by not utilizing the cache when paging and also optimized performance by updated the initial call in the cache containing the full response. Each paging call is not saved in cache anymore – only that initial call.

I've also changed so that the results are only formatted once.