### PR TITLE
Federated domains always fail password expiry check

### DIFF
--- a/powershell/public/cis/Test-MtCisPasswordExpiry.ps1
+++ b/powershell/public/cis/Test-MtCisPasswordExpiry.ps1
@@ -29,14 +29,14 @@ function Test-MtCisPasswordExpiry {
         $domains = Invoke-MtGraphRequest -RelativeUri 'domains'
 
         Write-Verbose 'Get domains where passwords are set to expire'
-        $result = $domains | Where-Object { $_.PasswordValidityPeriodInDays -ne '2147483647' }
+        $result = $domains | Where-Object { ($_.PasswordValidityPeriodInDays -ne '2147483647') -and ($_.authenticationType -eq "Managed") }
 
         $testResult = ($result | Measure-Object).Count -eq 0
 
         if ($testResult) {
-            $testResultMarkdown = "Well done. Your tenant passwords are not set to expire:`n`n%TestResult%"
+            $testResultMarkdown = "Well done. Your tenant passwords are not set to expire on all your 'managed' domains:`n`n%TestResult%"
         } else {
-            $testResultMarkdown = "Your tenant has 1 or more domains which expire passwords:`n`n%TestResult%"
+            $testResultMarkdown = "Your tenant has 1 or more 'managed' domains which expire passwords:`n`n%TestResult%"
         }
 
         $resultMd = "| Display Name | Domain |`n"


### PR DESCRIPTION
Changed the query to look only for managed domains. 

# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

Changed the query to look only for managed domains. For example a Federated domain appears as follows: 

authenticationType               : Federated
availabilityStatus               :
id                               : domain.com
isAdminManaged                   : True
isDefault                        : False
isInitial                        : False
isRoot                           : True
isVerified                       : True
supportedServices                : {Email, Intune}
passwordValidityPeriodInDays     :
passwordNotificationWindowInDays :
state                            :

And the original code checked for a value in passwordValidityPeriodInDays, but this is null for Federated domains


<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [ ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
