### PR TITLE
Fix for issue 1102 CISA.MS.EXO.4.2: The DMARC message rejection option SHALL be p=reject. Fails for contoso.mail.onmicrosoft.com

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
@@ -34,29 +34,52 @@ function Test-MtCisaDmarcRecordReject {
     #>
     $expandedDomains = @()
     foreach($domain in $acceptedDomains){
+        # If it's the coexistence domain (contoso.mail.onmicrosoft.com), skip the 2nd level check.
+        # If it's the initial domain (contoso.onmicrosoft.com), skip the 2nd level check. We cannot manage onmicrosoft.com.
+        if ($domain.IsCoexistenceDomain -or $domain.InitialDomain) {
+            $expandedDomains += [PSCustomObject]@{
+                DomainName = $domain.DomainName
+                IsCoexistenceDomain = $domain.IsCoexistenceDomain
+            }
+            continue
+        }
+
         #This regex does NOT capture for third level domain scenarios
         #e.g., example.co.uk; example.ny.us;
         $matchDomain = "(?:^|\.)(?'second'\w+.\w+$)"
         $dmarcMatch = $domain.domainname -match $matchDomain
         if($dmarcMatch){
-            $expandedDomains += $Matches.second
+            $expandedDomains += [PSCustomObject]@{
+                DomainName = $Matches.second
+                IsCoexistenceDomain = $domain.IsCoexistenceDomain
+            }
             if($domain.domainname -ne $Matches.second){
-                $expandedDomains += $domain.domainname
+                $expandedDomains += [PSCustomObject]@{
+                    DomainName = $domain.domainname
+                    IsCoexistenceDomain = $domain.IsCoexistenceDomain
+                }
             }
         }else{
-            $expandedDomains += $domain.domainname
+            $expandedDomains += [PSCustomObject]@{
+                DomainName = $domain.domainname
+                IsCoexistenceDomain = $domain.IsCoexistenceDomain
+            }
         }
     }
+    $expandedDomains = $expandedDomains | Sort-Object DomainName
 
     $dmarcRecords = @()
     foreach($domain in $expandedDomains){
-        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domain -Records DMARC
+        $dmarcRecord = Get-MailAuthenticationRecord -DomainName $domain.DomainName -Records DMARC
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "pass" -Value "Failed"
         $dmarcRecord | Add-Member -MemberType NoteProperty -Name "reason" -Value ""
 
         $checkType = $dmarcRecord.dmarcRecord.GetType().Name -eq "DMARCRecord"
 
-        if($checkType -and $dmarcRecord.dmarcRecord.policy -eq "reject"){
+        if($domain.IsCoexistenceDomain){
+            $dmarcRecord.pass = "Skipped"
+            $dmarcRecord.reason = "coexistence domain"
+        }elseif($checkType -and $dmarcRecord.dmarcRecord.policy -eq "reject"){
             $dmarcRecord.pass = "Passed"
         }elseif($checkType -and $dmarcRecord.dmarcRecord.policy -ne "reject"){
             $dmarcRecord.reason = "Policy is not reject"
@@ -95,11 +118,13 @@ function Test-MtCisaDmarcRecordReject {
 
     $passResult = "✅ Pass"
     $failResult = "❌ Fail"
-    $result = "| Domain | Result | Reason | Policy | Subdomain Poliy |`n"
+    $skipResult = "🗄️ Skip"
+    $result = "| Domain | Result | Reason | Policy | Subdomain Policy |`n"
     $result += "| --- | --- | --- | --- | --- |`n"
     foreach ($item in $dmarcRecords) {
         switch($item.pass){
             "Passed" {$itemResult = $passResult}
+            "Skipped" {$itemResult = $skipResult}
             "Failed" {$itemResult = $failResult}
         }
 

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
@@ -66,7 +66,9 @@ function Test-MtCisaDmarcRecordReject {
             }
         }
     }
-    $expandedDomains = $expandedDomains | Sort-Object DomainName
+
+    # Sort and remove duplicate Domains
+    $expandedDomains = $expandedDomains |  Sort-Object DomainName, IsCoexistenceDomain -Unique
 
     $dmarcRecords = @()
     foreach($domain in $expandedDomains){

--- a/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDmarcRecordReject.ps1
@@ -80,7 +80,7 @@ function Test-MtCisaDmarcRecordReject {
 
         if($domain.IsCoexistenceDomain){
             $dmarcRecord.pass = "Skipped"
-            $dmarcRecord.reason = "coexistence domain"
+            $dmarcRecord.reason = "Not applicable for coexistence domain"
         }elseif($checkType -and $dmarcRecord.dmarcRecord.policy -eq "reject"){
             $dmarcRecord.pass = "Passed"
         }elseif($checkType -and $dmarcRecord.dmarcRecord.policy -ne "reject"){


### PR DESCRIPTION
### Description

The test fails for contoso.mail.onmicrosoft.com and onmicrosoft.com.

We have no possibility to add DMARC records for these domains.

The missing record on onmicrosoft.com is a soft failure, the test is still successful / green

contoso.mail.onmicrosoft.com is a hard failure and the test fails / red.

From this:
<img width="873" height="364" alt="image" src="https://github.com/user-attachments/assets/1319537a-eb30-42fe-9d6a-38aab345fc4c" />

To:
<img width="871" height="314" alt="image" src="https://github.com/user-attachments/assets/e214a781-a424-4b12-96c5-bcf96a8260b6" />


I added code to:
+ Skipp and not splitting of InitialDomain and CoexistenceDomain
+ Added the icon for skipped
+ Sorted the domains

Note: 
+ This is my first PR, hope it's the correct way ;-)
+ No idea how to link to the issue. Should I place a: f i x #issueNr somewhere
