### PR TITLE
Try/catch for Defender XDR license check

### DIFF
--- a/tests/XSPM/Test-XspmPrivilegedIdentities.Tests.ps1
+++ b/tests/XSPM/Test-XspmPrivilegedIdentities.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿BeforeDiscovery {
-    try {    
+    try {
         $DefenderPlan = Get-MtLicenseInformation -Product "DefenderXDR"
     catch {
         Write-Warning "Unable to get license information for Defender XDR."


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

Wrap the license check in a try/catch block so test discovery and test inventory can still be performed when not yet connected to Microsoft Graph. Supports `Get-MtTestInventory` function.

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
