### PR TITLE
Correct portal link format for secure score

### DIFF
--- a/powershell/public/maester/exchange/Test-MtExoModernAuth.ps1
+++ b/powershell/public/maester/exchange/Test-MtExoModernAuth.ps1
@@ -28,7 +28,7 @@ function Test-MtExoModernAuth {
     try {
         Write-Verbose "Getting Organization Config..."
         $organizationConfig = Get-MtExo -Request OrganizationConfig
-        $portalLink_SecureScore = "$($__MtSession.AdminPortalUrl.Security)/securescore"
+        $portalLink_SecureScore = "$($__MtSession.AdminPortalUrl.Security)securescore"
 
         $result = $organizationConfig.OAuth2ClientProfileEnabled
 


### PR DESCRIPTION
### Description

Removed an extraneous "/" in `Test-MtExoModernAuth.ps1` that created a malformed Secure Score link (double slashes).

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [x] Read the guidelines for contributions

#### PRs related to all code

- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [x] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).