### PR TITLE
$env:TEMP not set on mac/unix. Let .NET handle that

### DIFF
--- a/powershell/public/maester/exchange/Test-MtExoMoeraMailActivity.ps1
+++ b/powershell/public/maester/exchange/Test-MtExoMoeraMailActivity.ps1
@@ -44,8 +44,8 @@ function Test-MtExoMoeraMailActivity {
             return $null
         }
     }
+    $file = "$([System.IO.Path]::GetTempPath())\maester-EmailActivityUserDetail.csv"
 
-    $file = "$env:TEMP\maester-EmailActivityUserDetail.csv"
     try {
             Write-Verbose "Downloading report"
             Invoke-MgGraphRequest -Uri "v1.0/reports/getEmailActivityUserDetail(period='D7')" -OutputFilePath $file

--- a/powershell/public/maester/exchange/Test-MtExoMoeraMailActivity.ps1
+++ b/powershell/public/maester/exchange/Test-MtExoMoeraMailActivity.ps1
@@ -44,7 +44,7 @@ function Test-MtExoMoeraMailActivity {
             return $null
         }
     }
-    $file = "$([System.IO.Path]::GetTempPath())\maester-EmailActivityUserDetail.csv"
+    $file = "$([System.IO.Path]::GetTempPath())maester-EmailActivityUserDetail.csv"
 
     try {
             Write-Verbose "Downloading report"


### PR DESCRIPTION
### Description

$file will be empty,  trying to store a file in root.  This defers the job to .NET.

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.

- [x] Read the guidelines for contributions

#### PRs related to all code

- [x] Before you submit the PR, run the tests locally by running `/powershell/tests/pester.ps1`
- [x] After submitting, verify the tests are still passing on your PR in GitHub (the tests are run across all platforms).
