### PR TITLE
Change BeforeDiscovery to BeforeAll in tests

### DIFF
--- a/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeDiscovery {
+BeforeAll {
     $EntraIDPlan = Get-MtLicenseInformation -Product 'EntraID'
     $RegularUsers = Get-MtUser -Count 5 -UserType 'Member'
     $AdminUsers = Get-MtUser -Count 5 -UserType 'Admin'


### PR DESCRIPTION
### Description

Querying tenant data in the `BeforeDiscovery` block causes discovery to fail if not connected to the tenant. Using `BeforeAll` instead avoids this problem. I must have missed this one block when pushing the other test and tag updates.