### PR TITLE
Refactor version check to prevent delays and NuGet prompts

### DIFF
--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -42,6 +42,12 @@ jobs:
           Install-Module PSFramework -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module PSModuleDevelopment -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module Microsoft.Graph.Authentication -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
+          try {
+            Install-Module Microsoft.PowerShell.PSResourceGet -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber -ErrorAction Stop
+          }
+          catch {
+            Write-Warning "Unable to install Microsoft.PowerShell.PSResourceGet: $($_.Exception.Message)"
+          }
 
       - name: Run Pester tests
         if: steps.filter.outputs.pwshmodule == 'true'

--- a/powershell/internal/ConvertTo-MtMaesterResult.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResult.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-  Converts Pester results to the Maester test results format which includes additional information.
+    Converts Pester results to the Maester test results format which includes additional information.
 #>
 
 function ConvertTo-MtMaesterResult {
@@ -31,7 +31,7 @@ function ConvertTo-MtMaesterResult {
             $tenant = Get-CsTenant
             return $tenant.DisplayName
         } else {
-            return "TenantName (not connected to Graph)"
+            return 'TenantName (not connected to Graph)'
         }
     }
 
@@ -43,7 +43,7 @@ function ConvertTo-MtMaesterResult {
             $tenant = Get-CsTenant
             return $tenant.TenantId
         } else {
-            return "TenantId (not connected to Graph)"
+            return 'TenantId (not connected to Graph)'
         }
     }
 
@@ -55,7 +55,7 @@ function ConvertTo-MtMaesterResult {
             #    $tenant = Get-CsTenant #ToValidate: N/A
             #    return $tenant.DisplayName
         } else {
-            return "Account (not connected to Graph)"
+            return 'Account (not connected to Graph)'
         }
     }
 
