### PR TITLE
Issue1128 changed checks to check the Default Policy that is actually set

### DIFF
--- a/powershell/public/cis/Test-MtCisAttachmentFilterComprehensive.ps1
+++ b/powershell/public/cis/Test-MtCisAttachmentFilterComprehensive.ps1
@@ -65,7 +65,7 @@ function Test-MtCisAttachmentFilterComprehensive {
             $policy = $policies | Where-Object { $_.Id -eq $policyId }
             if ($policy.EnableFileFilter -ne 'True') {
                 # If the policy isn't enabled, skip
-                break
+                continue
             }
 
             foreach ($extension in $L2Extensions) {

--- a/powershell/public/cis/Test-MtCisConnectionFilterSafeList.ps1
+++ b/powershell/public/cis/Test-MtCisConnectionFilterSafeList.ps1
@@ -26,12 +26,13 @@ function Test-MtCisConnectionFilterSafeList {
 
     try {
         Write-Verbose 'Getting the Hosted Connection Filter policy...'
-        $connectionFilterSafeList = Get-HostedConnectionFilterPolicy -Identity Default | Select-Object EnableSafeList
+        $connectionFilterSafeList = Get-HostedConnectionFilterPolicy | Where-Object {$_.isDefault -eq $true} | Select-Object EnableSafeList
 
         Write-Verbose 'Check if the Connection Filter safe list is enabled'
-        $result = $connectionFilterSafeList | Where-Object { $_.EnableSafeList -eq 'False' }
+        $result = $connectionFilterSafeList.EnableSafeList
 
-        $testResult = ($result | Measure-Object).Count -eq 0
+        # We need to Invert the $result that we don't need to change the Markdown. False in $result is good and True is bad
+        $testResult = !$result
 
         if ($testResult) {
             $testResultMarkdown = 'Well done. The connection filter safe list was not enabled ✅'

--- a/powershell/public/cis/Test-MtCisHostedConnectionFilterPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisHostedConnectionFilterPolicy.ps1
@@ -26,12 +26,11 @@ function Test-MtCisHostedConnectionFilterPolicy {
 
     try {
         Write-Verbose 'Getting the Hosted Connection Filter policy...'
-        $connectionFilterIPAllowList = Get-HostedConnectionFilterPolicy -Identity Default | Select-Object IPAllowList
+        $connectionFilterIPAllowList = Get-HostedConnectionFilterPolicy | Where-Object {$_.isDefault -eq $true} | Select-Object IPAllowList
 
         Write-Verbose 'Check if the Connection Filter IP allow list is empty'
-        $result = $connectionFilterIPAllowList | Where-Object { $_.IPAllowList.Count -ne 0 }
+        $testResult = -not $connectionFilterIPAllowList.IPAllowList
 
-        $testResult = ($result | Measure-Object).Count -eq 0
         if ($testResult) {
             $testResultMarkdown = 'Well done. The connection filter IP allow list was empty ✅'
         } else {

--- a/powershell/public/cis/Test-MtCisInternalMalwareNotification.ps1
+++ b/powershell/public/cis/Test-MtCisInternalMalwareNotification.ps1
@@ -32,7 +32,7 @@ function Test-MtCisInternalMalwareNotification {
         $policies = Get-MtExo -Request MalwareFilterPolicy
 
         # We grab the default policy as that is what CIS checks
-        $policy = $policies | Where-Object { $_.Name -eq 'Default' }
+        $policy = $policies | Where-Object { $_.IsDefault -eq $true }
 
         Write-Verbose 'Executing checks'
         $enableInternalSenderAdminNotification = $policy | Where-Object {

--- a/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisOutboundSpamFilterPolicy.ps1
@@ -32,7 +32,7 @@ function Test-MtCisOutboundSpamFilterPolicy {
         $policies = Get-MtExo -Request HostedOutboundSpamFilterPolicy
 
         # We grab the default policy as that is what CIS checks
-        $policy = $policies | Where-Object { $_.Name -eq 'Default' }
+        $policy = $policies | Where-Object { $_.IsDefault -eq $true }
 
         $OutboundSpamFilterPolicyCheckList = @()
 

--- a/powershell/public/cis/Test-MtCisSafeAntiPhishingPolicy.ps1
+++ b/powershell/public/cis/Test-MtCisSafeAntiPhishingPolicy.ps1
@@ -35,7 +35,7 @@ function Test-MtCisSafeAntiPhishingPolicy {
         $policies = Get-MtExo -Request AntiPhishPolicy
 
         # We grab the default policy as that is what CIS checks
-        $policy = $policies | Where-Object { $_.Name -eq 'Office365 AntiPhish Default' }
+        $policy = $policies | Where-Object { $_.IsDefault -eq $true }
 
         $antiPhishingPolicyCheckList = @()
 


### PR DESCRIPTION
### Description
Fixes #1128 #942 #1077 
#### Test-MtCisAttachmentFilterComprehensive
Not sure why the foreach loop exited with a break instead of a continue. Maybe change the check to only check the IsDefault Policy? I now opted for the Continue Variant so all policies get checked. Let me know if you want me to change it.
#### All other Policies
Changed all checks to utilize the "IsDefault" Parameters that all these commands have, instead of the hardcoded names.
#### Test-MtCisConnectionFilterSafeList 
This had issues and was always True. The Object is already selected and we can work with it straight away. I inverted the Result that I don't need to change the Markdown result. False is what we want and True is bad. Made a comment for it.
#### Test-MtCisHostedConnectionFilterPolicy 
Had Issues when the Array is empty. This happens when an IP was entered previously and then removed again.

### Your checklist for this pull request
- [x] Read the guidelines for contributions
#### PRs related to all code
- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1` "[12:36:07][pester.ps1] All 3646 tests executed without a single failure!"
- [ ] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).
