### PR TITLE
Allow definition of emergency access accounts

### DIFF
--- a/build/aitools/test-metadata/maester-config.json
+++ b/build/aitools/test-metadata/maester-config.json
@@ -1,4 +1,7 @@
 {
+  "GlobalSettings": {
+    "EmergencyAccessAccounts": []
+  },
   "TestSettings": [
     {
       "Id": "CIS.M365.1.1.1",

--- a/powershell/internal/Get-MtMaesterConfigGlobalSetting.ps1
+++ b/powershell/internal/Get-MtMaesterConfigGlobalSetting.ps1
@@ -1,0 +1,32 @@
+﻿<#
+.SYNOPSIS
+    Gets the global settings from the Maester config.
+.DESCRIPTION
+    This function retrieves the global settings from the Maester config.
+    It returns the settings as a hashtable, which can be used to customize the behavior of the tests.
+.EXAMPLE
+    $globalSettings = Get-MtMaesterConfigGlobalSetting -SettingName 'EmergencyAccessAccounts'
+    # This will return the global settings for the setting with name 'EmergencyAccessAccounts'.
+#>
+
+function Get-MtMaesterConfigGlobalSetting {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        # The setting name of the configuration for which to retrieve the settings.
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$SettingName
+    )
+
+    # Check if the Maester config is loaded
+    if (-not ($__MtSession -and $__MtSession.MaesterConfig -and $__MtSession.MaesterConfig.GlobalSettings )) {
+        Write-Verbose "Maester global config not loaded. Please run Get-MtMaesterConfig first to load the config."
+        return $null
+    } else {
+        Write-Verbose "Maester global config loaded"
+        Write-Verbose "Maester global config `"$SettingName`": $($__MtSession.MaesterConfig.GlobalSettings.$SettingName | ConvertTo-Json -Depth 5 -Compress)"
+    }
+
+    # Retrieve the test settings from the Maester config
+    return $__MtSession.MaesterConfig.GlobalSettings.$SettingName
+}

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -493,7 +493,7 @@ function Invoke-Maester {
             Write-Host "Skipped ⚫: $($maesterResults.SkippedCount), " -NoNewline -ForegroundColor DarkGray
             Write-Host "Error ⚠️: $($maesterResults.ErrorCount), " -NoNewline -ForegroundColor DarkGray
             Write-Host "Not Run ⚫: $($maesterResults.NotRunCount), " -NoNewline -ForegroundColor DarkGray
-            Write-Host "Total ⭐: $($maesterResults.TotalCount)`n" 
+            Write-Host "Total ⭐: $($maesterResults.TotalCount)`n"
         }
 
         if (-not $SkipVersionCheck -and 'Next' -ne $version) {

--- a/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
+++ b/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
@@ -26,6 +26,8 @@ function Test-MtCaEmergencyAccessExists {
         return $null
     }
 
+    $EmergencyAccessAccounts = Get-MtMaesterConfigGlobalSetting -SettingName 'EmergencyAccessAccounts'
+
     try {
         # Only check policies that are not related to authentication context (the state of policy does not have to be enabled)
         $policies = Get-MtConditionalAccessPolicy | Where-Object { -not $_.conditions.applications.includeAuthenticationContextClassReferences }
@@ -35,44 +37,116 @@ function Test-MtCaEmergencyAccessExists {
 
         $result = $false
         $PolicyCount = $policies | Measure-Object | Select-Object -ExpandProperty Count
-        $ExcludedUserObjectGUID = $policies.conditions.users.excludeUsers | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 -ExpandProperty Name
-        $ExcludedUsers = $policies.conditions.users.excludeUsers | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Count
-        $ExcludedGroupObjectGUID = $policies.conditions.users.excludeGroups | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 -ExpandProperty Name
-        $ExcludedGroups = $policies.conditions.users.excludeGroups | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Count
+        if (-not $EmergencyAccessAccounts -or $EmergencyAccessAccounts.Count -eq 0) {
+            Write-Verbose "No emergency access accounts or groups defined in the Maester config. Use the default logic to detect emergency access accounts or groups."
+            $ExcludedUserObjectGUID = $policies.conditions.users.excludeUsers | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 -ExpandProperty Name
+            $ExcludedUsers = $policies.conditions.users.excludeUsers | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Count
+            $ExcludedGroupObjectGUID = $policies.conditions.users.excludeGroups | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 -ExpandProperty Name
+            $ExcludedGroups = $policies.conditions.users.excludeGroups | Group-Object -NoElement | Sort-Object -Property Count -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Count
 
-        # If the number of enabled policies is not the same as the number of excluded users or groups, there is no emergency access
-        if ($PolicyCount -eq $ExcludedUsers -or $PolicyCount -eq $ExcludedGroups) {
-            $result = $true
-        } else {
-            # If the number of excluded users is higher than the number of excluded groups, check the user object GUID
-            $CheckId = $ExcludedGroupObjectGUID
-            $EmergencyAccessUUIDType = 'group'
-            if ($ExcludedUsers -gt $ExcludedGroups) {
-                $EmergencyAccessUUIDType = 'user'
-                $CheckId = $ExcludedUserObjectGUID
-            }
-
-            # Get displayName of the emergency access account or group
-            if ($CheckId) {
-                if ($EmergencyAccessUUIDType -eq 'user') {
-                    $DisplayName = Invoke-MtGraphRequest -RelativeUri "users/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
-                } else {
-                    $DisplayName = Invoke-MtGraphRequest -RelativeUri "groups/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
+            # If the number of enabled policies is not the same as the number of excluded users or groups, there is no emergency access
+            if ($PolicyCount -eq $ExcludedUsers -or $PolicyCount -eq $ExcludedGroups) {
+                $result = $true
+            } else {
+                # If the number of excluded users is higher than the number of excluded groups, check the user object GUID
+                $CheckId = $ExcludedGroupObjectGUID
+                $EmergencyAccessUUIDType = 'group'
+                if ($ExcludedUsers -gt $ExcludedGroups) {
+                    $EmergencyAccessUUIDType = 'user'
+                    $CheckId = $ExcludedUserObjectGUID
                 }
 
-                Write-Verbose "Emergency access account or group: $CheckId"
-                $testResult = "Automatically detected emergency access $($EmergencyAccessUUIDType): $DisplayName ($CheckId)`n`n"
+                # Get displayName of the emergency access account or group
+                if ($CheckId) {
+                    if ($EmergencyAccessUUIDType -eq 'user') {
+                        $DisplayName = Invoke-MtGraphRequest -RelativeUri "users/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
+                    } else {
+                        $DisplayName = Invoke-MtGraphRequest -RelativeUri "groups/$CheckId" -Select displayName | Select-Object -ExpandProperty displayName
+                    }
+
+                    Write-Verbose "Emergency access account or group: $CheckId"
+                    $testResult = "Automatically detected emergency access`n`n* $($EmergencyAccessUUIDType): $DisplayName ($CheckId)`n`n"
+                }
+
+                $policiesWithoutEmergency = $policies | Where-Object { $CheckId -notin $_.conditions.users.excludeUsers -and $CheckId -notin $_.conditions.users.excludeGroups }
+                $policiesWithoutEmergency | Select-Object -ExpandProperty displayName | Sort-Object | ForEach-Object {
+                    Write-Verbose "Conditional Access policy $_ does not exclude emergency access $EmergencyAccessUUIDType"
+                }
             }
 
-            $policiesWithoutEmergency = $policies | Where-Object { $CheckId -notin $_.conditions.users.excludeUsers -and $CheckId -notin $_.conditions.users.excludeGroups }
-            $policiesWithoutEmergency | Select-Object -ExpandProperty displayName | Sort-Object | ForEach-Object {
-                Write-Verbose "Conditional Access policy $_ does not exclude emergency access $EmergencyAccessUUIDType"
+            $testResult += "These conditional access policies don't have the emergency access $EmergencyAccessUUIDType excluded:`n`n%TestResult%"
+            Add-MtTestResultDetail -GraphObjects $policiesWithoutEmergency -GraphObjectType ConditionalAccess -Result $testResult
+            return $result
+
+        } else {
+            # Translate any UPNs to object IDs and get display names for UUIDs
+            $ResolvedEmergencyAccessAccounts = @()
+            foreach ($account in $EmergencyAccessAccounts) {
+                if ($account -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+                    # It's already an object ID
+                    # Get the display name to show in the test result
+                    $DisplayName = Invoke-MtGraphRequest -RelativeUri "directoryObjects/$account" -Select displayName | Select-Object -ExpandProperty displayName
+                    if ($DisplayName) {
+                        Write-Verbose "Emergency access account or group: $DisplayName ($account)"
+                    } else {
+                        Write-Verbose "Emergency access account or group: $account"
+                    }
+                    $ResolvedEmergencyAccessAccounts += @{ObjectId = $account; displayName = $DisplayName }
+                } elseif ($account -match '^[^@]+@[^@]+\.[^@]+$') {
+                    # It's a UPN, resolve it to an object ID
+                    try {
+                        $user = Invoke-MtGraphRequest -RelativeUri "users/$account" -Select id, displayName -ErrorAction Stop
+                        if ($user) {
+                            $ResolvedEmergencyAccessAccounts += @{ObjectId = $user.id; displayName = $user.displayName }
+                        } else {
+                            Write-Warning "Could not resolve emergency access account UPN: $account"
+                        }
+                    } catch {
+                        Write-Warning "Could not resolve emergency access account UPN: $account. Error: $_"
+                    }
+                } else {
+                    # Assume it's a display name, try to resolve it to an object ID
+                    try {
+                        $group = Invoke-MtGraphRequest -RelativeUri "groups" -Filter "displayName eq '$account'" -ErrorAction Stop
+                        if ($group) {
+                            $ResolvedEmergencyAccessAccounts += @{ObjectId = $group.id; displayName = $group.displayName }
+                        } else {
+                            Write-Warning "Could not resolve emergency access group display name: $account"
+                        }
+                    } catch {
+                        Write-Warning "Could not resolve emergency access group display name: $account. Error: $_"
+                    }
+                }
+            }
+            Write-Verbose "Emergency access accounts or groups defined in the Maester config: $($EmergencyAccessAccounts -join ', ')"
+            $policiesWithoutEmergency = $policies | Where-Object {
+                ($_.conditions.users.excludeUsers | Where-Object { $ResolvedEmergencyAccessAccounts.ObjectId -contains $_ }).Count -eq 0 -and
+                ($_.conditions.users.excludeGroups | Where-Object { $ResolvedEmergencyAccessAccounts.ObjectId -contains $_ }).Count -eq 0
+            }
+            if ($policiesWithoutEmergency.Count -eq 0) {
+                $result = $true
+                $testResult = "All conditional access policies exclude the configured emergency access accounts or groups:`n`n"
+                $ResolvedEmergencyAccessAccounts | ForEach-Object {
+                    if ($_.displayName) {
+                        $testResult += "* $($_.displayName) ($($_.ObjectId))`n"
+                    } else {
+                        $testResult += "* $($_.ObjectId)`n"
+                    }
+                }
+            } else {
+                $testResult = "Configured emergency access accounts or groups:`n`n"
+                $ResolvedEmergencyAccessAccounts | ForEach-Object {
+                    if ($_.displayName) {
+                        $testResult += "* $($_.displayName) ($($_.ObjectId))`n"
+                    } else {
+                        $testResult += "* $($_.ObjectId)`n"
+                    }
+                }
+                $testResult += "`n`nThese conditional access policies don't have the configured emergency access accounts or groups excluded:`n`n%TestResult%"
+                Add-MtTestResultDetail -GraphObjects $policiesWithoutEmergency -GraphObjectType ConditionalAccess -Result $testResult
+                return $result
             }
         }
-
-        $testResult += "These conditional access policies don't have the emergency access $EmergencyAccessUUIDType excluded:`n`n%TestResult%"
-        Add-MtTestResultDetail -GraphObjects $policiesWithoutEmergency -GraphObjectType ConditionalAccess -Result $testResult
-        return $result
     } catch {
         Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $null

--- a/tests/maester-config.json
+++ b/tests/maester-config.json
@@ -1,4 +1,7 @@
 {
+  "GlobalSettings": {
+    "EmergencyAccessAccounts": []
+  },
   "TestSettings": [
     {
       "Id": "CIS.M365.1.1.1",
@@ -1145,7 +1148,7 @@
       "Severity": "High",
       "Title": "Conditional access policies should not use the deprecated Approved Client App grant."
     },
-{
+    {
       "Id": "MT.1073",
       "Severity": "Medium",
       "Title": "Soft- and hard-matching of synchronized objects should be blocked."


### PR DESCRIPTION
This pull request introduces the ability to change the configuration of the `maester-config.json` file to provide one or multiple emergency access accounts/groups

```json
{
  "GlobalSettings": {
    "EmergencyAccessAccounts": []
  }
// [...]
```

You can use ObjectIds, User UPNs, Group Names

