### PR TITLE
Update build-docs workflow to use pinned actions

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Update docs
         run: ./build/Update-CommandReference.ps1
         shell: pwsh
 
       - name: Create PR to update repo
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           title: Update maester.dev command reference


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request updates the pinned commit SHAs for two GitHub Actions used in the documentation build workflow. This ensures that the workflow uses specific, immutable versions of these actions for improved security and reproducibility.

Dependency pinning in GitHub Actions workflow:

* Updated the `actions/checkout` action from a version tag (`v6.0.1`) to a specific commit SHA (`8e8c483db84b4bee98b60c0593521ed34d9990e8`) in `.github/workflows/build-docs.yaml`.
* Updated the `peter-evans/create-pull-request` action from a version tag (`v8`) to a specific commit SHA (`c0f553fe549906ede9cf27b5156039d195d2ece0`) in `.github/workflows/build-docs.yaml`.