### PR TITLE
fix: correct env var typo MEASTER_FOLDER_DRIFT -> MAESTER_FOLDER_DRIFT

### DIFF
--- a/tests/Maester/Drift/MT1060Drift.tests.ps1
+++ b/tests/Maester/Drift/MT1060Drift.tests.ps1
@@ -34,7 +34,7 @@ BeforeDiscovery {
     # Get root directory for drift tests
     # This assumes the drift tests are located in a folder named "drift" at the root of the current location
     # $driftRoot = Join-Path -Path $(Get-Location) -ChildPath "drift"
-    $driftRoot = $env:MEASTER_FOLDER_DRIFT
+    $driftRoot = $env:MAESTER_FOLDER_DRIFT
     # Ensure the drift root directory exists
     if ($null -eq $driftRoot -or -not (Test-Path -Path $driftRoot)) {
         return $null


### PR DESCRIPTION
## Bug

`MT1060Drift.tests.ps1` line 37 reads `\$env:MEASTER_FOLDER_DRIFT` (letters E and A swapped), but `Invoke-Maester.ps1` line 430 sets `\$env:MAESTER_FOLDER_DRIFT`.

This causes `-DriftRoot` passed to `Invoke-Maester` to be silently ignored — MT.1060 never discovers any drift folders.

## Fix

One-line change:

\\\diff
- \$driftRoot = \$env:MEASTER_FOLDER_DRIFT
+ \$driftRoot = \$env:MAESTER_FOLDER_DRIFT
\\\

## How I found it

I'm building [EasyTCM](https://github.com/kayasax/EasyTCM), a PowerShell module that bridges Microsoft's new Tenant Configuration Management (TCM) APIs to Maester via MT.1060. When testing the integration end-to-end, `Invoke-Maester -Path '.\Maester\Drift\'` returned 0 tests. Setting `\$env:MEASTER_FOLDER_DRIFT` manually made it work.

## Tested

- Maester v2.0.0
- PowerShell 7.x, Windows 11
- Confirmed: 4 drift tests pass after the fix