### PR TITLE
Errorhandling `Test-MtPrivPermanentDirectoryRole`, unused `BeforeAll`

### DIFF
--- a/powershell/public/maester/entra/Test-MtPrivPermanentDirectoryRole.ps1
+++ b/powershell/public/maester/entra/Test-MtPrivPermanentDirectoryRole.ps1
@@ -139,8 +139,8 @@ function Test-MtPrivPermanentDirectoryRole {
       return $result
     } catch {
       Write-Error "An error occurred while testing Permanent Directory Role Assignments: $_"
-      Add-MtTestResultDetail -Description 'An error occurred while testing Permanent Directory Role Assignments' -Result $_.Exception.Message
-      return $false
+      Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+      return $null
     }
   } # end process block
 } # end function

--- a/tests/Maester/Entra/Test-PrivilegedAssignments.Tests.ps1
+++ b/tests/Maester/Entra/Test-PrivilegedAssignments.Tests.ps1
@@ -1,8 +1,4 @@
-﻿BeforeAll {
-    $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
-}
-
-Describe "Maester/Entra" -Tag "Maester", "Privileged", "Security" {
+﻿Describe "Maester/Entra" -Tag "Maester", "Privileged", "Security" {
     It "MT.1025: No external user with permanent role assignment on Control Plane. See https://maester.dev/docs/tests/MT.1025" -Tag "MT.1025" {
         $Check = Test-MtPrivPermanentDirectoryRole -FilteredAccessLevel "ControlPlane" -FilterPrincipal "ExternalUser"
         $Check | Should -Be $false -Because "External user shouldn't have high-privileged roles"


### PR DESCRIPTION
### Description

Catch in `Test-MtPrivPermanentDirectoryRole` wasn't using `Add-MtTestResultDetail -SkippedBecause Error` so
`MT.1025` - `MT.1028`  had status==Passed  if the `catch` block was reached. 

I tested with a `throw` in the  Request.

Also, 
```
1 BeforeAll {
2     $EntraIDPlan = Get-MtLicenseInformation -Product EntraID
3 }
``` 

was unused,  just deleted.  (`MT-1029 - MT-1031`) 

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [x] Read the guidelines for contributions

#### PRs related to all code

- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [x] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).

#### PRs related to Maester Tests

### Review

We will try to review your pull request as soon as possible. If you have any queries or need any help please jump on [Discord](https://discord.maester.dev/). We really appreciate your contributions!

<!-- While your wait for a review, why not try to spread some Maester love on social media? -->

💖 Thank you!
