### PR TITLE
Fix typo in environment variable name for drift folder

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -376,12 +376,12 @@ function Invoke-Maester {
             Write-Warning "❌ The specified drift root directory '$DriftRoot' does not exist."
 
         } else {
-            Set-Item -Path Env:\MEASTER_FOLDER_DRIFT -Value $DriftRoot
+            Set-Item -Path Env:\MAESTER_FOLDER_DRIFT -Value $DriftRoot
             Write-Verbose "🧪 Drift root directory set to: $DriftRoot"
         }
     } else {
         # Default drift root directory
-        # Set-Item -Path Env:\MEASTER_FOLDER_DRIFT -Value $(Join-Path -Path (Get-Location) -ChildPath "drift")
+        # Set-Item -Path Env:\MAESTER_FOLDER_DRIFT -Value $(Join-Path -Path (Get-Location) -ChildPath "drift")
     }
 
     $maesterResults = $null


### PR DESCRIPTION
Fixed typo from "MEASTER" to "MAESTER" in DriftRoot block.