### PR TITLE
Refactor Get-MtAdminPortalUrl and remove retired sovereign cloud URLs

### DIFF
--- a/powershell/public/core/Get-MtAdminPortalUrl.ps1
+++ b/powershell/public/core/Get-MtAdminPortalUrl.ps1
@@ -1,4 +1,5 @@
-﻿<#
+﻿function Get-MtAdminPortalUrl {
+    <#
     .SYNOPSIS
         Get the URL for the specific Microsoft admin portal based on the environment.
 
@@ -9,16 +10,18 @@
         Get-MtAdminPortalUrl -Environment 'USGov' -Portal 'Azure'
         Returns the URL for the Azure portal in the Global environment.
 
+    .EXAMPLE
+        Get-MtAdminPortalUrl
+        Returns the URLs for all portals in the default Global environment.
+
     .LINK
         https://maester.dev/docs/commands/Get-MtAdminPortalUrl
-#>
-
-function Get-MtAdminPortalUrl {
+    #>
     [CmdletBinding()]
     param(
         # The environment to use. If not specified, will use Global as default.
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Global', 'USGov', 'USGovDoD', 'Germany', 'China')]
+        [ValidateSet('Global', 'USGov', 'USGovDoD', 'China')]
         [string] $Environment = 'Global',
 
         # The portal to use. If not specified, returns all the portals.
@@ -29,45 +32,45 @@ function Get-MtAdminPortalUrl {
 
     Write-Verbose -Message "Getting admin portal URL for environment: $Environment"
 
-    if ([string]::IsNullOrEmpty($Environment) -or $Environment -eq 'Global') {
-        $adminPortalUrl = @{
-            Azure    = 'https://portal.azure.com/'
-            Entra    = 'https://entra.microsoft.com/'
-            Intune   = 'https://intune.microsoft.com/'
-            Purview  = 'https://purview.microsoft.com/'
-            Security = 'https://security.microsoft.com/'
+    switch ($environment) {
+        'China' {
+            $adminPortalUrl = @{
+                Azure    = 'https://portal.azure.cn/'
+                Entra    = 'https://entra.microsoft.cn/'
+                Intune   = 'https://intune.microsoft.cn/'
+                Purview  = 'https://purview.microsoft.cn/'
+                Security = 'https://security.microsoft.cn/'
+            }
         }
-    } else {
-        switch ($environment) {
-            "China" {
-                $adminPortalUrl = @{
-                    Azure    = 'https://portal.azure.cn/'
-                    Entra    = 'https://entra.microsoft.cn/'
-                    Intune   = 'https://intune.microsoft.cn/'
-                    Purview  = 'https://purview.microsoft.cn/'
-                    Security = 'https://security.microsoft.cn/'
-                }
+        { $_ -in 'USGov', 'USGovDoD' } {
+            $adminPortalUrl = @{
+                Azure    = 'https://portal.azure.us/'
+                Entra    = 'https://entra.microsoft.us/'
+                Intune   = 'https://intune.microsoft.us/'
+                Purview  = 'https://purview.microsoft.us/'
+                Security = 'https://security.microsoft.us/'
             }
-            "Germany" {
-                $adminPortalUrl = @{
-                    Azure    = 'https://portal.azure.de/'
-                    Entra    = 'https://entra.microsoft.de/'
-                    Intune   = 'https://intune.microsoft.de/'
-                    Purview  = 'https://purview.microsoft.de/'
-                    Security = 'https://security.microsoft.de/'
-                }
+        }
+        'Global' {
+            $adminPortalUrl = @{
+                Azure    = 'https://portal.azure.com/'
+                Entra    = 'https://entra.microsoft.com/'
+                Intune   = 'https://intune.microsoft.com/'
+                Purview  = 'https://purview.microsoft.com/'
+                Security = 'https://security.microsoft.com/'
             }
-            { $_ -in "USGov", "USGovDoD" } {
-                $adminPortalUrl = @{
-                    Azure    = 'https://portal.azure.us/'
-                    Entra    = 'https://entra.microsoft.us/'
-                    Intune   = 'https://intune.microsoft.us/'
-                    Purview  = 'https://purview.microsoft.us/'
-                    Security = 'https://security.microsoft.us/'
-                }
+        }
+        Default {
+            $adminPortalUrl = @{
+                Azure    = 'https://portal.azure.com/'
+                Entra    = 'https://entra.microsoft.com/'
+                Intune   = 'https://intune.microsoft.com/'
+                Purview  = 'https://purview.microsoft.com/'
+                Security = 'https://security.microsoft.com/'
             }
         }
     }
+
     if ($Portal) {
         return $adminPortalUrl[$Portal]
     }


### PR DESCRIPTION
## Description

This pull request refactors the `Get-MtAdminPortalUrl` function to improve its structure and handling of environments. The change includes using a single `switch` statement instead a `switch` nested within an `if/else` statement.

Support for the German cloud service URLs was removed due to its retirement in 2021.

**Functionality and logic changes:**

* Removed support for the 'Germany' environment in both the parameter validation and the internal URL mapping logic. [[1]](diffhunk://#diff-1346e9705976810c14cd4600ad60c1da342dac08652bda3a276461f6acbb7d0aR13-R24) [[2]](diffhunk://#diff-1346e9705976810c14cd4600ad60c1da342dac08652bda3a276461f6acbb7d0aL51-R45)
* Refactored the environment selection logic to use a `switch` statement for all environments, including 'Global' and a `Default` case, making the code more consistent and maintainable. [[1]](diffhunk://#diff-1346e9705976810c14cd4600ad60c1da342dac08652bda3a276461f6acbb7d0aL32-R36) [[2]](diffhunk://#diff-1346e9705976810c14cd4600ad60c1da342dac08652bda3a276461f6acbb7d0aR54-R73)

**Documentation improvements:**

* Added a new example to the function's help section, demonstrating how to get all portal URLs for the default Global environment.