### PR TITLE
ci: Pin action to commit SHA in publish-module

### DIFF
--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Download updated report template
         if: needs.build-report.outputs.report-updated == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: updated-report-template
           path: powershell/assets/
@@ -57,7 +57,7 @@ jobs:
           Compress-Archive -Path ${{ github.workspace }}/maester/* -DestinationPath ${{ github.workspace }}/maester.zip
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: "maester.zip"
           replacesArtifacts: true


### PR DESCRIPTION
# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request updates the GitHub Actions workflow configuration in `.github/workflows/publish-module.yaml` to use specific commit SHAs for third-party actions instead of version tags. This enhances security and reliability by ensuring the workflow always uses the exact, reviewed versions of these actions.

**Workflow dependency pinning:**

* Updated `actions/checkout` from a version tag (`v6.0.1`) to a specific commit SHA for more secure and predictable action usage.
* Updated `actions/download-artifact` from a version tag (`v8`) to a specific commit SHA for improved security and consistency.
* Updated `ncipollo/release-action` from a version tag (`v1`) to a specific commit SHA (`v1.21.0`) to ensure reproducibility and prevent unexpected changes from upstream updates.