### PR TITLE
Added missing entry for MT.1063 in maester-config.json

### DIFF
--- a/tests/maester-config.json
+++ b/tests/maester-config.json
@@ -1096,6 +1096,11 @@
       "Title": "Ensure Direct Send is set to be rejected"
     },
     {
+      "Id": "MT.1063",
+      "Severity": "High",
+      "Title": "All app registration owners should have MFA registered"
+    },
+    {
       "Id": "MT.1064",
       "Severity": "High",
       "Title": "Management group creation should be limited to users with explicit write access"


### PR DESCRIPTION
### Description

This pull request adds a missing entry for MT.1063 to the `tests/maester-config.json` configuration file.

Security rule addition:

* Added rule `MT.1063` with high severity to require MFA registration for all app registration owners in `tests/maester-config.json`.

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [x] Read the guidelines for contributions

#### PRs related to all code

- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [x] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).

#### PRs related to Maester Tests

If you are contributing a test or making updates to a test please verify these.

- [x] Add test Id, Severity and Title to "maester-config.json" file `.\tests\maester-config.json`