### PR TITLE
Rename folder to maester for publishing

### DIFF
--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -36,7 +36,9 @@ jobs:
         id: publish-to-gallery
         shell: pwsh
         run: |
-          Publish-Module -Path ${{ github.workspace }}/powershell/ -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
+          # Copy to maester folder to avoid issues when publishing
+          Copy-Item ${{ github.workspace }}/powershell -Recurse -Destination ${{ github.workspace }}/maester/ -Force
+          Publish-Module -Path ${{ github.workspace }}/maester -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
 
       - name: Build PowerShell module for GitHub
         id: module-creation

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -57,7 +57,9 @@ jobs:
         id: publish-to-gallery
         shell: pwsh
         run: |
-          Publish-Module -Path ${{ github.workspace }}/powershell/ -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
+          # Copy to maester folder to avoid issues when publishing
+          Copy-Item ${{ github.workspace }}/powershell -Recurse -Destination ${{ github.workspace }}/maester/ -Force
+          Publish-Module -Path ${{ github.workspace }}/maester -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
 
       - name: Build PowerShell module for GitHub
         id: module-creation

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -46,7 +46,9 @@ jobs:
         id: publish-to-gallery
         shell: pwsh
         run: |
-          Publish-Module -Path ${{ github.workspace }}/powershell/ -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
+          # Copy to maester folder to avoid issues when publishing
+          Copy-Item ${{ github.workspace }}/powershell -Recurse -Destination ${{ github.workspace }}/maester/ -Force
+          Publish-Module -Path ${{ github.workspace }}/maester -NuGetApiKey ${{ secrets.PS_GALLERY_KEY }}
 
       - name: Build PowerShell module for GitHub
         id: module-creation


### PR DESCRIPTION
Copy the PowerShell module to a new maester folder before publishing to avoid issues during the publishing process.