### PR TITLE
Revert "Add container failure detection, PSScriptAnalyzer on `/tests`"

### DIFF
--- a/powershell/tests/functions/Common.Tests.ps1
+++ b/powershell/tests/functions/Common.Tests.ps1
@@ -1,25 +1,19 @@
 ﻿BeforeDiscovery {
     $moduleName = 'Maester'
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'moduleRoot')]
     $moduleRoot = "$PSScriptRoot/../.."
     # Get all the functions in the /public folder
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'exportedFunctions')]
     $exportedFunctions = Get-Command -Module $moduleName -CommandType Function
 
     # Eventually this should include all functions in the /public folder
     # For now, just the ones that we have tested and added
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'functionsWithTests')]
     $functionsWithTests = @('Invoke-Maester')
 }
 
-Describe 'Common function tests' -Tags 'Acceptance' -ForEach @{ exportedFunctions = $exportedFunctions; moduleRoot = $moduleRoot; functionsWithTests = $functionsWithTests } {
+Describe 'Common function tests' -Tags 'Acceptance' -ForEach @{ exportedFunctions = $exportedFunctions; moduleRoot = $moduleRoot } {
     Context '<_.CommandType> <_.Name>' -ForEach $exportedFunctions {
         BeforeAll {
-            # PSScriptAnalyzer doesn't understand this is used in tests below
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'function')]
             $function = $_
             # Need to update this if we start building the module as a single psm1 file (for improved performance)
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'functionPath')]
             $functionPath = $_.ScriptBlock.File
         }
 
@@ -55,8 +49,8 @@ Describe 'Common function tests' -Tags 'Acceptance' -ForEach @{ exportedFunction
         }
 
         # Intentionally using skip so the output will remind us of the missing test files :)
-        It 'Matching test file should exist' -Skip:($function.Name -notin $functionsWithTests) {
-            "$moduleRoot/tests/functions/$($function.Name).Tests.ps1" | Should -Exist
+        It 'Matching test file file should exist' -Skip:$($_ -notin $functionsWithTests) {
+            "$moduleRoot/tests/functions/$($_).Tests.ps1" | Should -Exist
         }
     }
 }

--- a/powershell/tests/functions/Invoke-Maester.Tests.ps1
+++ b/powershell/tests/functions/Invoke-Maester.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe 'Invoke-Maester' {
     It 'Not connected to graph should return error' {
-        if (Get-MgContext) { Disconnect-MgGraph } # Ensure we are disconnected
+        if (Get-MgContext) { Disconnect-Graph } # Ensure we are disconnected
         { Invoke-Maester } | Should -Throw 'Not connected to Microsoft Graph.*'
     }
 

--- a/powershell/tests/general/Help.Tests.ps1
+++ b/powershell/tests/general/Help.Tests.ps1
@@ -1,17 +1,13 @@
 ﻿# Based on https://github.com/pester/Pester/blob/main/tst/Help.Tests.ps1
 BeforeDiscovery {
 	$moduleName = 'Maester'
-	# PSScriptAnalyzer doesn't understand Pester's scoping model for ForEach data
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'exportedCommands')]
 	$exportedCommands = Get-Command -Module $moduleName -CommandType Cmdlet, Function
 }
 
 Describe 'Testing module help' -Tag 'Help','Acceptance' -ForEach @{ exportedCommands = $exportedCommands; moduleName = $moduleName } {
 	Context '<_.CommandType> <_.Name>' -ForEach $exportedCommands {
 		BeforeAll {
-			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'command')]
 			$command = $_
-			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'help')]
 			$help = $_ | Get-Help
 		}
 

--- a/powershell/tests/general/Manifest.Tests.ps1
+++ b/powershell/tests/general/Manifest.Tests.ps1
@@ -1,14 +1,12 @@
 BeforeDiscovery {
     $moduleRoot = "$PSScriptRoot/../.."
     # Using Import-PowerShellDataFile over Test-ModuleManifest as it's easier to navigate
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'manifest')]
     $manifest = Import-PowerShellDataFile -Path (Join-Path -Path $moduleRoot -ChildPath 'Maester.psd1')
 }
 
 Describe 'Validating the module manifest' -ForEach @{ moduleRoot = $moduleRoot; manifest = $manifest } {
     Context 'Basic resources validation' {
         BeforeAll {
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'files')]
             $files = Get-ChildItem -Path "$moduleRoot/public" -Recurse -File -Filter '*.ps1'
         }
 

