### PR TITLE
Remove npm audit step from build report workflow

### DIFF
--- a/.github/workflows/build-report.yaml
+++ b/.github/workflows/build-report.yaml
@@ -41,11 +41,6 @@ jobs:
           cd report
           npm ci
 
-      - name: Audit dependencies
-        run: |
-          cd report
-          npm audit --audit-level=high
-
       - name: Build report
         run: |
           cd report


### PR DESCRIPTION
Removed the dependency audit step from the build process.

# Description
<!-- Please provide a detailed description of your enhancement or bug fix here. If this will resolve an issue, please tag the issue number as well. For example, "Fixes #1212." -->

This pull request makes a minor update to the build workflow by removing the dependency audit step from the `.github/workflows/build-report.yaml` file. This means that `npm audit` will no longer be run as part of the build process.

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [ ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
