### PR TITLE
Remove trailing commas from inline JSON

### DIFF
--- a/powershell/tests/functions/Test-MtCaMfaForGuest.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaMfaForGuest.Tests.ps1
@@ -1,9 +1,4 @@
-﻿BeforeAll {
-  # Skip this Pester test if running on Windows PowerShell
-  $skip = $PSVersionTable.PSEdition -eq 'Desktop'
-}
-
-Describe 'Test-MtCaMfaForGuest' -Skip:$skip {
+Describe 'Test-MtCaMfaForGuest' {
   BeforeAll {
     Import-Module $PSScriptRoot/../../Maester.psd1 -Force
     Mock -ModuleName Maester Get-MtLicenseInformation { return "P1" }
@@ -20,19 +15,19 @@ Describe 'Test-MtCaMfaForGuest' -Skip:$skip {
       "applications": {
         "includeApplications": [
           "All"
-        ],
+        ]
       },
       "users": {
         "includeUsers": [
           "All"
-        ],
+        ]
       }
     },
     "grantControls": {
       "operator": "OR",
       "builtInControls": [
         "mfa"
-      ],
+      ]
     }
   }
 ]
@@ -78,7 +73,7 @@ Describe 'Test-MtCaMfaForGuest' -Skip:$skip {
       "operator": "OR",
       "builtInControls": [
         "mfa"
-      ],
+      ]
     }
   }
 ]
@@ -109,7 +104,7 @@ Describe 'Test-MtCaMfaForGuest' -Skip:$skip {
             "membershipKind": "all"
           }
         },
-        "excludeGuestsOrExternalUsers": null,
+        "excludeGuestsOrExternalUsers": null
       }
     },
     "grantControls": {


### PR DESCRIPTION
### Description

This resolves the issue with `Test-MtCaMfaForGuest.Tests.ps1` that prevented it from running in Windows PowerShell because of JSON validation errors.

Test execution improvements:
* Removed the logic that skips this Pester test when running on Windows PowerShell, so the test now always runs regardless of the PowerShell edition.

Formatting and consistency cleanups:
* Cleaned up trailing commas in JSON-like objects and arrays for improved consistency and to avoid potential parsing issues. [[1]](diffhunk://#diff-ced063b43660eb642a89c97d112755cca1179b004bd8ddfdf860c860b0349a7bL23-R30) [[2]](diffhunk://#diff-ced063b43660eb642a89c97d112755cca1179b004bd8ddfdf860c860b0349a7bL81-R76)
* Ensured consistent property formatting by removing unnecessary trailing commas in object definitions.