### PR TITLE
Prevent spf infinite recursion due to self-referencing redirect directive

### DIFF
--- a/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
+++ b/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
@@ -122,8 +122,13 @@ function Resolve-SPFRecord {
             if ( $SPFDirectives -match "redirect" ) {
                 $RedirectRecord = $SPFDirectives -match "redirect" -replace "redirect="
                 Write-Verbose "[REDIRECT]`t$RedirectRecord"
-                # Follow the include and resolve the include
-                Resolve-SPFRecord -Name "$RedirectRecord" -Server $Server -Referrer $Name
+                # Follow the redirect and resolve the redirect
+                # Check for SPF records that redirect to themselves, it will lead to an infinite loop => ** explosion **
+                if ( $Name -ne $RedirectRecord ) {
+                    Resolve-SPFRecord -Name "$RedirectRecord" -Server $Server -Referrer $Name
+                } else {
+                    return "Self-referencing SPF directive"
+                }
             } else {
 
                 # Extract the qualifier

--- a/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
+++ b/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
@@ -150,6 +150,8 @@ function Resolve-SPFRecord {
                             # Check for SPF records that include themselves, it will lead to an infinite loop => ** explosion **
                             if ( $Name -ne $IncludeTarget ) {
                                 Resolve-SPFRecord -Name $IncludeTarget -Server $Server -Referrer $Name
+                            } else {
+                                return "Self-referencing SPF directive"
                             }
                         }
                         '^ip[46]:.*$' {

--- a/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
+++ b/powershell/public/cisa/exchange/Resolve-SPFRecord.ps1
@@ -146,7 +146,11 @@ function Resolve-SPFRecord {
                         }
                         '^include:.*$' {
                             # Follow the include and resolve the include
-                            Resolve-SPFRecord -Name ( $SPFDirective -replace "^include:" ) -Server $Server -Referrer $Name
+                            $IncludeTarget = ( $SPFDirective -replace "^include:" )
+                            # Check for SPF records that include themselves, it will lead to an infinite loop => ** explosion **
+                            if ( $Name -ne $IncludeTarget ) {
+                                Resolve-SPFRecord -Name $IncludeTarget -Server $Server -Referrer $Name
+                            }
                         }
                         '^ip[46]:.*$' {
                             Write-Verbose "[IP]`tSPF entry: $SPFDirective"


### PR DESCRIPTION
When running the MS.EXO.2.2 (SPF) test against a domain that has a recursive loop in the SPF records (i.e. it redirects to itself), the test fails to identify the misconfiguration and goes into an infinite loop, ultimately resulting in a stack overflow. This results in the execution aborting and other tests not being run.

This PR adds a simple check in the Resolve-SPFRecord function to prevent this.

This change is very similar to the change in https://github.com/maester365/maester/pull/1070 but handles misconfigured *redirect* directives, rather than *include* directives.