### PR TITLE
Added GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,13 +7,27 @@
 🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
 
 - [ ] Read the guidelines for contributions
-- [ ] Check that the unique ID you want to use is not already picked. See [here](https://github.com/maester365/maester/issues/697)
-- [ ] Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
-- [ ] If changing anything in the action, make sure it still works and is backward compatible.
+
+#### PRs related to all code
+
+- [ ] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
+- [ ] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).
+
+#### PRs related to Maester Tests
+
+If you are contributing a test or making updates to a test please verify these.
+
+- [ ] Check that the unique ID you want to use is not already picked. See [Pick next Maester test sequence number](https://github.com/maester365/maester/issues/697)
+- [ ] Add Test with your .ps1 and .md-file (make sure .ps1 file is encoded with "UTF8 with BOM") `.\powershell\public\maester...`
+- [ ] Add your new test-function to a corresponding .test.ps1 file `\tests\Maester..*.test.ps1`
+- [ ] Add your new test-function to 'FunctionsToExport'-List `.\powershell\Maester.psd1`
+- [ ] Add test Id, Severity and Title to "maester-config.json" file `.\tests\maester-config.json`
+- [ ] Add website documentation for test with name of "testId.md" `.\website\docs\tests\maester`
+- [ ] If Invoke-Maester parameters are changed, update the GitHub action to use the new parameters.
 
 ### Review
 
-We will try to review your pull request as soon as possible.
+We will try to review your pull request as soon as possible. If you have any queries or need any help please jump on [Discord](https://discord.maester.dev/). We really appreciate your contributions!
 
 <!-- While your wait for a review, why not try to spread some Maester love on social media? -->
 


### PR DESCRIPTION
Due to recent events in https://github.com/maester365/maester/issues/697, I propose a request template. I took this from the maester-action repo and adapted it.
Please adapt it as you see fit; this is only a suggestion to get the idea out there.

<img width="685" height="404" alt="image" src="https://github.com/user-attachments/assets/da004bef-d4d1-465a-9eea-15d9ce03b76a" />
