### PR TITLE
Update and pin action version in build-report.yaml

### DIFF
--- a/.github/workflows/build-report.yaml
+++ b/.github/workflows/build-report.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload report template as artifact
         if: steps.check-changes.outputs.changed == 'true'
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: updated-report-template
           path: powershell/assets/ReportTemplate.html


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request makes minor updates to the GitHub Actions workflow by pinning the action dependencies to specific commit SHAs for improved security and reproducibility.

Dependency pinning in workflow actions:

* Updated the `actions/checkout` action to use a specific commit SHA instead of the version tag `v6.0.1` in `.github/workflows/build-report.yaml`.
* Updated the `actions/upload-artifact` action to use a specific commit SHA instead of the version tag `v7.0.0` in `.github/workflows/build-report.yaml`.