### PR TITLE
Fix variable scoping in EIDSCA tests by using BeforeDiscovery

### DIFF
--- a/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
+++ b/tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1
@@ -1,9 +1,13 @@
 BeforeDiscovery {
-    $AuthorizationPolicyAvailable = (Invoke-MtGraphRequest -RelativeUri 'policies/authorizationpolicy' -ApiVersion beta)
-    $SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
-    $EntraIDPlan = Get-MtLicenseInformation -Product 'EntraID'
-    $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
-    $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
+    try {
+        $AuthorizationPolicyAvailable = (Invoke-MtGraphRequest -RelativeUri 'policies/authorizationpolicy' -ApiVersion beta)
+        $SettingsApiAvailable = (Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion beta).values.name
+        $EntraIDPlan = Get-MtLicenseInformation -Product 'EntraID'
+        $EnabledAuthMethods = (Get-MtAuthenticationMethodPolicyConfig -State Enabled).Id
+        $EnabledAdminConsentWorkflow = (Invoke-MtGraphRequest -RelativeUri 'policies/adminConsentRequestPolicy' -ApiVersion beta).isenabled
+    } catch {
+        $EntraIDPlan = "NotConnected"
+    }
 }
 Describe "EIDSCA" -Tag "EIDSCA", "Security", "EIDSCA.AP01" {
     It "EIDSCA.AP01: Default Authorization Settings - Enabled Self service password reset for administrators. See https://maester.dev/docs/tests/EIDSCA.AP01" -TestCases @{ AuthorizationPolicyAvailable = $AuthorizationPolicyAvailable } {


### PR DESCRIPTION
# Description

Fixes #1221.

Changed BeforeAll to BeforeDiscovery to ensure variables like $EntraIDPlan are accessible to test functions in separate files. This resolves the issue where test functions couldn't access variables defined in BeforeAll. e.g PR02 would report Failed for tenants that don't have sufficient licensing, when it should have been Skipped.

Before submitting this PR, please confirm you have completed the following:

- [ YES ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ YES ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.