--- a/powershell/tests/general/Module.Tests.ps1
+++ b/powershell/tests/general/Module.Tests.ps1
@@ -1,7 +1,5 @@
 ﻿BeforeAll {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'module')]
     $module = 'Maester'
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'moduleRoot')]
     $moduleRoot = "$PSScriptRoot/../.."
 }
 

--- a/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/powershell/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -1,36 +1,32 @@
-﻿# PSScriptAnalyzer doesn't understand parameter is used in BeforeDiscovery
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'CommandPath')]
-Param (
+﻿Param (
     [switch]
     $SkipTest,
 
     [string[]]
-    $CommandPath = @("$PSScriptRoot/../../public/", "$PSScriptRoot/../../internal/", "$PSScriptRoot/../../tests/")
+    $CommandPath = @("$PSScriptRoot/../../public/", "$PSScriptRoot/../../internal/")
 )
 
 if ($SkipTest) { return }
 
 BeforeDiscovery {
-    # PSScriptAnalyzer doesn't understand these are used in ForEach data
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'commandFiles')]
     $commandFiles = Get-ChildItem -Path $CommandPath -Recurse -File -Filter '*.ps1'
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'scriptAnalyzerRules')]
     $scriptAnalyzerRules = Get-ScriptAnalyzerRule
 }
 
