### PR TITLE
Fix diagnostic settings retrieval to ensure array output

### DIFF
--- a/powershell/public/maester/intune/Test-MtIntuneDiagnosticSettings.ps1
+++ b/powershell/public/maester/intune/Test-MtIntuneDiagnosticSettings.ps1
@@ -31,7 +31,7 @@ function Test-MtIntuneDiagnosticSettings {
     try {
         Write-Verbose 'Retrieving Intune Diagnostic Settings status...'
         $diagnosticSettingsRequest = Invoke-AzRestMethod -Method GET -Path "/providers/microsoft.intune/diagnosticSettings?api-version=2017-04-01-preview"
-        $diagnosticSettings = $diagnosticSettingsRequest | Select-Object -ExpandProperty Content | ConvertFrom-Json | Select-Object -ExpandProperty value
+        $diagnosticSettings = @($diagnosticSettingsRequest | Select-Object -ExpandProperty Content | ConvertFrom-Json | Select-Object -ExpandProperty value)
         $testResultMarkdown = ''
         if ($diagnosticSettings) {
             $testResultMarkdown += "Intune Diagnostic Settings:`n"


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

Forces $diagnosticSettings to be returned as an array, even if only one diagnostic setting object exists. Required for the `foreach ($entry in $diagnosticSettings)` statement to properly handle the results as an array.

Fixes #1391

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
