### PR TITLE
Pin GitHub actions to specific version in publish-module-preview

### DIFF
--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Download updated report template
         if: needs.build-report.outputs.report-updated == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: updated-report-template
           path: powershell/assets/
@@ -47,7 +47,7 @@ jobs:
         run: ./.github/workflows/minor-version-update.ps1 -preview
 
       - name: Archive PowerShell build
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: maester-module
           path: |
@@ -68,7 +68,7 @@ jobs:
           Compress-Archive -Path ${{ github.workspace }}/maester/* -DestinationPath ${{ github.workspace }}/maester.zip
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: "maester.zip"
           replacesArtifacts: true


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request updates the GitHub Actions workflow in `.github/workflows/publish-module-preview.yaml` to use pinned commit SHAs for all third-party actions, improving security and reproducibility by avoiding implicit updates from version tags.

**Workflow security and reliability improvements:**

* Updated `actions/checkout` to use a specific commit SHA (`8e8c483db84b4bee98b60c0593521ed34d9990e8`) instead of the version tag `v6.0.1`.
* Updated `actions/download-artifact` to use a specific commit SHA (`3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`) instead of the version tag `v8.0.1`.
* Updated `actions/upload-artifact` to use a specific commit SHA (`bbbca2ddaa5d8feaa63e36b76fdaad77386f024f`) instead of the version tag `v7.0.0`.
* Updated `ncipollo/release-action` to use a specific commit SHA (`339a81892b84b4eeb0f6e744e4574d79d0d9b8dd`) instead of the version tag `v1.21.0`.