### PR TITLE
Fix typo in comment-based help for Disconnect-Maester

### DIFF
--- a/powershell/public/Disconnect-Maester.ps1
+++ b/powershell/public/Disconnect-Maester.ps1
@@ -7,7 +7,7 @@
 
     This cmdlet is a helper method for running the following command.
     ```
-    Disconnnect-MgGraph
+    Disconnect-MgGraph
     ```
 
  .Example


### PR DESCRIPTION
Correct cmdlet name from 'Disconnnect' to 'Disconnect' in comment-based help.