### PR TITLE
Fix API version condition for Microsoft Graph

### DIFF
--- a/powershell/public/core/Invoke-MtAzureRequest.ps1
+++ b/powershell/public/core/Invoke-MtAzureRequest.ps1
@@ -62,7 +62,7 @@ function Invoke-MtAzureRequest {
     if ($Graph) {
         $baseUri = $((Get-AzContext).Environment.ExtendedProperties.MicrosoftGraphUrl)
         if ( -not $baseUri) { $baseUri = 'https://graph.microsoft.com' }
-        if ($ApiVersion -ne 'v1.0' -or $ApiVersion -ne 'beta') { $ApiVersion = 'v1.0' }
+        if ($ApiVersion -ne 'v1.0' -and $ApiVersion -ne 'beta') { $ApiVersion = 'v1.0' }
 
         $uriQueryEndpoint = New-Object System.UriBuilder -ArgumentList ([IO.Path]::Combine($baseUri, $ApiVersion, $RelativeUri))
 


### PR DESCRIPTION
# Description

**Intent:** When the `-Graph` switch is used, this line is meant to validate `$ApiVersion` and default it to `'v1.0'` if the caller didn't pass a valid Microsoft Graph API version (`'v1.0'` or `'beta'`). Since the parameter defaults to `'2024-11-01'` (an ARM version), this normalization is needed for Graph calls.

**⚠️ Bug:** The condition uses `-or` but should use `-and`. As written, the expression **always evaluates to `$true`**:

| `$ApiVersion` value | `-ne 'v1.0'` | `-ne 'beta'` | `-or` result |
|:---|:---|:---|:---|
| `'v1.0'` | `$false` | `$true` | **`$true`** ✗ |
| `'beta'` | `$true` | `$false` | **`$true`** ✗ |
| `'2024-11-01'` | `$true` | `$true` | **`$true`** ✓ |

This means `$ApiVersion` is **always** overwritten to `'v1.0'`, making it impossible to use `'beta'`.

**Fix:** Replace `-or` with `-and`:

```powershell
if ($ApiVersion -ne 'v1.0' -and $ApiVersion -ne 'beta') { $ApiVersion = 'v1.0' }
```

This correctly reads: *"if the version is **neither** `'v1.0'` **nor** `'beta'`, default to `'v1.0'`."*

## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [X] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [X] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

