### PR TITLE
Remove the check for unused scope "RoleEligibilitySchedule.ReadWrite.Directory"

### DIFF
--- a/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
+++ b/powershell/public/cisa/entra/Test-MtCisaGlobalAdminCount.ps1
@@ -23,13 +23,6 @@ function Test-MtCisaGlobalAdminCount {
         return $null
     }
 
-    $scopes = (Get-MgContext).Scopes
-    $permissionMissing = "RoleEligibilitySchedule.ReadWrite.Directory" -notin $scopes -and "RoleManagement.ReadWrite.Directory" -notin $scopes
-    if($permissionMissing){
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Missing Scope RoleEligibilitySchedule.ReadWrite.Directory"
-        return $null
-    }
-
     $role = Get-MtRole | Where-Object {`
         $_.id -eq "62e90394-69f5-4237-9190-012177145e10" } # Global Administrator
 


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->
In addition to PR #1389 this change removes the scope check for "RoleEligibilitySchedule.ReadWrite.Directory" in the CISA test.




<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
