### PR TITLE
Tiny regression in 1.3.55-preview

### DIFF
--- a/powershell/internal/Invoke-MtGraphRequestCache.ps1
+++ b/powershell/internal/Invoke-MtGraphRequestCache.ps1
@@ -26,7 +26,10 @@ function Invoke-MtGraphRequestCache {
     } elseif ($Method -eq 'POST' -and $Uri.AbsoluteUri.EndsWith('security/runHuntingQuery')) {
         $cacheKey = $Uri.AbsoluteUri + "_" + ($Body -replace '\s', '')
         $isXdrQuery = $true
-    }
+    } else {
+        $cacheKey = $Uri.AbsoluteUri + "_" + ($Body -replace '\s', '')
+        $isMethodGet = $false
+   }
 
     $isBatch = $uri.AbsoluteUri.EndsWith('$batch')
     $isInCache = $__MtSession.GraphCache.ContainsKey($cacheKey)


### PR DESCRIPTION
cacheKey not always initialized (could be null) and gave:
`Exception calling "ContainsKey" with "1" argument(s): "Value cannot be
     | null. (Parameter 'key')""`

### Description

This fixes a small error in  77c081f9e294bde3e1b22ff47eb292c536e91a6e. 

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [x] Read the guidelines for contributions

#### PRs related to all code

- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [x] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).

#### PRs related to Maester Tests

 It triggered an Error in `Test-MtCisCloudAdmin` / CIS.M365.1.1.1


### Review

We will try to review your pull request as soon as possible. If you have any queries or need any help please jump on [Discord](https://discord.maester.dev/). We really appreciate your contributions!

<!-- While your wait for a review, why not try to spread some Maester love on social media? -->

💖 Thank you!
