### PR TITLE
Add tags and skip condition to test cases

### DIFF
--- a/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessWhatIf.Tests.ps1
@@ -17,7 +17,7 @@ BeforeDiscovery {
 }
 
 
-Describe 'Maester/Entra' -Tag 'CA', 'CAWhatIf', 'LongRunning', 'Maester'  {
+Describe 'Maester/Entra' -Tag 'CA', 'CAWhatIf', 'LongRunning', 'Maester' {
 
     Context 'Maester/Entra' -ForEach @( $RegularUsers ) {
         # Regular users


### PR DESCRIPTION
Skip condition on the Describe line causes the tags to be ignored. So when running the tests and this specific test is skipped because it is "LongRunning" but this tag is not shown in the results, so it is not clear why the test was skipped.  

# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

Steps: Invoke-Maester, wait for results, filter by "Not Tested" and then find this test - it shows it was "Not Tested" (becuase LongRunning was not specified in Invoke-... but the Tags shown in the result do not show "LongRunning" so it is unclear why the test was skipped. Move the -Skip to the It line and copy the tags to the It line and you get a better result in Maester results page.


<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [ ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