-Describe 'Invoking PSScriptAnalyzer against commandbase' -ForEach @{ commandFiles = $commandFiles; scriptAnalyzerRules = $scriptAnalyzerRules } {
+Describe 'Invoking PSScriptAnalyzer against commandbase' -ForEach @{ commandFiles = $commandFiles } {
     BeforeAll {
-        # PSScriptAnalyzer doesn't understand this is used in nested contexts
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'analysis')]
         $analysis = $commandFiles | Invoke-ScriptAnalyzer -ExcludeRule PSAvoidTrailingWhitespace, PSShouldProcess
     }
 
     # The next Context blocks are kinda duplicate, but helps us document both
     # which files and which rules where evaluated without running every rule for every file
     Context 'Analyzing rule <_.RuleName>' -ForEach $scriptAnalyzerRules {
+        BeforeAll {
+            $rule = $_
+        }
         It 'All files should be compliant' {
             $failedFiles = foreach ($failure in $analysis) {
-                if ($failure.RuleName -eq $_.RuleName) {
+                if ($failure.RuleName -eq $rule.RuleName) {
                     $failure.ScriptPath
                 }
             }
@@ -39,9 +35,12 @@ Describe 'Invoking PSScriptAnalyzer against commandbase' -ForEach @{ commandFile
     }
 
     Context 'Analyzing file <_.BaseName>' -ForEach $commandFiles {
+        BeforeAll {
+            $file = $_
+        }
         It "Should pass all rules" -Tag 'ScriptAnalyzerRule' {
             $failedRules = foreach ($failure in $analysis) {
-                if ($failure.ScriptPath -eq $_.FullName) {
+                if ($failure.ScriptPath -eq $file.FullName) {
                     $failure
                 }
             }

--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -15,8 +15,8 @@
     $NoError
 )
 
-Write-Information "Starting Tests" -InformationAction Continue
-Write-Information "Importing Module" -InformationAction Continue
+Write-Host "Starting Tests"
+Write-Host "Importing Module"
 
 Remove-Module Maester -ErrorAction Ignore
 Import-Module "$PSScriptRoot\..\Maester.psd1"
@@ -66,9 +66,11 @@ function Test-ContainsFailureRule {
 }
 
 #region Run General Tests
-if ($TestGeneral) {
+if ($TestGeneral)
+{
     Write-PSFMessage -Level Important -Message "Modules imported, proceeding with general tests"
-    foreach ($file in (Get-ChildItem "$PSScriptRoot\general" -Filter '*.Tests.ps1' -File)) {
+    foreach ($file in (Get-ChildItem "$PSScriptRoot\general" -Filter '*.Tests.ps1' -File))
+    {
         if ($file.Name -notlike $Include) { continue }
         if ($file.Name -like $Exclude) { continue }
 
@@ -82,18 +84,6 @@ if ($TestGeneral) {
 
         $totalRun += $result.TotalCount
         $totalFailed += $result.FailedCount
-        # Also count containers (Describe/Context blocks) that failed
-        if ($result.FailedContainersCount -gt 0) {
-            Write-Information "WARNING: $($file.Name) test container failed (syntax errors or discovery failures)" -InformationAction Continue
-            $totalFailed += $result.FailedContainersCount
-            if ($file.Name -eq 'PSScriptAnalyzer.Tests.ps1') {
-                # We should ensure that PSScriptAnalyzer is installed and working
-                if (-not (Get-Module -Name PSScriptAnalyzer -ListAvailable)) {
-                    Write-Information "PSScriptAnalyzer module is not installed. Please install it from the PowerShell Gallery." -InformationAction Continue
-                }
-            }
-        }
-
         foreach ($test in $result.Tests) {
             if ($test.Result -ne 'Passed') {
                 $failedTest = [pscustomobject]@{
@@ -120,7 +110,7 @@ $scriptAnalyzerFailures | Out-Host
 $hasBomRuleFailure = Test-ContainsFailureRule -RuleName 'PSUseBOMForUnicodeEncodedFile' -ScriptAnalyzerFailures $scriptAnalyzerFailures -TestResults $testresults
 
 if ($hasBomRuleFailure) {
-    Write-Information "`n❌ To fix PSUseBOMForUnicodeEncodedFile → Run the following script with the affected file to fix the issue`n" -InformationAction Continue
+    Write-Host "`n❌ To fix PSUseBOMForUnicodeEncodedFile → Run the following script with the affected file to fix the issue`n" -ForegroundColor Yellow
     @'
 $affectedFilePath = '/Users/merill/GitHub/maester/powershell/public/maester/entra/Test-MtTenantCreationRestricted.ps1'
 $content = Get-Content $affectedFilePath -Raw; $content | Out-File $affectedFilePath -Encoding UTF8BOM
@@ -129,13 +119,15 @@ $content = Get-Content $affectedFilePath -Raw; $content | Out-File $affectedFile
 }
 
 #region Test Commands
-if ($TestFunctions) {
+if ($TestFunctions)
+{
     Write-PSFMessage -Level Important -Message "Proceeding with individual tests"
-    foreach ($file in (Get-ChildItem "$PSScriptRoot\functions" -Recurse -File -Filter '*.Tests.ps1')) {
+    foreach ($file in (Get-ChildItem "$PSScriptRoot\functions" -Recurse -File -Filter '*.Tests.ps1'))
+    {
         if ($file.Name -notlike $Include) { continue }
         if ($file.Name -like $Exclude) { continue }
 
-        Write-PSFMessage -Level Significant -Message "  Executing <c='em'>$($file.Name)</c>"
+        Write-PSFMessage -Level Significant -Message "  Executing $($file.Name)"
         $config.TestResult.OutputPath = Join-Path "$PSScriptRoot\..\..\TestResults" "TEST-$($file.BaseName).xml"
         $config.Run.Path = $file.FullName
         $config.Run.PassThru = $true
@@ -145,7 +137,7 @@ if ($TestFunctions) {
         $totalRun += $result.TotalCount
         $totalFailed += $result.FailedCount + $result.FailedContainersCount
         foreach ($test in $result.Tests) {
-            if ($test.Result -notin 'Passed', 'Skipped') {
+            if ($test.Result -notin 'Passed','Skipped') {
                 $failedTest = [pscustomobject]@{
                     Block   = $test.Block.ExpandedName
                     Name    = "It $($test.ExpandedName)"
@@ -167,6 +159,7 @@ $testresults | Sort-Object Block, Name, Result, Message | Format-List
 if ($totalFailed -eq 0) { Write-PSFMessage -Level Critical -Message "All <c='em'>$totalRun</c> tests executed without a single failure!" }
 else { Write-PSFMessage -Level Critical -Message "<c='em'>$totalFailed tests</c> out of <c='sub'>$totalRun</c> tests failed!" }
 
-if ($totalFailed -gt 0) {
+if ($totalFailed -gt 0)
+{
     throw "$totalFailed / $totalRun tests failed!"
 }


### PR DESCRIPTION
#1269 needs more testing and validation. It is currently causing build validation to fail and the report generated does not yet have necessary details. It looks close, though!