### PR TITLE
Fix issue 1132 CIS.M365.2.4.4: (L1) Ensure Zero-hour auto purge for Microsoft Teams is on (Only Checks ZAP is enabled). Fail when connected to Exchange and not to Teams instead of skipping

### DIFF
--- a/powershell/public/cis/Test-MtCisZAP.ps1
+++ b/powershell/public/cis/Test-MtCisZAP.ps1
@@ -19,8 +19,8 @@ function Test-MtCisZAP {
     [OutputType([bool])]
     param()
 
-    if (!(Test-MtConnection ExchangeOnline)) {
-        Add-MtTestResultDetail -SkippedBecause NotConnectedExchange
+    if (!(Test-MtConnection Teams)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedTeams
         return $null
     }
 


### PR DESCRIPTION
### Description

Fix #1132 

Test for connectiuon to Teams instead of Exchange
