### PR TITLE
Fix incorrect escaping in wildcard match

### DIFF
--- a/powershell/public/cisa/exchange/Test-MtCisaCalendarSharing.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaCalendarSharing.ps1
@@ -27,7 +27,7 @@ function Test-MtCisaCalendarSharing {
 
     $resultPolicies = $policies | Where-Object {`
         $_.Enabled -and `
-        ($_.Domains -like "`*:*CalendarSharing*" -or `
+        ($_.Domains -like "``*:*CalendarSharing*" -or `
          $_.Domains -like "Anonymous:*CalendarSharing*")
     }
 


### PR DESCRIPTION
# Description

Fixes a problem with incorrect escaping of asterisk character in the Test-MtCisaCalendarSharing function. 

I believe the intention of the test is to validate there are no policies that share calendars with "everyone", denoted in the policy by an asterisk character. Due to an error with the escaping of the asterisk character, the test is incorrectly identifying policies that share with a specific domain, e.g. "domain.com" because domain.com matches the (incorrectly escaped) wildcard character.

Before the fix, this policy would fail
```
{
  "Domains": [
    "Anonymous:0",
    "domain.com:CalendarSharingFreeBusySimple"
  ],
  "Enabled": true
}
```

Now it will pass.

## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [ YES ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ YES ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.
