### PR TITLE
Disable emergency access detection paging for large groups

### DIFF
--- a/powershell/public/Get-MtUser.ps1
+++ b/powershell/public/Get-MtUser.ps1
@@ -131,7 +131,8 @@ function Get-MtUser {
                 # Handling Emergency Access Groups
                 Write-Verbose "Emergency access group: $EmergencyAccessGroups"
                 foreach ( $EmergencyAccessGroup in $EmergencyAccessGroups ) {
-                    $TmpUsers = Invoke-MtGraphRequest -RelativeUri "groups/$EmergencyAccessGroup/members" -Select id, userPrincipalName, userType -OutputType Hashtable
+                    # Disable paging to avoid timeout of large groups which are excluded. Fix for https://github.com/maester365/maester/issues/1227
+                    $TmpUsers = Invoke-MtGraphRequest -RelativeUri "groups/$EmergencyAccessGroup/members" -Select id, userPrincipalName, userType -OutputType Hashtable -DisablePaging
                     if ( $TmpUsers.ContainsKey('userType') ) {
                         Write-Verbose "Setting userType to $UserType for $(($TmpUsers | Measure-Object).count) users that are member of EmergencyAccess."
                         $TmpUsers | ForEach-Object {


### PR DESCRIPTION
Fix for #1227 

The `Get-MtUser -UserType EmergencyAccess` command was paging all users in the group even when checking for emergency access accounts. This causes issues when tenants exclude large groups with 3K+ users.

Fix is to stop at first page when checking for users within the group for emergency access.