### PR TITLE
Fix issue 1106 MT.1028: No user with mailbox and permanent role assignment on Control Plane

### DIFF
--- a/powershell/public/maester/entra/Test-MtPrivPermanentDirectoryRole.ps1
+++ b/powershell/public/maester/entra/Test-MtPrivPermanentDirectoryRole.ps1
@@ -99,7 +99,7 @@ function Test-MtPrivPermanentDirectoryRole {
   "
         }
         UserMailbox {
-          $DirectAssignments | Where-Object { $_.principal.provisionedPlans.capabilityStatus -eq 'Enabled' -and $_.principal.provisionedPlans.service -contains 'exchange' }
+          $DirectAssignments | Where-Object { $_.principal.provisionedPlans | Where-Object { $_.capabilityStatus -eq 'Enabled' -and $_.service -contains "exchange" } }
           $testDescription = "
   Take attention on mail-enabled administrative accounts with $($FilteredAccessLevel) privileges.
   It's recommended to use mail forwarding to regular work account which allows to avoid direct mail access and phishing attacks on privileged user.


### PR DESCRIPTION

### Description

Fix #1106 

Initial test was searching for the existence of an enabled plan and an Exchange plan on all $DirectAssigments instead of searching for an enable Exchange plan for a/each specific $DirectAssignment
