### PR TITLE
ci: Update GitHub Actions workflow for module docs

### DIFF
--- a/.github/workflows/update-module-docs.yaml
+++ b/.github/workflows/update-module-docs.yaml
@@ -18,12 +18,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Update maester.dev powershell docs
         run: ./build/Update-CommandReference.ps1
         shell: pwsh
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           title: Update maester.dev powershell docs


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request makes minor updates to the GitHub Actions workflow by pinning action dependencies to specific commit SHAs for improved security and reproducibility.

- Workflow dependency pinning:
  * Updated the `actions/checkout` action to use a specific commit SHA instead of a version tag in `.github/workflows/update-module-docs.yaml`.
  * Updated the `peter-evans/create-pull-request` action to use a specific commit SHA instead of a version tag in `.github/workflows/update-module-docs.yaml`.