### PR TITLE
Possible fix #1212

### DIFF
--- a/powershell/public/maester/exchange/Test-MtExoMoeraMailActivity.ps1
+++ b/powershell/public/maester/exchange/Test-MtExoMoeraMailActivity.ps1
@@ -47,11 +47,16 @@ function Test-MtExoMoeraMailActivity {
     $file = "$([System.IO.Path]::GetTempPath())maester-EmailActivityUserDetail.csv"
 
     try {
-            Write-Verbose "Downloading report"
-            Invoke-MgGraphRequest -Uri "v1.0/reports/getEmailActivityUserDetail(period='D7')" -OutputFilePath $file
-        } catch {
-            Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        Write-Verbose "Downloading report"
+        $oProgressPreference = $ProgressPreference # save progressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-MgGraphRequest -Uri "v1.0/reports/getEmailActivityUserDetail(period='D7')" -OutputFilePath $file
+    } catch {
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $null
+    } finally {
+        # Always restore progressPreference, even if exception occurs
+        $ProgressPreference = $oProgressPreference
     }
     $results = Import-Csv $file
     $filteredResults = $results|Where-Object {


### PR DESCRIPTION
# Description

Fix for #1212 . 

Update, @O365-Zende verified that its this one particular call to `Invoke-MgGraphRequest -Uri "v1.0/reports/getEmailActivityUserDetail(period='D7')" -OutputFilePath $file` that triggers the reset.  

This simply sets progress to silent and restores the old value afterwards.


## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

