### PR TITLE
FIX EIDSCA.AS04: Authentication Method - SMS - Use for sign-in.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -502,3 +502,4 @@ build/orca/orca/
 #Ignore Codacy's MCP server configuration and instruction files
 .github/instructions/codacy.instructions.md
 .codacy/**
+.github/instructions/copilot.instructions.md

--- a/powershell/internal/eidsca/Test-MtEidscaAS04.ps1
+++ b/powershell/internal/eidsca/Test-MtEidscaAS04.ps1
@@ -27,16 +27,31 @@ function Test-MtEidscaAS04 {
     }
     $result = Invoke-MtGraphRequest -RelativeUri "policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')" -ApiVersion beta
 
-    [string]$tenantValue = $result.includeTargets.isUsableForSignIn
-    $testResult = $tenantValue -eq 'false'
-    $tenantValueNotSet = ($null -eq $tenantValue -or $tenantValue -eq "") -and 'false' -notlike '*$null*'
+    $includeTargets = @($result.includeTargets)
+    $tenantValueNotSet = ($includeTargets.Count -eq 0) -and 'false' -notlike '*$null*'
 
-    if($testResult){
+    if (-not $tenantValueNotSet) {
+        $failingTargets = @($includeTargets | Where-Object { [string]$_.isUsableForSignIn -ne 'false' })
+        $testResult = $failingTargets.Count -eq 0
+        $tenantValue = if ($testResult) { 'false' } else { 'true' }
+    } else {
+        $testResult = $false
+        $tenantValue = $null
+    }
+
+    if ($testResult) {
         $testResultMarkdown = "Well done. The configuration in your tenant and recommended value is **'false'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')**"
     } elseif ($tenantValueNotSet) {
         $testResultMarkdown = "Your tenant is **not configured explicitly**.`n`nThe recommended value is **'false'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')**. It seems that you are using a default value by Microsoft. We recommend to set the setting value explicitly since non set values could change depending on what Microsoft decides the current default should be."
     } else {
-        $testResultMarkdown = "Your tenant is configured as **$($tenantValue)**.`n`nThe recommended value is **'false'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')**"
+        $directoryObjects = Get-MtDirectoryObjects -ObjectId $failingTargets.id
+        $failingDetails = ($failingTargets | ForEach-Object {
+            $target = $PSItem
+            $displayName = ($directoryObjects | Where-Object { $_.id -eq $target.id }).displayName
+            if (-not $displayName) { $displayName = $target.id }
+            "- Target **$displayName**: isUsableForSignIn = **$($target.isUsableForSignIn)**"
+        }) -join "`n"
+        $testResultMarkdown = "Your tenant has **$($failingTargets.Count)** target(s) with **isUsableForSignIn** not set to **false** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')**:`n`n$failingDetails`n`nThe recommended value is **'false'** for **policies/authenticationMethodsPolicy/authenticationMethodConfigurations('Sms')**"
     }
     Add-MtTestResultDetail -Result $testResultMarkdown -Severity 'High'
 


### PR DESCRIPTION
# Description
User Bennell flagged an issue in discord related to multiple groups assigned to the SMS Authentication Method and this EIDSCA.AS04 test. The returned value would be 'False False' if for example 2 groups are assigned to the Authentication method SMS rather than 'False'. Marking the test as failed, where it would actually have passed if logic was set correctly.

Compute failingTargets where isUsableForSignIn != 'false', set tenantValue/testResult accordingly, and fetch directory objects to include display names for failing targets. 

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [ ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.