### PR TITLE
Html report cleanup

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -5,7 +5,7 @@ This is the main Maester command that runs the tests and generates a report of t
 .DESCRIPTION
 Using Invoke-Maester is the easiest way to run the Pester tests and generate a report of the results.
 
-For more advanced configuration, you can directly use the Pester module and the Export-MtHtmlReport function.
+For more advanced configuration, you can directly use the Pester module and the Get-MtHtmlReport function.
 
 By default, Invoke-Maester runs all *.Tests.ps1 files in the current directory and all subdirectories recursively.
 

--- a/report/README.md
+++ b/report/README.md
@@ -2,7 +2,7 @@
 
 This folder contains the test report for the Maester project.
 
-It uses vite-plugin-singlefile to generate a single HTML file which will be used by the Export-MtHtmlReport cmdlet to generate the html report
+It uses vite-plugin-singlefile to generate a single HTML file which will be used by the Get-MtHtmlReport cmdlet to generate the html report
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh

--- a/report/src/App.jsx
+++ b/report/src/App.jsx
@@ -10,7 +10,7 @@ import MtDonutChart from "./components/MtDonutChart";
 import MtTestSummary from "./components/MtTestSummary";
 import MtBlocksArea from './components/MtBlocksArea';
 
-/*The sample data will be replaced by the New-MtReport when it runs the generation.*/
+/*The sample data will be replaced by the Get-MtHtmlReport when it runs the generation.*/
 const testResults = {
   "Result": "Failed",
   "FailedCount": 2,
@@ -210,7 +210,7 @@ const testResults = {
 };
 
 /* Note: DO NOT place any code between the line 'const testResults = {' and 'function App'.
-    They will be stripped away new New-MtReport cmdlet generates the user's content */
+    They will be stripped away when Get-MtHtmlReport cmdlet generates the user's content */
 
 function App() {
 

--- a/website/docs/commands/Invoke-Maester.mdx
+++ b/website/docs/commands/Invoke-Maester.mdx
@@ -28,7 +28,7 @@ Invoke-Maester [[-Path] <String>] [-Tag <String[]>] [-ExcludeTag <String[]>] [-O
 
 Using Invoke-Maester is the easiest way to run the Pester tests and generate a report of the results.
 
-For more advanced configuration, you can directly use the Pester module and the Export-MtHtmlReport function.
+For more advanced configuration, you can directly use the Pester module and the Get-MtHtmlReport function.
 
 By default, Invoke-Maester runs all *.Tests.ps1 files in the current directory and all subdirectories recursively.
 


### PR DESCRIPTION
Missed a few spots going from `New-MtReport` -> `Export-MtHtmlReport` -> `Get-MtHtmlReport`.