@@ -71,15 +71,16 @@ function ConvertTo-MtMaesterResult {
     function GetFormattedDate($date) {
         if (!$IsCoreCLR) {
             # Prevent 5.1 date format to json issue
-            return $date.ToString("o")
+            return $date.ToString('o')
         } else {
             return $date
         }
     }
 
     function GetMaesterLatestVersion() {
-        if (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
-            return (Find-Module -Name Maester).Version
+        $latestVersion = Get-MtLatestModuleVersion -Name Maester -TimeoutSec 10
+        if ($null -ne $latestVersion) {
+            return $latestVersion.ToString()
         }
 
         return 'Unknown'
@@ -99,9 +100,9 @@ function ConvertTo-MtMaesterResult {
 
     function GetPowerShellInfo() {
         $psInfo = [PSCustomObject]@{
-            Version       = $PSVersionTable.PSVersion.ToString()
-            Edition       = $PSVersionTable.PSEdition
-            Platform      = if ($PSVersionTable.Platform) { $PSVersionTable.Platform } else { 'Win32NT' }
+            Version  = $PSVersionTable.PSVersion.ToString()
+            Edition  = $PSVersionTable.PSEdition
+            Platform = if ($PSVersionTable.Platform) { $PSVersionTable.Platform } else { 'Win32NT' }
         }
         return $psInfo
     }
@@ -121,16 +122,16 @@ function ConvertTo-MtMaesterResult {
             $mgContext = Get-MgContext
             if ($null -ne $mgContext) {
                 return [PSCustomObject]@{
-                    ClientId             = $mgContext.ClientId
-                    TenantId             = $mgContext.TenantId
-                    Scopes               = @($mgContext.Scopes)
-                    AuthType             = [string]$mgContext.AuthType
-                    TokenCredentialType  = [string]$mgContext.TokenCredentialType
-                    Account              = $mgContext.Account
-                    AppName              = $mgContext.AppName
-                    ContextScope         = [string]$mgContext.ContextScope
-                    Environment          = $mgContext.Environment
-                    ManagedIdentityId    = $mgContext.ManagedIdentityId
+                    ClientId            = $mgContext.ClientId
+                    TenantId            = $mgContext.TenantId
+                    Scopes              = @($mgContext.Scopes)
+                    AuthType            = [string]$mgContext.AuthType
+                    TokenCredentialType = [string]$mgContext.TokenCredentialType
+                    Account             = $mgContext.Account
+                    AppName             = $mgContext.AppName
+                    ContextScope        = [string]$mgContext.ContextScope
+                    Environment         = $mgContext.Environment
+                    ManagedIdentityId   = $mgContext.ManagedIdentityId
                 }
             }
         }
@@ -146,7 +147,7 @@ function ConvertTo-MtMaesterResult {
                     $base64Logo = [System.Convert]::ToBase64String($logoBytes)
                     # Detect content type from response or default to png
                     $contentType = $response.Content.Headers.ContentType.MediaType
-                    if ([string]::IsNullOrEmpty($contentType)) { $contentType = "image/png" }
+                    if ([string]::IsNullOrEmpty($contentType)) { $contentType = 'image/png' }
                     return "data:$contentType;base64,$base64Logo"
                 }
             }
@@ -181,7 +182,7 @@ function ConvertTo-MtMaesterResult {
 
         # Convert PesterConfiguration to a simple hashtable for JSON serialization
         $configInfo = [PSCustomObject]@{
-            Run = [PSCustomObject]@{
+            Run          = [PSCustomObject]@{
                 Path                   = @($config.Run.Path.Value)
                 ExcludePath            = @($config.Run.ExcludePath.Value)
                 ScriptBlock            = @($config.Run.ScriptBlock.Value | ForEach-Object { if ($null -ne $_) { $_.ToString() } })
@@ -193,7 +194,7 @@ function ConvertTo-MtMaesterResult {
                 SkipRun                = $config.Run.SkipRun.Value
                 SkipRemainingOnFailure = [string]$config.Run.SkipRemainingOnFailure.Value
             }
-            Filter = [PSCustomObject]@{
+            Filter       = [PSCustomObject]@{
                 Tag         = @($config.Filter.Tag.Value)
                 ExcludeTag  = @($config.Filter.ExcludeTag.Value)
                 Line        = @($config.Filter.Line.Value)
@@ -212,24 +213,24 @@ function ConvertTo-MtMaesterResult {
                 UseBreakpoints        = $config.CodeCoverage.UseBreakpoints.Value
                 SingleHitBreakpoints  = $config.CodeCoverage.SingleHitBreakpoints.Value
             }
-            TestResult = [PSCustomObject]@{
+            TestResult   = [PSCustomObject]@{
                 Enabled        = $config.TestResult.Enabled.Value
                 OutputFormat   = $config.TestResult.OutputFormat.Value
                 OutputPath     = $config.TestResult.OutputPath.Value
                 OutputEncoding = $config.TestResult.OutputEncoding.Value
                 TestSuiteName  = $config.TestResult.TestSuiteName.Value
             }
-            Should = [PSCustomObject]@{
+            Should       = [PSCustomObject]@{
                 ErrorAction = [string]$config.Should.ErrorAction.Value
             }
-            Debug = [PSCustomObject]@{
+            Debug        = [PSCustomObject]@{
                 ShowFullErrors         = $config.Debug.ShowFullErrors.Value
                 WriteDebugMessages     = $config.Debug.WriteDebugMessages.Value
                 WriteDebugMessagesFrom = @($config.Debug.WriteDebugMessagesFrom.Value)
                 ShowNavigationMarkers  = $config.Debug.ShowNavigationMarkers.Value
                 ReturnRawResultObject  = $config.Debug.ReturnRawResultObject.Value
             }
-            Output = [PSCustomObject]@{
+            Output       = [PSCustomObject]@{
                 Verbosity           = [string]$config.Output.Verbosity.Value
                 StackTraceVerbosity = [string]$config.Output.StackTraceVerbosity.Value
                 CIFormat            = [string]$config.Output.CIFormat.Value
@@ -270,7 +271,7 @@ function ConvertTo-MtMaesterResult {
 
         $helpUrl = ''
 
-        $start = $name.IndexOf("See https")
+        $start = $name.IndexOf('See https')
         # Get the Help Url from the message and the ID
         if ($start -gt 0) {
             $helpUrl = $name.Substring($start + 4).Trim() #Strip away the "See https://maester.dev" part
@@ -301,21 +302,20 @@ function ConvertTo-MtMaesterResult {
         }
 
         # Setting Result to Error or Investigate, Overwriting the Skipped state
-        if ($testResultDetail.TestSkipped -eq "Error" ) {
-            $result = "Error"
+        if ($testResultDetail.TestSkipped -eq 'Error' ) {
+            $result = 'Error'
         } elseif ($testResultDetail.TestInvestigate -eq $true) {
-            $result = "Investigate"
+            $result = 'Investigate'
         } elseif ((
                 $test -and
                 $test.ErrorRecord -and
                 $test.ErrorRecord.Count -gt 0 -and
                 $test.ErrorRecord[0].CategoryInfo -and
                 $test.ErrorRecord[0].CategoryInfo.Reason) -and
-                (@("RuntimeException","ParameterBindingValidationException","ParameterBindingException","HttpRequestException","TaskCanceledException") -Contains $test.ErrorRecord[0].CategoryInfo.Reason )) {
+            (@('RuntimeException', 'ParameterBindingValidationException', 'ParameterBindingException', 'HttpRequestException', 'TaskCanceledException') -contains $test.ErrorRecord[0].CategoryInfo.Reason )) {
             Write-Verbose "Setting result=Error $($name) because: $($test.ErrorRecord[0].CategoryInfo.Reason)"
-            $result = "Error"
-        }
-        else {
+            $result = 'Error'
+        } else {
             $result = $test.Result
         }
 
@@ -377,8 +377,7 @@ function ConvertTo-MtMaesterResult {
                     Tag              = $block.Tag
                 }
                 $mtBlocks += $mtBlockInfo
-            }
-            else {
+            } else {
                 # We already seen and counted all blocks
             }
         }
@@ -413,7 +412,7 @@ function ConvertTo-MtMaesterResult {
         MaesterConfig     = $__MtSession.MaesterConfig
         Tests             = $mtTests
         Blocks            = $mtBlocks
-        EndOfJson         = "EndOfJson" # Always leave this as the last property. Used by the script to determine the end of the JSON
+        EndOfJson         = 'EndOfJson' # Always leave this as the last property. Used by the script to determine the end of the JSON
     }
 
     # Add output files information if provided

--- a/powershell/internal/Get-IsNewMaesterVersionAvailable.ps1
+++ b/powershell/internal/Get-IsNewMaesterVersionAvailable.ps1
@@ -1,35 +1,69 @@
-﻿<#
-.SYNOPSIS
-   Checks the PowerShell Gallery for a newer version of the Maester module and displays a message if a newer version is available.
+﻿function Get-IsNewMaesterVersionAvailable {
+    <#
+    .SYNOPSIS
+        Checks the PowerShell Gallery for a newer version of the Maester module and displays a message if a newer version is available.
 
-.DESCRIPTION
-    Compares the installed version of the Maester module with the latest version available on the PowerShell Gallery.
+    .DESCRIPTION
+        Compares the installed version of the Maester module with the latest version available on the PowerShell Gallery.
+        This is useful to let the user know if there are newer versions with updates and bug fixes.
+        The function returns $true if a newer version is available, otherwise $false.
 
-    This is useful to let the user know if there are newer versions with updates and bug fixes.
+    .EXAMPLE
+        Get-IsNewMaesterVersionAvailable
+    #>
 
-    The function returns $true if a newer version is available, otherwise $false.
-
-.EXAMPLE
-    Get-IsNewMaesterVersionAvailable
-#>
-
-function Get-IsNewMaesterVersionAvailable {
+    [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Colors are beautiful')]
     [OutputType([bool])]
-    [CmdletBinding()]
     param()
 
-    try {
-        $currentVersion = $ModuleInfo.ModuleVersion
-        $latestVersion = (Find-Module -Name Maester).Version
+    function ConvertTo-ComparableVersion {
+        param(
+            [Parameter(Mandatory = $true)]
+            [AllowNull()]
+            [object] $InputVersion
+        )
 
-        if ($currentVersion -lt $latestVersion) {
-            Write-Host "🔥 FYI: A newer version of Maester is available! Run the commands below to update to the latest version."
+        if ($null -eq $InputVersion) {
+            return $null
+        }
+
+        if ($InputVersion -is [version]) {
+            return $InputVersion
+        }
+
+        $versionString = [string]$InputVersion
+        if ([string]::IsNullOrWhiteSpace($versionString)) {
+            return $null
+        }
+
+        # Normalize prerelease-like strings to comparable version values.
+        $numericVersion = $versionString -replace '-.*$', ''
+
+        try {
+            return [version]$numericVersion
+        } catch {
+            Write-Verbose -Message "Could not parse current module version '$InputVersion' (numeric: '$numericVersion')."
+            return $null
+        }
+    }
+
+    try {
+        $currentVersion = ConvertTo-ComparableVersion -InputVersion (Get-MtModuleVersion)
+        $latestVersion = Get-MtLatestModuleVersion -Name Maester -TimeoutSec 10
+
+        if ($null -eq $currentVersion) {
+            Write-Verbose -Message 'Unable to determine installed Maester version.'
+            return $false
+        }
+
+        if ($null -ne $latestVersion -and $currentVersion -lt $latestVersion) {
+            Write-Host '🔥 FYI: A newer version of Maester is available! Run the commands below to update to the latest version.'
             Write-Host "💥 Installed version: $currentVersion → Latest version: $latestVersion" -ForegroundColor DarkGray
-            Write-Host "✨ Update-Module Maester" -NoNewline -ForegroundColor Green
-            Write-Host " → Install the latest version of Maester." -ForegroundColor Yellow
-            Write-Host "💫 Update-MaesterTests" -NoNewline -ForegroundColor Green
-            Write-Host " → Get the latest tests built by the Maester team and community." -ForegroundColor Yellow
+            Write-Host '✨ Update-Module Maester' -NoNewline -ForegroundColor Green
+            Write-Host ' → Install the latest version of Maester.' -ForegroundColor Yellow
+            Write-Host '💫 Update-MaesterTests' -NoNewline -ForegroundColor Green
+            Write-Host ' → Get the latest tests built by the Maester team and community.' -ForegroundColor Yellow
             return $true
         }
     } catch { Write-Verbose -Message $_ }

--- a/powershell/internal/Get-MtLatestModuleVersion.ps1
+++ b/powershell/internal/Get-MtLatestModuleVersion.ps1
@@ -1,0 +1,161 @@
+﻿function Get-MtLatestModuleVersion {
+    <#
+    .SYNOPSIS
+    Retrieves the latest stable version (non-prerelease) of a module from the PowerShell Gallery.
+    #>
+    [OutputType([version])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Name = 'Maester',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 300)]
+        [int] $TimeoutSec = 10
+    )
+
+    function ConvertTo-StableVersion {
+        <#
+        .SYNOPSIS
+        Converts an input version string to a [version] object if it's a stable version.
+
+        .DESCRIPTION
+        ConvertTo-StableVersion attempts to parse the input version and returns a [version] object if it's a stable version.
+        If the input is null, empty, or contains a prerelease suffix (indicated by a hyphen), it returns $null.
+        This ensures that only stable versions are considered when determining the latest module version.
+        #>
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $true)]
+            [AllowNull()]
+            [object] $InputVersion
+        )
+
+        if ($null -eq $InputVersion) {
+            return $null
+        }
+
+        # If the version is null or empty after converting to string, return null.
+        $VersionString = [string]$InputVersion
+        if ([string]::IsNullOrWhiteSpace($VersionString)) {
+            return $null
+        }
+
+        # Keep behavior aligned with Find-Module default by ignoring prerelease versions (indicated by a hyphen).
+        if ($VersionString -match '-') {
+            return $null
+        }
+
+        try {
+            return [version]$versionString
+        } catch {
+            Write-Error "Could not parse version '$versionString': $_"
+            return $null
+        }
+    } # End of ConvertTo-StableVersion
+
+    function Get-LatestVersionFromOData {
+        <#
+        .SYNOPSIS
+        Retrieves the latest stable version (non-prerelease) of a module from the PowerShell Gallery using the OData API.
+        #>
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $ModuleName,
+
+            [Parameter()]
+            [int] $RequestTimeoutSec = 10
+        )
+
+        $escapedModuleName = $ModuleName.Replace("'", "''")
+        $uri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='$escapedModuleName'&`$filter=IsLatestVersion and not IsPrerelease"
+        $response = Invoke-RestMethod -Uri $uri -Method Get -TimeoutSec $RequestTimeoutSec -ErrorAction Stop
+
+        $xmlNamespaceManager = $null
+        if ($response -is [System.Xml.XmlElement] -and $null -ne $response.OwnerDocument) {
+            $xmlNamespaceManager = [System.Xml.XmlNamespaceManager]::new($response.OwnerDocument.NameTable)
+            $xmlNamespaceManager.AddNamespace('m', 'http://schemas.microsoft.com/ado/2007/08/dataservices/metadata')
+            $xmlNamespaceManager.AddNamespace('d', 'http://schemas.microsoft.com/ado/2007/08/dataservices')
+        }
+
+        $rawVersion = $null
+        if ($null -ne $response.properties -and $null -ne $response.properties.Version) {
+            $rawVersion = $response.properties.Version
+        } elseif ($response -is [System.Xml.XmlElement] -and $null -ne $xmlNamespaceManager) {
+            $versionNode = $response.SelectSingleNode('m:properties/d:Version', $xmlNamespaceManager)
+            if ($null -ne $versionNode) {
+                $rawVersion = $versionNode.InnerText
+            }
+        }
+
+        $stableVersion = ConvertTo-StableVersion -InputVersion $rawVersion
+        if ($null -ne $stableVersion) {
+            return $stableVersion
+        } else {
+            Write-Verbose "No stable version found in OData response for '$ModuleName'. Raw version value: '$rawVersion'"
+            return $null
+        }
+    } # End of Get-LatestVersionFromOData
+
+    function Get-LatestVersionFromPSResourceGet {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $ModuleName
+        )
+
+        $resource = Find-PSResource -Name $ModuleName -ErrorAction Stop | Select-Object -First 1
+        return ConvertTo-StableVersion -InputVersion $resource.Version
+    } # End of Get-LatestVersionFromPSResourceGet
+
+    function Get-LatestVersionFromPowerShellGet {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $ModuleName
+        )
+
+        # NuGet provider readiness check avoids interactive provider bootstrap prompts in PS7 environments.
+        $nugetProvider = Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue
+        if ($null -eq $nugetProvider) {
+            Write-Verbose 'Skipping Find-Module fallback because NuGet provider is not installed.'
+            return $null
+        }
+
+        $module = Find-Module -Name $ModuleName -ErrorAction Stop
+        return ConvertTo-StableVersion -InputVersion $module.Version
+    } # End of Get-LatestVersionFromPowerShellGet
+
+    # Main logic of Get-MtLatestModuleVersion starts here.
+
+    # Attempt to get the latest version from the OData API first, as it's the most direct source and doesn't rely on installed modules.
+    try {
+        $ODataVersion = Get-LatestVersionFromOData -ModuleName $Name -RequestTimeoutSec $TimeoutSec
+        if ($null -ne $ODataVersion) {
+            return $ODataVersion
+        }
+    } catch {
+        Write-Verbose "Unable to get latest version from PowerShell Gallery OData API for '$Name': $_"
+    }
+
+    # If OData lookup fails, fall back to PSResourceGet if available, then PowerShellGet, as these may have cached data even when the API is unreachable.
+    if (Get-Command 'Find-PSResource' -ErrorAction SilentlyContinue) {
+        try {
+            return Get-LatestVersionFromPSResourceGet -ModuleName $Name
+        } catch {
+            Write-Verbose "Unable to get latest version using Find-PSResource for '$Name': $_"
+        }
+    }
+
+    # As a last resort, attempt to get the latest version using PowerShellGet's Find-Module, but only if the NuGet provider is available to avoid unnecessary errors and delays.
+    if (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
+        try {
+            return Get-LatestVersionFromPowerShellGet -ModuleName $Name
+        } catch {
+            Write-Verbose "Unable to get latest version using Find-Module for '$Name': $_"
+        }
+    }
+
+    # If all methods fail, return null to indicate that the latest version could not be determined.
+    return $null
+}

--- a/powershell/internal/Get-MtLatestModuleVersion.ps1
+++ b/powershell/internal/Get-MtLatestModuleVersion.ps1
@@ -50,7 +50,7 @@
         try {
             return [version]$versionString
         } catch {
-            Write-Error "Could not parse version '$versionString': $_"
+            Write-Warning "Could not parse version '$versionString': $_"
             return $null
         }
     } # End of ConvertTo-StableVersion

--- a/powershell/internal/Get-MtLatestModuleVersion.ps1
+++ b/powershell/internal/Get-MtLatestModuleVersion.ps1
@@ -26,6 +26,7 @@
         This ensures that only stable versions are considered when determining the latest module version.
         #>
         [CmdletBinding()]
+        [OutputType([version])]
         param(
             [Parameter(Mandatory = $true)]
             [AllowNull()]
@@ -61,6 +62,7 @@
         Retrieves the latest stable version (non-prerelease) of a module from the PowerShell Gallery using the OData API.
         #>
         [CmdletBinding()]
+        [OutputType([version])]
         param(
             [Parameter(Mandatory = $true)]
             [string] $ModuleName,
@@ -100,6 +102,8 @@
     } # End of Get-LatestVersionFromOData
 
     function Get-LatestVersionFromPSResourceGet {
+        [CmdletBinding()]
+        [OutputType([version])]
         param(
             [Parameter(Mandatory = $true)]
             [string] $ModuleName
@@ -110,6 +114,8 @@
     } # End of Get-LatestVersionFromPSResourceGet
 
     function Get-LatestVersionFromPowerShellGet {
+        [CmdletBinding()]
+        [OutputType([version])]
         param(
             [Parameter(Mandatory = $true)]
             [string] $ModuleName

--- a/powershell/internal/Get-MtLatestModuleVersion.ps1
+++ b/powershell/internal/Get-MtLatestModuleVersion.ps1
@@ -3,8 +3,8 @@
     .SYNOPSIS
     Retrieves the latest stable version (non-prerelease) of a module from the PowerShell Gallery.
     #>
-    [OutputType([version])]
     [CmdletBinding()]
+    [OutputType([version])]
     param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]

--- a/powershell/internal/Get-MtLatestModuleVersion.ps1
+++ b/powershell/internal/Get-MtLatestModuleVersion.ps1
@@ -109,7 +109,17 @@
             [string] $ModuleName
         )
 
+        if (-not (Get-Command 'Find-PSResource' -ErrorAction SilentlyContinue)) {
+            Write-Verbose 'Skipping Find-PSResource fallback because Microsoft.PowerShell.PSResourceGet is not installed.'
+            return $null
+        }
+
         $resource = Find-PSResource -Name $ModuleName -ErrorAction Stop | Select-Object -First 1
+        if ($null -eq $resource) {
+            Write-Verbose "Find-PSResource returned no results for '$ModuleName'."
+            return $null
+        }
+
         return ConvertTo-StableVersion -InputVersion $resource.Version
     } # End of Get-LatestVersionFromPSResourceGet
 

--- a/powershell/internal/Get-MtModuleInfo.ps1
+++ b/powershell/internal/Get-MtModuleInfo.ps1
@@ -1,7 +1,7 @@
 ﻿function Get-MtModuleInfo {
 <#
 .SYNOPSIS
-    Returns the module details from the psd1 fle.
+    Returns the module details from the psd1 file.
 #>
     [CmdletBinding()]
     [OutputType([PSObject])]

--- a/powershell/internal/Get-MtModuleInfo.ps1
+++ b/powershell/internal/Get-MtModuleInfo.ps1
@@ -1,13 +1,12 @@
-﻿<#
+﻿function Get-MtModuleInfo {
+<#
 .SYNOPSIS
     Returns the module details from the psd1 fle.
-
 #>
-function Get-MtModuleInfo {
+    [CmdletBinding()]
+    [OutputType([PSObject])]
     param()
-
-
-
-    Write-Debug $moduleInfo | ConvertTo-Json -Depth 5
-    return $moduleInfo
+    $MtModuleInfo = $MyInvocation.MyCommand.Module
+    Write-Debug $MtModuleInfo | ConvertTo-Json -Depth 5
+    return $MtModuleInfo
 }

--- a/powershell/internal/Get-MtModuleInfo.ps1
+++ b/powershell/internal/Get-MtModuleInfo.ps1
@@ -7,6 +7,6 @@
     [OutputType([PSObject])]
     param()
     $MtModuleInfo = $MyInvocation.MyCommand.Module
-    Write-Debug $MtModuleInfo | ConvertTo-Json -Depth 5
+    $MtModuleInfo | ConvertTo-Json -Depth 5 | Write-Debug
     return $MtModuleInfo
 }

--- a/powershell/internal/Get-MtModuleVersion.ps1
+++ b/powershell/internal/Get-MtModuleVersion.ps1
@@ -4,6 +4,7 @@
     Return the module version.
     #>
     [CmdletBinding()]
+    [OutputType([string], [version])]
     param()
 
     $PSD1Version = $MyInvocation.MyCommand.Module.Version

--- a/powershell/internal/Get-MtModuleVersion.ps1
+++ b/powershell/internal/Get-MtModuleVersion.ps1
@@ -1,17 +1,16 @@
-﻿<#
-.SYNOPSIS
-    Returns the module version from the psd1 fle.
-
-#>
-function Get-MtModuleVersion {
+﻿function Get-MtModuleVersion {
+    <#
+    .SYNOPSIS
+    Return the module version.
+    #>
+    [CmdletBinding()]
     param()
 
-    $psd1Version = $ModuleInfo.ModuleVersion
-    # In dev, we'll call it vNext, if the static value in .psd1 is changed, update here as well
-    if ('0.1.0' -eq $psd1Version) {
+    $PSD1Version = $MyInvocation.MyCommand.Module.Version
+    # In dev, we'll call it vNext, if the static value in the .PSD1 is changed, update here as well.
+    if ('0.1.0' -eq $PSD1Version) {
         return 'Next'
-    }
-    else {
-        return $psd1Version
+    } else {
+        return $PSD1Version
     }
 }

--- a/powershell/tests/functions/Get-IsNewMaesterVersionAvailable.Tests.ps1
+++ b/powershell/tests/functions/Get-IsNewMaesterVersionAvailable.Tests.ps1
@@ -1,0 +1,92 @@
+﻿Describe 'Get-IsNewMaesterVersionAvailable' {
+    BeforeAll {
+        . "$PSScriptRoot/../../internal/Get-MtLatestModuleVersion.ps1"
+        . "$PSScriptRoot/../../internal/Get-MtModuleVersion.ps1"
+        . "$PSScriptRoot/../../internal/Get-IsNewMaesterVersionAvailable.ps1"
+    }
+
+    Context 'When a newer version exists' {
+        It 'returns true' {
+            $latestVersion = [version]'2.5.0'
+
+            Mock Get-MtModuleVersion { [version]'2.4.0' }
+            Mock Get-MtLatestModuleVersion { $latestVersion }
+            Mock Write-Host {}
+
+            $result = Get-IsNewMaesterVersionAvailable
+
+            $result | Should -BeTrue
+            Should -Invoke Get-MtModuleVersion -Exactly 1
+            Should -Invoke Get-MtLatestModuleVersion -Exactly 1
+        }
+
+        It 'returns false when installed is equal to latest' {
+            Mock Get-MtModuleVersion { [version]'2.0.0' }
+            Mock Get-MtLatestModuleVersion { [version]'2.0.0' }
+            Mock Write-Host {}
+
+            $result = Get-IsNewMaesterVersionAvailable
+
+            $result | Should -BeFalse
+        }
+
+        It 'returns false when current version is not comparable (for example, Next)' {
+            Mock Get-MtModuleVersion { 'Next' }
+            Mock Get-MtLatestModuleVersion { [version]'2.0.0' }
+            Mock Write-Host {}
+
+            $result = Get-IsNewMaesterVersionAvailable
+
+            $result | Should -BeFalse
+        }
+    }
+
+    Context 'When latest version cannot be determined' {
+        It 'returns false' {
+            Mock Get-MtModuleVersion { [version]'2.4.0' }
+            Mock Get-MtLatestModuleVersion { $null }
+            Mock Write-Host {}
+
+            $result = Get-IsNewMaesterVersionAvailable
+
+            $result | Should -BeFalse
+            Should -Invoke Get-MtLatestModuleVersion -Exactly 1
+        }
+    }
+
+    Context 'When version lookup throws' {
+        It 'returns false and does not throw' {
+            Mock Get-MtModuleVersion { [version]'2.4.0' }
+            Mock Get-MtLatestModuleVersion { throw 'Lookup failed' }
+            Mock Write-Host {}
+
+            { Get-IsNewMaesterVersionAvailable } | Should -Not -Throw
+            Get-IsNewMaesterVersionAvailable | Should -BeFalse
+        }
+    }
+
+    Context 'When installed version cannot be determined' {
+        It 'returns false' {
+            Mock Get-MtModuleVersion { $null }
+            Mock Get-MtLatestModuleVersion { [version]'2.5.0' }
+            Mock Write-Host {}
+
+            $result = Get-IsNewMaesterVersionAvailable
+
+            $result | Should -BeFalse
+        }
+    }
+
+    Context 'When current module version is a prerelease string' {
+        It 'parses and compares prerelease versions correctly' {
+            Mock Get-MtModuleVersion { '2.0.0-beta' }
+            Mock Get-MtLatestModuleVersion { [version]'2.1.0' }
+            Mock Write-Host {}
+
+            $result = Get-IsNewMaesterVersionAvailable
+
+            # 2.0.0-beta is normalized to 2.0.0 for deterministic comparison.
+            $result | Should -BeTrue
+        }
+    }
+}

--- a/powershell/tests/functions/Get-MtLatestModuleVersion.Tests.ps1
+++ b/powershell/tests/functions/Get-MtLatestModuleVersion.Tests.ps1
@@ -1,0 +1,119 @@
+﻿Describe 'Get-MtLatestModuleVersion' {
+    BeforeAll {
+        . "$PSScriptRoot/../../internal/Get-MtLatestModuleVersion.ps1"
+    }
+
+    Context 'OData API lookup' {
+        It 'returns a stable version from an object-based OData response' {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    properties = [PSCustomObject]@{ Version = '2.4.0' }
+                }
+            }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -Be ([version]'2.4.0')
+        }
+
+        It 'returns a stable version from an XML OData response' {
+            $xmlResponse = @"
+<entry xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices">
+  <m:properties>
+    <d:Version>3.1.0</d:Version>
+  </m:properties>
+</entry>
+"@
+
+            Mock Invoke-RestMethod {
+                ([xml]$xmlResponse).DocumentElement
+            }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -Be ([version]'3.1.0')
+        }
+
+        It 'returns null when OData returns prerelease version and no fallback is available' {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    properties = [PSCustomObject]@{ Version = '2.5.0-preview1' }
+                }
+            }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Find-PSResource' }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Find-Module' }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -BeNullOrEmpty
+        }
+
+        It 'passes the requested timeout to Invoke-RestMethod' {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    properties = [PSCustomObject]@{ Version = '2.4.0' }
+                }
+            }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 30
+
+            $latestVersion | Should -Be ([version]'2.4.0')
+            Should -Invoke Invoke-RestMethod -Exactly 1 -ParameterFilter { $TimeoutSec -eq 30 }
+        }
+    }
+
+    Context 'Fallback to PSResourceGet' {
+        It 'uses Find-PSResource when OData lookup fails' {
+            Mock Invoke-RestMethod { throw 'Network failure' }
+            Mock Get-Command {
+                [PSCustomObject]@{ Name = 'Find-PSResource' }
+            } -ParameterFilter { $Name -eq 'Find-PSResource' }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Find-Module' }
+            Mock Find-PSResource {
+                [PSCustomObject]@{ Version = '2.6.1' }
+            }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -Be ([version]'2.6.1')
+        }
+    }
+
+    Context 'Guarded Find-Module fallback' {
+        It 'skips Find-Module when NuGet provider is unavailable' {
+            Mock Invoke-RestMethod { throw 'Network failure' }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Find-PSResource' }
+            Mock Get-Command {
+                [PSCustomObject]@{ Name = 'Find-Module' }
+            } -ParameterFilter { $Name -eq 'Find-Module' }
+            Mock Get-PackageProvider { $null }
+            Mock Find-Module {
+                [PSCustomObject]@{ Version = '2.7.0' }
+            }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -BeNullOrEmpty
+            Should -Invoke Find-Module -Exactly 0
+        }
+
+        It 'uses Find-Module when NuGet provider is available' {
+            Mock Invoke-RestMethod { throw 'Network failure' }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Find-PSResource' }
+            Mock Get-Command {
+                [PSCustomObject]@{ Name = 'Find-Module' }
+            } -ParameterFilter { $Name -eq 'Find-Module' }
+            Mock Get-PackageProvider {
+                [PSCustomObject]@{ Name = 'NuGet' }
+            }
+            Mock Find-Module {
+                [PSCustomObject]@{ Version = '2.7.0' }
+            }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -Be ([version]'2.7.0')
+            Should -Invoke Find-Module -Exactly 1
+        }
+    }
+}

--- a/powershell/tests/functions/Get-MtLatestModuleVersion.Tests.ps1
+++ b/powershell/tests/functions/Get-MtLatestModuleVersion.Tests.ps1
@@ -64,6 +64,11 @@
 
     Context 'Fallback to PSResourceGet' {
         It 'uses Find-PSResource when OData lookup fails' {
+            if (-not (Get-Command 'Find-PSResource' -ErrorAction SilentlyContinue)) {
+                Set-ItResult -Skipped -Because 'Find-PSResource is not available in this host session.'
+                return
+            }
+
             Mock Invoke-RestMethod { throw 'Network failure' }
             Mock Get-Command {
                 [PSCustomObject]@{ Name = 'Find-PSResource' }
@@ -76,6 +81,19 @@
             $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
 
             $latestVersion | Should -Be ([version]'2.6.1')
+        }
+
+        It 'returns null when Find-PSResource returns no results' {
+            Mock Invoke-RestMethod { throw 'Network failure' }
+            Mock Get-Command {
+                [PSCustomObject]@{ Name = 'Find-PSResource' }
+            } -ParameterFilter { $Name -eq 'Find-PSResource' }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Find-Module' }
+            Mock Find-PSResource { @() }
+
+            $latestVersion = Get-MtLatestModuleVersion -Name 'Maester' -TimeoutSec 10
+
+            $latestVersion | Should -BeNullOrEmpty
         }
     }
 

--- a/powershell/tests/functions/Get-MtLatestModuleVersion.Tests.ps1
+++ b/powershell/tests/functions/Get-MtLatestModuleVersion.Tests.ps1
@@ -17,13 +17,13 @@
         }
 
         It 'returns a stable version from an XML OData response' {
-            $xmlResponse = @"
+            $xmlResponse = @'
 <entry xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices">
   <m:properties>
     <d:Version>3.1.0</d:Version>
   </m:properties>
 </entry>
-"@
+'@
 
             Mock Invoke-RestMethod {
                 ([xml]$xmlResponse).DocumentElement


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request refactors Maester's check for new versions to improve performance and avoid issues with legacy NuGet package providers on some systems.
- It replaces the use of `Find-Module` with a query to the PSGallery API.
- It avoids using `Get-Module` and `Get-InstalledModule` by checking the version of the currently running module.
- It replaces blocks of redundant code with calls to version helper scripts.

**Version checking improvements:**

* Added `Get-MtLatestModuleVersion.ps1`, which retrieves the latest stable version of a module from multiple sources (PowerShell Gallery OData API, PSResourceGet, PowerShellGet), ensuring reliability even if some methods fail.
* Added `Get-MtModuleVersion.ps1`, which reliably determines the installed Maester module version, including handling development versions labeled as 'Next'.
* Refactored `Get-IsNewMaesterVersionAvailable.ps1` to use the new version helpers, normalize version strings (including prerelease handling), and improve user messaging.

**Testing:**

* Added `Get-IsNewMaesterVersionAvailable.Tests.ps1` with comprehensive tests covering scenarios such as newer version detection, equality, invalid or missing versions, lookup failures, and prerelease normalization.

**Code style consistency:**

* Standardized string literals throughout `ConvertTo-MtMaesterResult.ps1` to use single quotes for improved PowerShell style and readability. [[1]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L34-R34) [[2]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L46-R46) [[3]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L58-R58) [[4]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L74-R83) [[5]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L149-R150) [[6]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L273-R274) [[7]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L304-R318) [[8]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L380-R380) [[9]](diffhunk://#diff-1148618f3a0a43e1ed3d2c2a6cb3605989305524df2274ce039890c87c1a55b7L416-R415)

Resolves #1474 

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.