### PR TITLE
Fix PSModulePath assignment in build-validation.yaml

### DIFF
--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -54,7 +54,7 @@ jobs:
         shell: powershell
         run: |
           # Reuse downloaded modules from pwsh
-          $env:PSModulePath += ";$HOME\Documents\PowerShell\Modules"
+          $env:PSModulePath = ($env:PSModulePath).TrimEnd(';')+";$HOME\Documents\PowerShell\Modules"
           # Remove old test results
           Remove-Item -Path TestResults -Recurse -Force -ErrorAction SilentlyContinue
           # Run Pester tests on Windows PowerShell


### PR DESCRIPTION
### Description

This pull request makes a minor adjustment to the way the `PSModulePath` environment variable is set in the `build-validation.yaml` workflow. The change ensures that the script properly handles additions to the PSModulePath variable regardless of whether the existing value has a trailing semicolon at the end of it. It prevents the problem of having an empty value between two semicolons.

* Improved handling of the `PSModulePath` environment variable in the PowerShell script by trimming any trailing semicolons before appending the new module path (`$HOME\Documents\PowerShell\Modules`).