### PR TITLE
Make pester.ps1 throw on failed Block (files)

### DIFF
--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -135,7 +135,7 @@ if ($TestFunctions)
         $result = Invoke-Pester -Configuration $config
 
         $totalRun += $result.TotalCount
-        $totalFailed += $result.FailedCount
+        $totalFailed += $result.FailedCount + $result.FailedContainersCount
         foreach ($test in $result.Tests) {
             if ($test.Result -notin 'Passed','Skipped') {
                 $failedTest = [pscustomobject]@{


### PR DESCRIPTION
# Description

Co-pilot suggested a broken regex here: 
https://github.com/maester365/maester/pull/1229#issuecomment-3429225186

In pester.ps1 we don't count failed blocks, so the above didn't break the build. 

Since I don't understand what infrastructure is running behind the scene, this is the minimal change I could think of. 
 There is another similar usage on line 86. 

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
