### PR TITLE
Added DeviceManagementServiceConfig.Read.All to the Scope Catalogue

### DIFF
--- a/powershell/public/Get-MtGraphScope.ps1
+++ b/powershell/public/Get-MtGraphScope.ps1
@@ -54,6 +54,7 @@ function Get-MtGraphScope {
         'DeviceManagementConfiguration.Read.All'
         'DeviceManagementManagedDevices.Read.All'
         'DeviceManagementRBAC.Read.All'
+        'DeviceManagementServiceConfig.Read.All'
         'Directory.Read.All'
         'DirectoryRecommendations.Read.All'
         'IdentityRiskEvent.Read.All'

--- a/website/docs/sections/permissions.md
+++ b/website/docs/sections/permissions.md
@@ -1,6 +1,7 @@
 - **DeviceManagementConfiguration.Read.All**
 - **DeviceManagementManagedDevices.Read.All**
 - **DeviceManagementRBAC.Read.All**
+- **DeviceManagementServiceConfig.Read.All**
 - **Directory.Read.All**
 - **DirectoryRecommendations.Read.All**
 - **IdentityRiskEvent.Read.All**


### PR DESCRIPTION
# Issue
When Running Maester Tests in Version 2.0.0 in a fresh Tenant I noticed quite a number of 403 Unauthorized Errors in the Test Results.

(  {"error":{"code":"Forbidden","message":"{\r\n  \"_version\": 3,\r\n
     | \"Message\": \"Application is not authorized to perform this operation. Application must have one of the
     | following scopes: DeviceManagementServiceConfiguration.Read.All, DeviceManagementServiceConfig.Read.All,
     | DeviceManagementServiceConfiguration.ReadWrite.All)

Affected Tests:
MT.1098
MT.1049
MT.1092
MT.1093
MT.1094
MT.1099
MT.1101
MT.1105

# Solution
For current Test Catalogue the Following permission is missing from Scopes: 'DeviceManagementServiceConfig.Read.All'

The Updated Version passes Pester Tests and the listed Tests no longer run into errors.