### PR TITLE
ci: Pin action to commit SHA in update-tag-documentation.yml

### DIFF
--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up PowerShell modules
         run: |


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request updates the `actions/checkout` GitHub Action in the `update-tag-documentation.yml` workflow to use a specific commit SHA instead of the version tag. This change improves security and reliability by ensuring the workflow always uses the exact intended version of the action.

- Dependency pinning:
  * Updated the `actions/checkout` step to use commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` instead of the `v6` tag in `.github/workflows/update-tag-documentation.yml`.
