### PR TITLE
Add path filter for PowerShell files in build-validation workflow

### DIFF
--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -9,6 +9,7 @@ on:
     branches: ["main"]
     paths:
       - 'powershell/**'
+      - '.github/workflows/build-validation.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request makes a small update to the build validation workflow configuration. The change restricts workflow runs for pull requests to only trigger when files in the `powershell` directory are modified. This should reduce the number of times that we get failure notifications for the **build-validation-report** workflow when it runs but there is nothing to report on.

<img width="348" height="483" alt="image" src="https://github.com/user-attachments/assets/347fb989-499d-489a-9cc7-ff127cb6bbdb" />

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
