### PR TITLE
Add support for new LongRunning and Preview tags to replace Full and All

### DIFF
--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -370,7 +370,6 @@ function Invoke-Maester {
 
     # Warn about deprecated tag usage.
     $DeprecatedTags = @('All','Full')
-    #$UsedDeprecatedTags = $Tag | Where-Object { $DeprecatedTags -contains $_ }
     $UsedDeprecatedTags = $DeprecatedTags | Where-Object { $Tag -contains $_ -or $ExcludeTag -contains $_ }
     if ($UsedDeprecatedTags) {
         Write-Warning "The 'All' and 'Full' tags are being deprecated and will be removed in a future release. Please use the following tags instead: `n`nLongRunning: Tests that can take a long time to run when the tenant has a large number of objects. Replaces 'Full'.`nPreview    : Tests that are still being tested or are dependent on preview APIs. Replaces 'All'."

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -9,6 +9,12 @@ For more advanced configuration, you can directly use the Pester module and the 
 
 By default, Invoke-Maester runs all *.Tests.ps1 files in the current directory and all subdirectories recursively.
 
+.PARAMETER IncludeLongRunning
+Include tests that can take a long time to run in tenants with a large number of objects.
+
+.PARAMETER IncludePreview
+Include tests that are still being tested or are dependent on preview APIs.
+
 .PARAMETER NoLogo
 Do not show the Maester logo.
 
@@ -18,57 +24,57 @@ This will suppress the logo when Maester starts and prevent the test results fro
 .EXAMPLE
 Invoke-Maester
 
-Runs all the test files under the current folder and generates a report of the results in the ./test-results folder.
+Runs all the test files under the current folder (except for those tagged as LongRunning and Preview) and generates a report of the results in the ./test-results folder.
 
 .EXAMPLE
 Invoke-Maester ./maester-tests
 
-Runs all the tests in the folder ./tests/Maester and generates a report of the results in the default ./test-results folder.
+Runs all the tests in the folder ./tests/Maester (except for those tagged as LongRunning and Preview) and generates a report of the results in the default ./test-results folder.
 
 .EXAMPLE
-Invoke-Maester -Tag 'CA'
+Invoke-Maester -Tag 'CA' -IncludeLongRunning
 
-Runs the tests with the tag "CA" and generates a report of the results in the default ./test-results folder.
+Runs the tests with the tag "CA" and includes long-running tests. Generates a report of the results in the default ./test-results folder.
 
 .EXAMPLE
-Invoke-Maester -Tag 'CA', 'App'
+Invoke-Maester -Tag 'CA', 'App' -IncludePreview
 
-Runs the tests with the tags 'CA' and 'App' and generates a report of the results in the default ./test-results folder.
+Runs the tests with the tags 'CA' and 'App' and includes preview tests. Generates a report of the results in the default ./test-results folder.
 
 .EXAMPLE
 Invoke-Maester -OutputFolder './my-test-results'
 
-Runs all the tests and generates a report of the results in the ./my-test-results folder.
+Runs tests and generates a report of the results in the ./my-test-results folder.
 
 .EXAMPLE
 Invoke-Maester -OutputHtmlFile './test-results/TestResults.html'
 
-Runs all the tests and generates a report of the results in the specified file.
+Runs the tests and generates a report of the results in the specified file.
 
 .EXAMPLE
 Invoke-Maester -Path ./tests/EIDSCA
 
-Runs all the tests in the EIDSCA folder.
+Runs tests in the EIDSCA folder.
 
 .EXAMPLE
 Invoke-Maester -MailRecipient john@contoso.com
 
-Runs all the tests and sends a report of the results to mail recipient.
+Runs the tests and sends a report of the results to an email recipient.
 
 .EXAMPLE
 Invoke-Maester -TeamId '00000000-0000-0000-0000-000000000000' -TeamChannelId '19%3A00000000000000000000000000000000%40thread.tacv2'
 
-Runs all the tests and posts a summary of the results to a Teams channel.
+Runs the tests and posts a summary of the results to a Teams channel.
 
 .EXAMPLE
 Invoke-Maester -TeamChannelWebhookUri 'https://some-url.logic.azure.com/workflows/invoke?api-version=2016-06-01'
 
-Runs all the tests and posts a summary of the results to a Teams channel.
+Runs the tests and posts a summary of the results to a Teams channel.
 
 .EXAMPLE
 Invoke-Maester -Verbosity Normal
 
-Shows results of tests as they are run including details on failed tests.
+Shows results of tests as they are run, including details on failed tests.
 
 .EXAMPLE
 ```powershell
@@ -80,7 +86,15 @@ $configuration.Filter.ExcludeTag = 'App'
 Invoke-Maester -PesterConfiguration $configuration
 ```
 
-Runs all the Pester tests in the EIDSCA folder.
+Runs Pester tests in the ./tests/Maester folder that include the 'CA' tag and exclude the 'App' tag.
+
+.EXAMPLE
+```powershell
+Connect-Maester -Service All
+Invoke-Maester -IncludeLongRunning -IncludePreview
+```
+
+Connect to all tested services and run all tests, including the long-running and preview tests.
 
 .LINK
     https://maester.dev/docs/commands/Invoke-Maester
@@ -91,7 +105,7 @@ function Invoke-Maester {
     [Alias("Invoke-MtMaester")]
     [CmdletBinding()]
     param (
-        # Specifies path to files containing tests. The value is a path\file name or name pattern. Wildcards are permitted.
+        # Specifies path to files containing tests. The value is a path\file name or a name pattern. Wildcards are permitted.
         [Parameter(Position = 0)]
         [string] $Path,
 
@@ -101,10 +115,10 @@ function Invoke-Maester {
         # Exclude the tests that match this tag(s).
         [string[]] $ExcludeTag,
 
-        # Include long running tests
+        # Include long running tests.
         [switch] $IncludeLongRunning,
 
-        # Include preview tests
+        # Include preview tests.
         [switch] $IncludePreview,
 
         # The path to the file to save the test results in html format. The filename should include an .html extension.
@@ -116,25 +130,24 @@ function Invoke-Maester {
         # The path to the file to save the test results in json format. The filename should include a .json extension.
         [string] $OutputJsonFile,
 
-        # The folder to save the test results. If PassThru and no -Output* is set, defaults to ./test-results.
-        # If set, other -Output* parameters are ignored and all formats will be generated (markdown, html, json)
-        # with a timestamp and saved in the folder.
+        # The folder to save the test results in. If no -Output* is set, defaults to ./test-results.
+        # If set, other -Output* parameters are ignored and all formats will be generated (markdown, html, json) with a timestamp and saved in the folder.
         [string] $OutputFolder,
 
-        # The filename to use for all the files in the output folder. e.g. 'TestResults' will generate TestResults.html, TestResults.md, TestResults.json.
+        # The filename prefix to use for all the files in the output folder. e.g. 'TestResults' will generate TestResults.html, TestResults.md, TestResults.json.
         [string] $OutputFolderFileName,
 
-        # [PesterConfiguration] object for Advanced Configuration
+        # An optional [PesterConfiguration] object for advanced configuration.
         # Default is New-PesterConfiguration
         # For help on each option see New-PesterConfiguration, or inspect the object it returns.
         # See [Pester Configuration](https://pester.dev/docs/usage/Configuration) for more information.
         [PesterConfiguration] $PesterConfiguration,
 
         # Set the Pester verbosity level. Default is 'None'.
-        # None: Shows only the final summary.
-        # Normal: Focus on successful containers and failed tests/blocks. Shows basic discovery information and the summary of all tests.
-        # Detailed: Similar to Normal, but this level shows all blocks and tests, including successful.
-        # Diagnostic: Very verbose, but useful when troubleshooting tests. This level behaves like Detailed, but also enables debug-messages.
+        # None      : Shows only the final summary.
+        # Normal    : Focus on successful containers and failed tests/blocks. Shows basic discovery information and the summary of all tests.
+        # Detailed  : Similar to Normal, but this level shows all blocks and tests, including successful.
+        # Diagnostic: Very verbose, but useful when troubleshooting tests. This level behaves like Detailed, but also enables debug messages.
         [ValidateSet('None', 'Normal', 'Detailed', 'Diagnostic')]
         [string] $Verbosity = 'None',
 
@@ -144,31 +157,31 @@ function Invoke-Maester {
         # Passes the output of the Maester tests to the console.
         [switch] $PassThru,
 
-        # Optional. The email addresses of the recipients. e.g. john@contoso.com
+        # Optional: The email addresses of the report recipients. e.g. john@contoso.com
         # No email will be sent if this parameter is not provided.
         [string[]] $MailRecipient,
 
-        # Uri to the detailed test results page.
+        # If sending the report to an email recipient, provide a Uri to the detailed test results page.
         [string] $MailTestResultsUri,
 
         # The user id of the sender of the mail. Defaults to the current user.
         # This is required when using application permissions.
         [string] $MailUserId,
 
-        # Optional. The Teams team where the test results should be posted.
+        # Optional: The Teams team where the test results should be posted.
         # To get the TeamId, right-click on the channel in Teams and select 'Get link to channel'. Use the value of groupId. e.g. ?groupId=<TeamId>
         [string] $TeamId,
 
-        # Optional. The channel where the message should be posted. e.g. 19%3A00000000000000000000000000000000%40thread.tacv2
+        # Optional: The channel where the results message should be posted. e.g. 19%3A00000000000000000000000000000000%40thread.tacv2
         # To get the TeamChannelId, right-click on the channel in Teams and select 'Get link to channel'. Use the value found between channel and the channel name. e.g. /channel/<TeamChannelId>/my%20channel
         [string] $TeamChannelId,
 
-        # Optional. The webhook Uri where the message should be posted. e.g. https://some-url/?value=123
-        # To get the Webhook Uri, right-click on the channel in Teams and select 'Workflow'. Create a workflow using the 'Post to a channel when a webhook request is received' template. Use the value after complete
+        # Optional: The webhook Uri where the results message should be posted. e.g. https://some-url/?value=123
+        # To get the Webhook Uri, right-click on the channel in Teams and select 'Workflow'. Create a workflow using the 'Post to a channel when a webhook request is received' template. Use the value after 'complete.'
         [string] $TeamChannelWebhookUri,
 
         # Skip the graph connection check.
-        # This is used for running tests that does not require a graph connection.
+        # This is used for running tests that does not require a Graph connection.
         [switch] $SkipGraphConnect,
 
         # Disable Telemetry
@@ -191,7 +204,7 @@ function Invoke-Maester {
         [Parameter(HelpMessage = 'Do not show the logo when starting Maester.')]
         [switch] $NoLogo,
 
-        # Drift tests
+        # The root directory for configuration drift tracking.
         [Parameter(HelpMessage = 'Specify drift root directory, see https://maester.dev/docs/tests/MT.1060')]
         [string] $DriftRoot
     )
@@ -228,11 +241,11 @@ function Invoke-Maester {
         }
 
         if (![string]::IsNullOrEmpty($out.OutputFolder)) {
-            # Create the output folder if it doesn't exist and generate filenames
-            New-Item -Path $out.OutputFolder -ItemType Directory -Force | Out-Null # Create the output folder if it doesn't exist
+            # Create the output folder if it doesn't exist.
+            New-Item -Path $out.OutputFolder -ItemType Directory -Force | Out-Null
 
             if ([string]::IsNullOrEmpty($out.OutputFolderFileName)) {
-                # Generate a default filename
+                # Generate a default filename.
                 $timestamp = Get-Date -Format "yyyy-MM-dd-HHmmss"
                 $out.OutputFolderFileName = "TestResults-$timestamp"
             }
@@ -290,7 +303,8 @@ function Invoke-Maester {
         Write-Host -ForegroundColor Green $motd
     }
 
-    Clear-ModuleVariable # Reset the graph cache and urls to avoid stale data
+    # Reset the graph cache and urls to avoid stale data.
+    Clear-ModuleVariable
 
     if (-not $DisableTelemetry) {
         Write-Telemetry -EventName InvokeMaester
@@ -308,11 +322,11 @@ function Invoke-Maester {
         if (!(Test-MtContext -SendMail:$isMail -SendTeamsMessage:$isTeamsChannelMessage)) { return }
     }
 
-    # Initialize after graph connected
+    # Initialize MtSession after Graph connected.
     Initialize-MtSession
 
     if ($isWebUri) {
-        # Check if TeamChannelWebhookUri is a valid URL
+        # Check if TeamChannelWebhookUri is a valid URL.
         $urlPattern = '^(https)://[^\s/$.?#].[^\s]*$'
         if (-not ($TeamChannelWebhookUri -match $urlPattern)) {
             Write-Output "Invalid Webhook URL: $TeamChannelWebhookUri"
@@ -342,14 +356,14 @@ function Invoke-Maester {
         $ExcludeTag += "LongRunning"
     }
 
-    # If $Tag is not set, run all tests except the ones with the "Preview" tag (unless -IncludePreview is passed).
+    # If $Tag is not set and IncludePreview is not passed, run all tests except the ones with the "Preview" tag.
     if (-not $Tag) {
         if (-not $IncludePreview.IsPresent) {
             $ExcludeTag += "Preview"
         }
     }
 
-    # Include tests tagged as "Preview" if "Full" is included in $Tag.
+    # Include tests tagged as "Preview" if "Full" is included in $Tag. Included for backward compatibility with deprecated tags.
     if ("Full" -in $Tag) {
         $Tag += "Preview"
     }
@@ -387,7 +401,7 @@ function Invoke-Maester {
         return
     }
 
-    # If DriftRoot is specified, set the environment variable for drift tests
+    # If DriftRoot is specified, set the environment variable for drift tests.
     if ($DriftRoot) {
         $DriftRoot = (Resolve-Path -Path $DriftRoot -ErrorAction SilentlyContinue).Path
         if (-not (Test-Path -Path $DriftRoot)) {
@@ -397,7 +411,7 @@ function Invoke-Maester {
             Write-Verbose "🧪 Drift root directory set to: $DriftRoot"
         }
     } else {
-        # Default drift root directory
+        # Set the default drift root directory.
         # Set-Item -Path Env:\MAESTER_FOLDER_DRIFT -Value $(Join-Path -Path (Get-Location) -ChildPath "drift")
     }
 
@@ -444,7 +458,7 @@ function Invoke-Maester {
             Write-Host "🔥 Maester test report generated at $($out.OutputHtmlFile)" -ForegroundColor Green
 
             if ( ( Get-MtUserInteractive ) -and ( -not $NonInteractive ) ) {
-                # Open test results in default browser
+                # Open test results in the default browser.
                 Invoke-Item $out.OutputHtmlFile | Out-Null
             }
         }
@@ -465,7 +479,7 @@ function Invoke-Maester {
         }
 
         if ($Verbosity -eq 'None') {
-            # Show final summary
+            # Show final summary.
             Write-Host "`nTests Passed ✅: $($pesterResults.PassedCount), " -NoNewline -ForegroundColor Green
             Write-Host "Failed ❌: $($pesterResults.FailedCount), " -NoNewline -ForegroundColor Red
             Write-Host "Skipped ⚫: $($pesterResults.SkippedCount) " -NoNewline -ForegroundColor DarkGray
@@ -473,11 +487,11 @@ function Invoke-Maester {
         }
 
         if (-not $SkipVersionCheck -and 'Next' -ne $version) {
-            # Don't check version if running in dev
+            # Don't check version if running in dev.
             Get-IsNewMaesterVersionAvailable | Out-Null
         }
 
-        Write-MtProgress -Activity "🔥 Completed tests" -Status "Total $($pesterResults.TotalCount) " -Completed -Force # Clear progress bar
+        Write-MtProgress -Activity "🔥 Completed tests" -Status "Total $($pesterResults.TotalCount) " -Completed -Force # Clear progress bar.
     }
     Reset-MtProgressView
     if ($PassThru) {

--- a/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
+++ b/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
@@ -1,11 +1,11 @@
-Describe "Maester/Entra" -Tag "Maester", "App", "Security", "Full", "Entra", "Graph" {
-    It "MT.1057: App registrations should no longer use secrets. See https://maester.dev/docs/tests/MT.1057" -Tag "MT.1057" {
-        Test-MtAppRegistrationsWithSecrets | Should -Be $true -Because "app registrations should not use secrets and instead use workload identities or certificate-based authentication"
+Describe 'Maester/Entra' -Tag 'App', 'Entra', 'Full', 'Graph', 'LongRunning', 'Maester', 'Security' {
+    It 'MT.1057: App registrations should no longer use secrets. See https://maester.dev/docs/tests/MT.1057' -Tag 'MT.1057' {
+        Test-MtAppRegistrationsWithSecrets | Should -Be $true -Because 'app registrations should not use secrets and instead use workload identities or certificate-based authentication'
     }
-    It "MT.1058: Exchange application access policies must be configured. See https://maester.dev/docs/tests/MT.1058" -Tag "MT.1058" {
-        Test-MtSpExchangeAppAccessPolicy | Should -Be $true -Because "all applications with Exchange permissions should have access policies configured"
+    It 'MT.1058: Exchange application access policies must be configured. See https://maester.dev/docs/tests/MT.1058' -Tag 'MT.1058' {
+        Test-MtSpExchangeAppAccessPolicy | Should -Be $true -Because 'all applications with Exchange permissions should have access policies configured'
     }
-    It "MT.1075: Require explicit assignment of Third Party Entra Apps. See https://maester.dev/docs/tests/MT.1075" -Tag "MT.1075" {
-        Test-MtServicePrincipalsForAllUsers | Should -Be $true -Because "Third Party Service Principals should require explicit assignment to users"
+    It 'MT.1075: Require explicit assignment of Third Party Entra Apps. See https://maester.dev/docs/tests/MT.1075' -Tag 'MT.1075' {
+        Test-MtServicePrincipalsForAllUsers | Should -Be $true -Because 'Third Party Service Principals should require explicit assignment to users'
     }
 }

--- a/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
@@ -1,8 +1,8 @@
 BeforeDiscovery {
-    $EntraIDPlan = Get-MtLicenseInformation -Product "EntraID"
-    $RegularUsers = Get-MtUser -Count 5 -UserType "Member"
-    $AdminUsers = Get-MtUser -Count 5 -UserType "Admin"
-    $EmergencyAccessUsers = Get-MtUser -Count 5 -UserType "EmergencyAccess"
+    $EntraIDPlan = Get-MtLicenseInformation -Product 'EntraID'
+    $RegularUsers = Get-MtUser -Count 5 -UserType 'Member'
+    $AdminUsers = Get-MtUser -Count 5 -UserType 'Admin'
+    $EmergencyAccessUsers = Get-MtUser -Count 5 -UserType 'EmergencyAccess'
     # Remove emergency access users from regular users
     $RegularUsers = $RegularUsers | Where-Object { $_.id -notin $EmergencyAccessUsers.id }
     # Remove emergency access users from admin users
@@ -13,23 +13,23 @@ BeforeDiscovery {
 }
 
 
-Describe "Maester/Entra" -Tag "Maester", "CA", "CAWhatIf", "Security" -Skip:( $EntraIDPlan -eq "Free" ) {
+Describe 'Maester/Entra' -Tag 'CA', 'CAWhatIf', 'LongRunning', 'Maester', 'Security' -Skip:( $EntraIDPlan -eq 'Free' ) {
 
-    Context "Maester/Entra" -ForEach @( $RegularUsers ) {
+    Context 'Maester/Entra' -ForEach @( $RegularUsers ) {
         # Regular users
-        It "MT.1033: User should be blocked from using legacy authentication (<userPrincipalName>)" -Tag "MT.1033" {
+        It 'MT.1033: User should be blocked from using legacy authentication (<userPrincipalName>)' -Tag 'MT.1033' {
             Test-MtCaWIFBlockLegacyAuthentication -UserId $id | Should -Be $true
         }
 
     }
 
-    Context "Maester/Entra" -ForEach @( $EmergencyAccessUsers ) {
+    Context 'Maester/Entra' -ForEach @( $EmergencyAccessUsers ) {
         # Emergency access users
-        It "MT.1034: Emergency access users should not be blocked (<userPrincipalName>)" -Tag "MT.1034" {
-            if ( ( Get-MtLicenseInformation EntraID ) -eq "Free" ) {
+        It 'MT.1034: Emergency access users should not be blocked (<userPrincipalName>)' -Tag 'MT.1034' {
+            if ( ( Get-MtLicenseInformation EntraID ) -eq 'Free' ) {
                 Add-MtTestResultDetail -SkippedBecause NotLicensedEntraIDP1
             } else {
-                Test-MtConditionalAccessWhatIf -UserId $id -IncludeApplications "00000002-0000-0ff1-ce00-000000000000" -ClientAppType exchangeActiveSync | Should -BeNullOrEmpty
+                Test-MtConditionalAccessWhatIf -UserId $id -IncludeApplications '00000002-0000-0ff1-ce00-000000000000' -ClientAppType exchangeActiveSync | Should -BeNullOrEmpty
             }
         }
 

--- a/tests/Maester/Entra/Test-MtAppRegistrationOwnersWithoutMFA.Tests.ps1
+++ b/tests/Maester/Entra/Test-MtAppRegistrationOwnersWithoutMFA.Tests.ps1
@@ -1,6 +1,6 @@
-Describe "Maester/Entra" -Tag "MT.1063", "Entra", "Security", "App", "Full" {
-    It "MT.1063: All App registration owners should have MFA registered" {
+Describe 'Maester/Entra' -Tag 'App', 'Entra', 'Full', 'LongRunning', 'Security' {
+    It 'MT.1063: All App registration owners should have MFA registered' -Tag 'MT.1063' {
         $result = Test-MtAppRegistrationOwnersWithoutMFA
-        $result | Should -Be $true -Because "All App registration owners should have MFA registered."
+        $result | Should -Be $true -Because 'All App registration owners should have MFA registered.'
     }
 }

--- a/tests/Maester/Entra/Test-MtHighRiskAppPermissions.Tests.ps1
+++ b/tests/Maester/Entra/Test-MtHighRiskAppPermissions.Tests.ps1
@@ -1,15 +1,15 @@
-Describe "Maester/Entra" -Tag "Full", "Entra", "Graph", "App" {
-    It "MT.1050: Apps with high-risk permissions having a direct path to Global Admin" -Tag "MT.1050" {
-        $result = Test-MtHighRiskAppPermissions -AttackPath "Direct"
+Describe 'Maester/Entra' -Tag 'App', 'Entra', 'Full', 'Graph', 'LongRunning', 'Preview' {
+    It 'MT.1050: Apps with high-risk permissions having a direct path to Global Admin' -Tag 'MT.1050' {
+        $result = Test-MtHighRiskAppPermissions -AttackPath 'Direct'
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "no graph application has permissions with a risk of having a direct path to Global Admin and full tenant takeover."
+            $result | Should -Be $true -Because 'no graph application has permissions with a risk of having a direct path to Global Admin and full tenant takeover.'
         }
     }
 
-    It "MT.1051: Apps with high-risk permissions having an indirect path to Global Admin" -Tag "MT.1051" {
-        $result = Test-MtHighRiskAppPermissions -AttackPath "Indirect"
+    It 'MT.1051: Apps with high-risk permissions having an indirect path to Global Admin' -Tag 'MT.1051' {
+        $result = Test-MtHighRiskAppPermissions -AttackPath 'Indirect'
         if ($null -ne $result) {
-            $result | Should -Be $true -Because "no graph application has permissions with a risk of having an indirect path to Global Admin and full tenant takeover."
+            $result | Should -Be $true -Because 'no graph application has permissions with a risk of having an indirect path to Global Admin and full tenant takeover.'
         }
     }
 }

--- a/tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1
+++ b/tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1
@@ -1,5 +1,5 @@
-Describe "Maester/Entra" -Tag "Maester", "DirSync", "Security", "Full", "Entra", "Graph" {
-    It "MT.1073: Soft- and hard-matching of synchronized objects should be blocked. See https://maester.dev/docs/tests/MT.1073" -Tag "MT.1073" {
-        Test-MtDirSyncSoftHardMatching | Should -Be $true -Because "on-premises directory synchronization soft- and hard-match is blocked"
+Describe 'Maester/Entra' -Tag 'DirSync', 'Entra', 'Graph', 'Maester', 'Security' {
+    It 'MT.1073: Soft- and hard-matching of synchronized objects should be blocked. See https://maester.dev/docs/tests/MT.1073' -Tag 'MT.1073' {
+        Test-MtDirSyncSoftHardMatching | Should -Be $true -Because 'on-premises directory synchronization soft- and hard-match is blocked'
     }
 }


### PR DESCRIPTION
# Description

This pull request begins the deprecation of the 'Full' and 'All' tags with the introduction of their 'LongRunning' and 'Preview' replacements.

All tests that currently use the 'Full' tag now have the 'LongRunning' tag added.
All tests that currently use the 'All' tag now have the 'Preview' tag added.
In a couple of cases, the 'Full' or 'All' tag have been removed where they are no longer relevant.

The `Invoke-Maester` function has been updated to rely on 'LongRunning' and 'Preview' as the new approach, but includes backwards compatible logic that still supports use of the 'Full' and 'All' tags. A warning has also been added to notify users if they are using a deprecated tag that may be removed in a future version.

The `Invoke-Maester` comment-based help and examples have been updated to reflect these changes and to clarify a few of the existing examples.

**New features and test selection improvements:**

* Added `-IncludeLongRunning` and `-IncludePreview` parameters to `Invoke-Maester`, allowing users to explicitly include long-running and preview tests. The command now excludes these tests by default unless specified. [[1]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aR12-R17) [[2]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aR118-R123) [[3]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL334-R376)
* Updated logic to handle deprecated tags (`All`, `Full`) and provide warnings, guiding users to use `LongRunning` and `Preview` tags instead.

**Documentation and examples:**

* Improved parameter descriptions and example usage in the command help, reflecting new options and clarifying output behavior. [[1]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL21-R77) [[2]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL83-R97) [[3]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL113-R140) [[4]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL131-R150) [[5]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL141-R184)
* Updated comments and help messages for parameters related to output, Teams, email, and drift tracking for better clarity. [[1]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL188-R207) [[2]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL141-R184)

**Code clarity and maintainability:**

* Improved inline comments, standardized naming, and fixed typos throughout `Invoke-Maester.ps1` for better readability and maintainability. [[1]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL225-R248) [[2]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL287-R307) [[3]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL305-R329) [[4]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL430-R461) [[5]](diffhunk://#diff-1648ccd5cdcd07c9d90774d966760b4224b9ace34f95192a7697cf4e6fc1ca7aL451-R494)

**Drift test configuration:**

* Updated drift root environment variable handling, fixing a typo (`MEASTER_FOLDER_DRIFT` → `MAESTER_FOLDER_DRIFT`) and clarifying logic for setting the default drift directory.

**Test file consistency:**

* Updated test files to use single quotes for strings and tags, and adjusted tagging to include `LongRunning` for relevant tests. [[1]](diffhunk://#diff-47a99ed12c8e14fa3e9b34c578031a507de1ed6910108b53f2f03c7f64522210L1-R9) [[2]](diffhunk://#diff-01e1cdd67a12562fec5841a19121cf52c22a34e531b1959665ed2bfcbcd574a5L2-R5)

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [x] Read the guidelines for contributions

#### PRs related to all code

- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [x] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).

#### PRs related to Maester Tests

If you are contributing a test or making updates to a test please verify these.

- [ ] If Invoke-Maester parameters are changed, update the GitHub action to use the new parameters.
