### PR TITLE
Improve resilience in Get-MtMarkdownReport

### DIFF
--- a/powershell/internal/Get-MtMarkdownReport.ps1
+++ b/powershell/internal/Get-MtMarkdownReport.ps1
@@ -57,7 +57,7 @@ function Get-MtMarkdownReport {
                 # Test author has provided details
                 $details += "#### Overview`n`n$($test.ResultDetail.TestDescription)`n`n"
                 $details += "#### Test Results`n`n$($test.ResultDetail.TestResult)`n`n"
-            } else {
+            } elseif (![string]::IsNullOrEmpty($test.ScriptBlock)) {
                 # Test author has not provided details, use default code in script
                 # make sure we do not execute the code in the script block!
                 $cleanedScriptBlock = $test.ScriptBlock.ToString() -replace '%\w+%', '' -replace '\$_', '€_' # or show me how I can make it not execute the $_ thing


### PR DESCRIPTION
# Description

* Improve resilience in Get-MtMarkdownReport by testing if processed property is not null or empty

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
