### PR TITLE
Switch to Ubuntu for CI jobs

### DIFF
--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -17,7 +17,7 @@ jobs:
 
   create-release:
     # needs: build-validation
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -36,7 +36,7 @@ jobs:
         id: publish-to-gallery
         shell: pwsh
         run: |
-          Publish-Module -Path ${{ github.workspace }}/powershell -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
+          Publish-Module -Path ${{ github.workspace }}/powershell/ -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
 
       - name: Build PowerShell module for GitHub
         id: module-creation

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -24,7 +24,7 @@ jobs:
 
   create-preview-release:
     needs: build-report
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -57,7 +57,7 @@ jobs:
         id: publish-to-gallery
         shell: pwsh
         run: |
-          Publish-Module -Path ${{ github.workspace }}/powershell -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
+          Publish-Module -Path ${{ github.workspace }}/powershell/ -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
 
       - name: Build PowerShell module for GitHub
         id: module-creation

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -20,7 +20,7 @@ jobs:
 
   create-release:
     needs: [build-validation, build-report]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -46,7 +46,7 @@ jobs:
         id: publish-to-gallery
         shell: pwsh
         run: |
-          Publish-Module -Path ${{ github.workspace }}/powershell -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
+          Publish-Module -Path ${{ github.workspace }}/powershell/ -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
 
       - name: Build PowerShell module for GitHub
         id: module-creation


### PR DESCRIPTION
Change the CI environment from Windows to Ubuntu for the release and preview release jobs to improve compatibility and performance.