### PR TITLE
Add support for browser sign-in in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 		}
 	},
 	"forwardPorts": [3000, 5173],
-	"postCreateCommand": "cd ./website && npm i && cd ../report && npm i",
+	"postCreateCommand": "/bin/bash ./.devcontainer/postCreateCommand.sh",
 	"customizations": {
 		"vscode": {
 			"settings": {
@@ -27,5 +27,8 @@
 				"website/docs/contributing.md"
 			]
 		}
-	}
+	},
+	"runArgs": [
+    	"--network=host"
+	]
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,6 @@
+# Install xdg-utils to open authentication in device browser
+sudo apt-get update
+sudo apt-get install -y xdg-utils
+
+# Build website and report
+cd ./website && npm i && cd ../report && npm i


### PR DESCRIPTION
### Description

I noticed that the devcontainer configuration did not support browser sign-in when running Connect-Maester. Because of this, a fallback happens on Device Code authentication. This PR includes the installation of xdg-utils as part of the post installation command, making sure the devcontainer is able to open a browser of the device it runs on to authenticate smoothly. For the tokens to be redirected to the container, the container needs to share the host network.

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [ X ] Read the guidelines for contributions

#### PRs related to all code

- [ X ] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [ X ] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).

