### PR TITLE
Shorten, standardize Exposure Management test describe value

### DIFF
--- a/tests/XSPM/Test-XspmPrivilegedIdentities.Tests.ps1
+++ b/tests/XSPM/Test-XspmPrivilegedIdentities.Tests.ps1
@@ -2,7 +2,8 @@
     $DefenderPlan = Get-MtLicenseInformation -Product "DefenderXDR"
 }
 
-Describe "Exposure Management - Privileged assets, identified by EntraOps and Critical Asset Management, should not be exposed due to weak security configurations." -Tag "Privileged", "Entra", "Full", "Graph", "LongRunning", "Security", "EntraOps", "XSPM" -Skip:( $DefenderPlan -ne "DefenderXDR" ) {
+Describe "Exposure Management" -Tag "Privileged", "Entra", "Graph", "LongRunning", "Security", "EntraOps", "XSPM" -Skip:( $DefenderPlan -ne "DefenderXDR" ) {
+    # Privileged assets, identified by EntraOps and Critical Asset Management, should not be exposed due to weak security configurations.
     It "MT.1077: App registrations with privileged API permissions should not have owners. See https://maester.dev/docs/tests/MT.1077" -Tag "MT.1077" {
         Test-MtXspmAppRegWithPrivilegedApiAndOwners | Should -Be $true -Because "an app registration with privileged API permissions should not have assigned owner, as permanent and/or lower privileged users have full control over privileged application and may lead to privilege escalation."
     }


### PR DESCRIPTION
# Description

Updated the `Describe` attribute of the Exposure Management test to be consistent with how all other Maester tests use the `Describe` attribute as a tag, or short label.

<img width="745" height="623" alt="image" src="https://github.com/user-attachments/assets/2b5a8ea7-7536-410b-86ea-40691f4b20ab" />