### PR TITLE
Fix timestamp field references in logon event queries

### DIFF
--- a/powershell/public/maester/entra/Test-MtEntraIDConnectSsso.ps1
+++ b/powershell/public/maester/entra/Test-MtEntraIDConnectSsso.ps1
@@ -75,7 +75,7 @@ function Test-MtEntraIDConnectSsso {
 let devices = (
     DeviceInfo
     // Search for 14 days
-    | where TimeGenerated > ago(14d)
+    | where Timestamp > ago(14d)
     // Normalize DeviceName
     // --> if it is an IP Address we keep it
     // --> If it is not an IP Address we only use the hostname for correlation
@@ -85,7 +85,7 @@ let devices = (
 );
 IdentityLogonEvents
 // Get the last 14 days of logon events on Domain Controllers
-| where TimeGenerated > ago(14d)
+| where Timestamp > ago(14d)
 // Search for Seamless SSO events
 | where Application == "Active Directory" and Protocol == "Kerberos"
 | where TargetDeviceName == "AZUREADSSOACC"

--- a/powershell/public/xspm/Test-MtXspmPublicRemotelyExploitableHighExposureDevices.ps1
+++ b/powershell/public/xspm/Test-MtXspmPublicRemotelyExploitableHighExposureDevices.ps1
@@ -54,7 +54,7 @@ function Test-MtXspmPublicRemotelyExploitableHighExposureDevices {
             // Focus on devices that are public exposed
             | join kind=inner (
                 DeviceNetworkEvents
-                | where TimeGenerated > ago(7d)
+                | where Timestamp > ago(7d)
                 | where ActionType contains 'InboundConnection'
                 | where RemoteIPType == 'Public'
                 // Exclude MacOS Rapportd and ControlCenter


### PR DESCRIPTION
Update logon event queries to use the correct timestamp field for filtering events. This change ensures that the tests will work also for environment without enabling Sentinel integration to Defender portal. Bug fix is related to the issue https://github.com/maester365/maester/issues/1443.

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!

