### PR TITLE
FIx: Test failed when no Subsciptions found. Not get skipped with reason

### DIFF
--- a/powershell/public/maester/azure/Get-AzureRootManagementGroup.ps1
+++ b/powershell/public/maester/azure/Get-AzureRootManagementGroup.ps1
@@ -1,0 +1,42 @@
+﻿<#
+.SYNOPSIS
+    Gets the Azure Tenant Root Management Group ID
+
+.DESCRIPTION
+    This function retrieves the Tenant Root Management Group ID by querying all management groups
+    and finding the one with the display name "Tenant Root Group".
+
+.EXAMPLE
+    Test-AzureRootManagementGroup
+
+    Returns the ID of the Tenant Root Management Group if found, otherwise returns $null.
+
+.LINK
+    https://maester.dev/docs/commands/Test-AzureRootManagementGroup
+#>
+function Get-AzureRootManagementGroup {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    try {
+        $mgResponse = Invoke-MtAzureRequest `
+            -RelativeUri "/providers/Microsoft.Management/managementGroups" `
+            -ApiVersion "2020-05-01"
+
+        $mgList = $mgResponse.value
+    }
+    catch {
+        Write-Verbose "Error retrieving management groups: $_"
+        return $null
+    }
+
+    $rootGroup = $mgList | Where-Object { $_.properties.displayName -eq "Tenant Root Group" }
+
+    if (-not $rootGroup) {
+        Write-Verbose "Tenant Root Group not found in management groups."
+        return $null
+    }
+
+    return $rootGroup.name
+}

--- a/powershell/public/maester/azure/Test-MtManagementGroupWriteRequirement.ps1
+++ b/powershell/public/maester/azure/Test-MtManagementGroupWriteRequirement.ps1
@@ -24,27 +24,13 @@ function Test-MtManagementGroupWriteRequirement {
         return $null
     }
 
-    try {
-        $mgResponse = Invoke-MtAzureRequest `
-            -RelativeUri "/providers/Microsoft.Management/managementGroups" `
-            -ApiVersion "2020-05-01"
+    $rootMgId = Get-AzureRootManagementGroup
 
-        $mgList = $mgResponse.value
-    }
-    catch {
-        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
-        return $null
-    }
-
-    $rootGroup = $mgList | Where-Object { $_.properties.displayName -eq "Tenant Root Group" }
-
-    if (-not $rootGroup) {
+    if (!($rootMgId)) {
         Write-Verbose "Tenant Root Group not found in management groups."
-        Add-MtTestResultDetail -SkippedBecause "Tenant Root Group not found"
+        Add-MtTestResultDetail -SkippedBecause "Custom" -SkippedCustomReason "Tenant Root Group not found"
         return $null
     }
-
-    $rootMgId = $rootGroup.name
 
     try {
         $settingResponse = Invoke-MtAzureRequest `


### PR DESCRIPTION
### Description

Moved the get tenant root group to a function and fixed the bug using Add-MtTestResultDetail for this test.