### PR TITLE
Add MT.1123 - BitLocker Full Disk Encryption Check

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -181,6 +181,7 @@
     'Test-MtAppleVolumePurchaseProgramToken',
     'Test-MtCertificateConnectors', 'Test-MtFeatureUpdatePolicy',
     'Test-MtIntuneDiagnosticSettings', 'Test-MtIntuneRbacGroupsProtected',
+    'Test-MtBitLockerFullDiskEncryption',
     'Test-MtMdmAuthority', 'Test-MtMobileThreatDefenseConnectors',
     'Test-MtTenantCustomization', 'Test-MtWindowsDataProcessor',
     'Test-MtXspmCriticalCredsOnDevicesWithNonCriticalAccounts',

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.md
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.md
@@ -1,0 +1,42 @@
+Ensure at least one Intune Disk Encryption policy enforces BitLocker with **full disk encryption type**.
+
+BitLocker Drive Encryption protects data on Windows devices by encrypting the disk.
+However, BitLocker supports two encryption types that have very different security implications:
+
+- **Full disk encryption** — encrypts the entire drive including free space. This is the recommended and secure option.
+- **Used space only encryption** — only encrypts sectors currently holding data. **This is dangerous on drives that previously contained unencrypted data**, because previously deleted files remain as raw data in unencrypted free space. This data can be recovered using commonly available data recovery software (e.g., Recuva, PhotoRec, or forensic imaging tools). NTFS marks deleted file sectors as "free" but does not zero them out — the original bytes stay on disk until overwritten by new data.
+
+**Bottom line:** If BitLocker is enabled with "Used space only" on a drive that already had data on it before encryption was turned on, that pre-existing deleted data is fully recoverable. Only "Full disk encryption" guarantees that the entire drive surface is protected.
+
+This test queries the Intune **Endpoint Security > Disk Encryption** policies via the `configurationPolicies` Graph API and inspects the BitLocker CSP settings to verify that **Enforce drive encryption type** is set to **Full encryption** for OS drives.
+
+#### Remediation action:
+
+1. Navigate to [Microsoft Intune admin center](https://intune.microsoft.com).
+2. Go to **Endpoint security** > **Disk encryption**.
+3. Click **+ Create policy**.
+4. Set **Platform** to **Windows 10 and later** and **Profile** to **BitLocker**.
+5. Enter a policy name (e.g., "BitLocker - Full Disk Encryption").
+6. Configure the following settings:
+   - **Require Device Encryption**: **Enabled**
+   - **Allow Warning For Other Disk Encryption**: **Disabled** (enables silent encryption)
+   - **Allow Standard User Encryption**: **Enabled**
+   - **Enforce drive encryption type on operating system drives**: **Enabled**, set to **Full encryption**
+   - **Enforce drive encryption type on fixed data drives**: **Enabled**, set to **Full encryption**
+   - **Choose drive encryption method and cipher strength**: **Enabled**
+     - OS drives: **XTS-AES 256-bit**
+     - Fixed data drives: **XTS-AES 256-bit**
+     - Removable data drives: **AES-CBC 256-bit**
+   - **Require additional authentication at startup**: **Enabled**, with **Require TPM**
+   - **Choose how BitLocker-protected OS drives can be recovered**: **Enabled**, with backup to Entra ID
+7. Assign the policy to your device groups and click **Create**.
+
+#### Related links
+
+- [Microsoft Intune - Endpoint Security Disk Encryption](https://intune.microsoft.com/#view/Microsoft_Intune_Workflows/SecurityManagementMenu/~/diskEncryption)
+- [Microsoft Learn - Encrypt devices with BitLocker in Intune](https://learn.microsoft.com/en-us/mem/intune/protect/encrypt-devices)
+- [Microsoft Learn - BitLocker CSP reference](https://learn.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp)
+- [CIS Benchmark - Ensure BitLocker is enabled on all Windows devices](https://www.cisecurity.org/benchmark/microsoft_intune_for_windows)
+
+<!--- Results --->
+%TestResult%

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -134,6 +134,7 @@ function Test-MtBitLockerFullDiskEncryption {
 
                 # Check Fixed drive encryption type (FixedDrivesEncryptionType)
                 if ($defId -eq $fixedEncryptionTypeId) {
+                    $policyDetail.IsBitLockerPolicy = $true
                     $parentVal = $setting.settingInstance.choiceSettingValue.value
                     if ($parentVal -like '*_1') {
                         $children = $setting.settingInstance.choiceSettingValue.children
@@ -152,6 +153,7 @@ function Test-MtBitLockerFullDiskEncryption {
 
                 # Check encryption method (cipher strength)
                 if ($defId -eq $encryptionMethodId) {
+                    $policyDetail.IsBitLockerPolicy = $true
                     $parentVal = $setting.settingInstance.choiceSettingValue.value
                     if ($parentVal -like '*_1') {
                         $children = $setting.settingInstance.choiceSettingValue.children

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -1,0 +1,206 @@
+function Test-MtBitLockerFullDiskEncryption {
+    <#
+    .SYNOPSIS
+    Ensure at least one Intune Disk Encryption policy enforces BitLocker with full disk encryption type.
+
+    .DESCRIPTION
+    Checks Intune Endpoint Security Disk Encryption policies (configurationPolicies API) for BitLocker
+    profiles that enforce full disk encryption rather than "Used space only" encryption.
+
+    BitLocker supports two encryption types with very different security implications:
+    - "Full disk encryption" — encrypts the entire drive including free space. This is the secure option.
+    - "Used space only encryption" — only encrypts sectors currently holding data. Previously deleted
+      files that were written before encryption was enabled remain in unencrypted free space and can be
+      recovered using data recovery software (e.g., Recuva, PhotoRec, or forensic tools). This is because
+      NTFS marks sectors as free but does not zero them out — the raw data stays on disk until overwritten.
+
+    This test queries the configurationPolicies Graph API (used by Endpoint Security > Disk Encryption)
+    which exposes the actual BitLocker CSP settings including:
+    - SystemDrivesEncryptionType (OS drive encryption type: full vs used space only)
+    - FixedDrivesEncryptionType (fixed drive encryption type: full vs used space only)
+    - RequireDeviceEncryption (require BitLocker encryption)
+    - EncryptionMethodByDriveType (cipher strength: XTS-AES 128/256, AES-CBC 128/256)
+
+    The test passes only if at least one BitLocker Disk Encryption policy has the OS drive encryption
+    type set to "Full encryption". It fails if no policies exist, if encryption type is set to
+    "Used space only", or if the encryption type setting is not configured.
+
+    .EXAMPLE
+    Test-MtBitLockerFullDiskEncryption
+
+    Returns true if at least one Disk Encryption policy enforces full disk encryption for OS drives.
+
+    .LINK
+    https://maester.dev/docs/commands/Test-MtBitLockerFullDiskEncryption
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (-not (Get-MtLicenseInformation -Product Intune)) {
+        Add-MtTestResultDetail -SkippedBecause NotLicensedIntune
+        return $null
+    }
+
+    try {
+        # Query only Endpoint Security Disk Encryption BitLocker policies (server-side filter)
+        $bitLockerPolicies = Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta
+
+        if (-not $bitLockerPolicies -or $bitLockerPolicies.Count -eq 0) {
+            $testResultMarkdown = "No Endpoint Security Disk Encryption (BitLocker) policies found in Intune.`n`n"
+            $testResultMarkdown += "Create a BitLocker policy under **Endpoint Security > Disk Encryption** with "
+            $testResultMarkdown += "**Enforce drive encryption type** set to **Full encryption** for OS and fixed data drives."
+            Add-MtTestResultDetail -Result $testResultMarkdown
+            return $false
+        }
+
+        # Setting definition IDs for BitLocker CSP settings
+        $osEncryptionTypeId = 'device_vendor_msft_bitlocker_systemdrivesencryptiontype'
+        $osEncryptionTypeDropdownId = 'device_vendor_msft_bitlocker_systemdrivesencryptiontype_osencryptiontypedropdown_name'
+        $fixedEncryptionTypeId = 'device_vendor_msft_bitlocker_fixeddrivesencryptiontype'
+        $fixedEncryptionTypeDropdownId = 'device_vendor_msft_bitlocker_fixeddrivesencryptiontype_fdeencryptiontypedropdown_name'
+        $requireEncryptionId = 'device_vendor_msft_bitlocker_requiredeviceencryption'
+        $encryptionMethodId = 'device_vendor_msft_bitlocker_encryptionmethodbydrivetype'
+        $osEncryptionMethodDropdownId = 'device_vendor_msft_bitlocker_encryptionmethodbydrivetype_encryptionmethodwithxtsosdropdown_name'
+
+        # Encryption type value suffixes: _0 = Allow user to choose, _1 = Full encryption, _2 = Used Space Only
+        $encryptionTypeLabels = @{
+            '_0' = 'Allow user to choose'
+            '_1' = 'Full encryption'
+            '_2' = 'Used Space Only'
+        }
+
+        # Encryption method value suffixes: _3=AES-CBC 128, _4=AES-CBC 256, _6=XTS-AES 128, _7=XTS-AES 256
+        $encryptionMethodLabels = @{
+            '_3' = 'AES-CBC 128-bit'
+            '_4' = 'AES-CBC 256-bit'
+            '_6' = 'XTS-AES 128-bit'
+            '_7' = 'XTS-AES 256-bit'
+        }
+
+        $policyResults = @()
+        $hasFullEncryption = $false
+
+        foreach ($policy in $bitLockerPolicies) {
+            # Fetch settings for this policy with definitions expanded
+            $settingsUri = "deviceManagement/configurationPolicies('$($policy.id)')/settings?`$expand=settingDefinitions&`$top=1000"
+            $settingsResponse = Invoke-MtGraphRequest -RelativeUri $settingsUri -ApiVersion beta
+
+            $policyDetail = @{
+                Name               = $policy.name
+                RequireEncryption  = 'Not configured'
+                OsEncryptionType   = 'Not configured'
+                FixedEncryptionType = 'Not configured'
+                OsEncryptionMethod = 'Not configured'
+            }
+
+            foreach ($setting in $settingsResponse) {
+                $defId = $setting.settingInstance.settingDefinitionId
+
+                # Check RequireDeviceEncryption
+                if ($defId -eq $requireEncryptionId) {
+                    $val = $setting.settingInstance.choiceSettingValue.value
+                    if ($val -like '*_1') {
+                        $policyDetail.RequireEncryption = 'Enabled'
+                    } else {
+                        $policyDetail.RequireEncryption = 'Disabled'
+                    }
+                }
+
+                # Check OS drive encryption type (SystemDrivesEncryptionType)
+                if ($defId -eq $osEncryptionTypeId) {
+                    $parentVal = $setting.settingInstance.choiceSettingValue.value
+                    if ($parentVal -like '*_1') {
+                        # Enabled — check the child dropdown for the actual encryption type
+                        $children = $setting.settingInstance.choiceSettingValue.children
+                        foreach ($child in $children) {
+                            if ($child.settingDefinitionId -eq $osEncryptionTypeDropdownId) {
+                                $dropdownVal = $child.choiceSettingValue.value
+                                foreach ($suffix in $encryptionTypeLabels.Keys) {
+                                    if ($dropdownVal -like "*$suffix") {
+                                        $policyDetail.OsEncryptionType = $encryptionTypeLabels[$suffix]
+                                        if ($suffix -eq '_1') { $hasFullEncryption = $true }
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        $policyDetail.OsEncryptionType = 'Disabled'
+                    }
+                }
+
+                # Check Fixed drive encryption type (FixedDrivesEncryptionType)
+                if ($defId -eq $fixedEncryptionTypeId) {
+                    $parentVal = $setting.settingInstance.choiceSettingValue.value
+                    if ($parentVal -like '*_1') {
+                        $children = $setting.settingInstance.choiceSettingValue.children
+                        foreach ($child in $children) {
+                            if ($child.settingDefinitionId -eq $fixedEncryptionTypeDropdownId) {
+                                $dropdownVal = $child.choiceSettingValue.value
+                                foreach ($suffix in $encryptionTypeLabels.Keys) {
+                                    if ($dropdownVal -like "*$suffix") {
+                                        $policyDetail.FixedEncryptionType = $encryptionTypeLabels[$suffix]
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        $policyDetail.FixedEncryptionType = 'Disabled'
+                    }
+                }
+
+                # Check encryption method (cipher strength)
+                if ($defId -eq $encryptionMethodId) {
+                    $parentVal = $setting.settingInstance.choiceSettingValue.value
+                    if ($parentVal -like '*_1') {
+                        $children = $setting.settingInstance.choiceSettingValue.children
+                        foreach ($child in $children) {
+                            if ($child.settingDefinitionId -eq $osEncryptionMethodDropdownId) {
+                                $methodVal = $child.choiceSettingValue.value
+                                foreach ($suffix in $encryptionMethodLabels.Keys) {
+                                    if ($methodVal -like "*$suffix") {
+                                        $policyDetail.OsEncryptionMethod = $encryptionMethodLabels[$suffix]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            $policyResults += $policyDetail
+        }
+
+        # Build result markdown
+        $testResultMarkdown = "Found $($bitLockerPolicies.Count) BitLocker Disk Encryption policy/policies in Intune.`n`n"
+        $testResultMarkdown += "| Policy | Require Encryption | OS Encryption Type | Fixed Encryption Type | OS Cipher |`n"
+        $testResultMarkdown += "| --- | --- | --- | --- | --- |`n"
+        foreach ($p in $policyResults) {
+            $testResultMarkdown += "| $($p.Name) | $($p.RequireEncryption) | $($p.OsEncryptionType) | $($p.FixedEncryptionType) | $($p.OsEncryptionMethod) |`n"
+        }
+
+        if ($hasFullEncryption) {
+            $testResultMarkdown += "`n**Result:** At least one BitLocker policy enforces **Full encryption** for OS drives."
+
+            # Warn if any policy uses Used Space Only
+            $usedSpaceOnly = $policyResults | Where-Object { $_.OsEncryptionType -eq 'Used Space Only' }
+            if ($usedSpaceOnly) {
+                $testResultMarkdown += "`n`n> **Warning:** $($usedSpaceOnly.Count) policy/policies use **Used Space Only** encryption. "
+                $testResultMarkdown += "Previously deleted data remains recoverable from unencrypted free space on those devices."
+            }
+
+            Add-MtTestResultDetail -Result $testResultMarkdown
+            return $true
+        } else {
+            $testResultMarkdown += "`n**Result:** No BitLocker policy enforces **Full encryption** for OS drives.`n`n"
+            $testResultMarkdown += "> **Risk:** If 'Used space only' encryption is configured (or encryption type is not enforced), "
+            $testResultMarkdown += "data written to the disk before BitLocker was enabled remains as raw unencrypted data in free space "
+            $testResultMarkdown += "and can be recovered using commonly available data recovery tools (Recuva, PhotoRec, forensic imaging)."
+            Add-MtTestResultDetail -Result $testResultMarkdown
+            return $false
+        }
+    } catch {
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        return $null
+    }
+}

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -43,12 +43,14 @@ function Test-MtBitLockerFullDiskEncryption {
     }
 
     try {
-        # Query only Endpoint Security Disk Encryption BitLocker policies (server-side filter)
-        $bitLockerPolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta)
+        # Query Endpoint Security Disk Encryption policies (server-side filter).
+        # This template family can include non-BitLocker templates (e.g., Personal Data Encryption);
+        # BitLocker-specific settings are evaluated per-policy below.
+        $diskEncryptionPolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta)
 
-        if ($bitLockerPolicies.Count -eq 0) {
-            $testResultMarkdown = "No Endpoint Security Disk Encryption (BitLocker) policies found in Intune.`n`n"
-            $testResultMarkdown += "Create a BitLocker policy under **Endpoint Security > Disk Encryption** with "
+        if ($diskEncryptionPolicies.Count -eq 0) {
+            $testResultMarkdown = "No Endpoint Security Disk Encryption policies found in Intune.`n`n"
+            $testResultMarkdown += "Create a Disk Encryption policy under **Endpoint Security > Disk Encryption** with "
             $testResultMarkdown += "**Enforce drive encryption type** set to **Full encryption** for OS and fixed data drives."
             Add-MtTestResultDetail -Result $testResultMarkdown
             return $false
@@ -78,13 +80,13 @@ function Test-MtBitLockerFullDiskEncryption {
             '_7' = 'XTS-AES 256-bit'
         }
 
-        $policyResults = @()
+        $policyResults = [System.Collections.Generic.List[hashtable]]::new()
         $hasFullEncryption = $false
 
-        foreach ($policy in $bitLockerPolicies) {
+        foreach ($policy in $diskEncryptionPolicies) {
             # Fetch settings for this policy with definitions expanded
             $settingsUri = "deviceManagement/configurationPolicies('$($policy.id)')/settings?`$expand=settingDefinitions&`$top=1000"
-            $settingsResponse = Invoke-MtGraphRequest -RelativeUri $settingsUri -ApiVersion beta
+            $settingsResponse = @(Invoke-MtGraphRequest -RelativeUri $settingsUri -ApiVersion beta)
 
             $policyDetail = @{
                 Name               = $policy.name
@@ -92,6 +94,7 @@ function Test-MtBitLockerFullDiskEncryption {
                 OsEncryptionType   = 'Not configured'
                 FixedEncryptionType = 'Not configured'
                 OsEncryptionMethod = 'Not configured'
+                IsBitLockerPolicy  = $false
             }
 
             foreach ($setting in $settingsResponse) {
@@ -99,6 +102,7 @@ function Test-MtBitLockerFullDiskEncryption {
 
                 # Check RequireDeviceEncryption
                 if ($defId -eq $requireEncryptionId) {
+                    $policyDetail.IsBitLockerPolicy = $true
                     $val = $setting.settingInstance.choiceSettingValue.value
                     if ($val -like '*_1') {
                         $policyDetail.RequireEncryption = 'Enabled'
@@ -109,6 +113,7 @@ function Test-MtBitLockerFullDiskEncryption {
 
                 # Check OS drive encryption type (SystemDrivesEncryptionType)
                 if ($defId -eq $osEncryptionTypeId) {
+                    $policyDetail.IsBitLockerPolicy = $true
                     $parentVal = $setting.settingInstance.choiceSettingValue.value
                     if ($parentVal -like '*_1') {
                         # Enabled — check the child dropdown for the actual encryption type
@@ -117,15 +122,13 @@ function Test-MtBitLockerFullDiskEncryption {
                             if ($child.settingDefinitionId -eq $osEncryptionTypeDropdownId) {
                                 $dropdownVal = $child.choiceSettingValue.value
                                 foreach ($suffix in $encryptionTypeLabels.Keys) {
-                                    if ($dropdownVal -like "*$suffix") {
+                                    if ($dropdownVal.EndsWith($suffix)) {
                                         $policyDetail.OsEncryptionType = $encryptionTypeLabels[$suffix]
                                         if ($suffix -eq '_1') { $hasFullEncryption = $true }
                                     }
                                 }
                             }
                         }
-                    } else {
-                        $policyDetail.OsEncryptionType = 'Disabled'
                     }
                 }
 
@@ -138,14 +141,12 @@ function Test-MtBitLockerFullDiskEncryption {
                             if ($child.settingDefinitionId -eq $fixedEncryptionTypeDropdownId) {
                                 $dropdownVal = $child.choiceSettingValue.value
                                 foreach ($suffix in $encryptionTypeLabels.Keys) {
-                                    if ($dropdownVal -like "*$suffix") {
+                                    if ($dropdownVal.EndsWith($suffix)) {
                                         $policyDetail.FixedEncryptionType = $encryptionTypeLabels[$suffix]
                                     }
                                 }
                             }
                         }
-                    } else {
-                        $policyDetail.FixedEncryptionType = 'Disabled'
                     }
                 }
 
@@ -158,7 +159,7 @@ function Test-MtBitLockerFullDiskEncryption {
                             if ($child.settingDefinitionId -eq $osEncryptionMethodDropdownId) {
                                 $methodVal = $child.choiceSettingValue.value
                                 foreach ($suffix in $encryptionMethodLabels.Keys) {
-                                    if ($methodVal -like "*$suffix") {
+                                    if ($methodVal.EndsWith($suffix)) {
                                         $policyDetail.OsEncryptionMethod = $encryptionMethodLabels[$suffix]
                                     }
                                 }
@@ -168,14 +169,25 @@ function Test-MtBitLockerFullDiskEncryption {
                 }
             }
 
-            $policyResults += $policyDetail
+            $policyResults.Add($policyDetail)
         }
 
-        # Build result markdown
+        # Filter to only BitLocker policies (those with BitLocker CSP settings)
+        $bitLockerPolicies = @($policyResults | Where-Object { $_.IsBitLockerPolicy })
+
+        if ($bitLockerPolicies.Count -eq 0) {
+            $testResultMarkdown = "Found $($diskEncryptionPolicies.Count) Disk Encryption policy/policies in Intune, but none are BitLocker policies.`n`n"
+            $testResultMarkdown += "Create a BitLocker policy under **Endpoint Security > Disk Encryption** with "
+            $testResultMarkdown += "**Enforce drive encryption type** set to **Full encryption** for OS and fixed data drives."
+            Add-MtTestResultDetail -Result $testResultMarkdown
+            return $false
+        }
+
+        # Build result markdown (only BitLocker policies)
         $testResultMarkdown = "Found $($bitLockerPolicies.Count) BitLocker Disk Encryption policy/policies in Intune.`n`n"
         $testResultMarkdown += "| Policy | Require Encryption | OS Encryption Type | Fixed Encryption Type | OS Cipher |`n"
         $testResultMarkdown += "| --- | --- | --- | --- | --- |`n"
-        foreach ($p in $policyResults) {
+        foreach ($p in $bitLockerPolicies) {
             $testResultMarkdown += "| $($p.Name) | $($p.RequireEncryption) | $($p.OsEncryptionType) | $($p.FixedEncryptionType) | $($p.OsEncryptionMethod) |`n"
         }
 
@@ -183,7 +195,7 @@ function Test-MtBitLockerFullDiskEncryption {
             $testResultMarkdown += "`n**Result:** At least one BitLocker policy enforces **Full encryption** for OS drives."
 
             # Warn if any policy uses Used Space Only
-            $usedSpaceOnly = @($policyResults | Where-Object { $_.OsEncryptionType -eq 'Used Space Only' })
+            $usedSpaceOnly = @($bitLockerPolicies | Where-Object { $_.OsEncryptionType -eq 'Used Space Only' })
             if ($usedSpaceOnly.Count -gt 0) {
                 $testResultMarkdown += "`n`n> **Warning:** $($usedSpaceOnly.Count) policy/policies use **Used Space Only** encryption. "
                 $testResultMarkdown += "Previously deleted data remains recoverable from unencrypted free space on those devices."

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -46,6 +46,7 @@
         # Query Endpoint Security Disk Encryption policies (server-side filter).
         # This template family can include non-BitLocker templates (e.g., Personal Data Encryption);
         # BitLocker-specific settings are evaluated per-policy below.
+        Write-Verbose "Querying Intune Endpoint Security Disk Encryption policies..."
         $diskEncryptionPolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta)
 
         if ($diskEncryptionPolicies.Count -eq 0) {

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -44,9 +44,9 @@ function Test-MtBitLockerFullDiskEncryption {
 
     try {
         # Query only Endpoint Security Disk Encryption BitLocker policies (server-side filter)
-        $bitLockerPolicies = Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta
+        $bitLockerPolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta)
 
-        if (-not $bitLockerPolicies -or $bitLockerPolicies.Count -eq 0) {
+        if ($bitLockerPolicies.Count -eq 0) {
             $testResultMarkdown = "No Endpoint Security Disk Encryption (BitLocker) policies found in Intune.`n`n"
             $testResultMarkdown += "Create a BitLocker policy under **Endpoint Security > Disk Encryption** with "
             $testResultMarkdown += "**Enforce drive encryption type** set to **Full encryption** for OS and fixed data drives."
@@ -183,8 +183,8 @@ function Test-MtBitLockerFullDiskEncryption {
             $testResultMarkdown += "`n**Result:** At least one BitLocker policy enforces **Full encryption** for OS drives."
 
             # Warn if any policy uses Used Space Only
-            $usedSpaceOnly = $policyResults | Where-Object { $_.OsEncryptionType -eq 'Used Space Only' }
-            if ($usedSpaceOnly) {
+            $usedSpaceOnly = @($policyResults | Where-Object { $_.OsEncryptionType -eq 'Used Space Only' })
+            if ($usedSpaceOnly.Count -gt 0) {
                 $testResultMarkdown += "`n`n> **Warning:** $($usedSpaceOnly.Count) policy/policies use **Used Space Only** encryption. "
                 $testResultMarkdown += "Previously deleted data remains recoverable from unencrypted free space on those devices."
             }
@@ -200,7 +200,11 @@ function Test-MtBitLockerFullDiskEncryption {
             return $false
         }
     } catch {
-        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -in @(401, 403)) {
+            Add-MtTestResultDetail -SkippedBecause NotAuthorized
+        } else {
+            Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        }
         return $null
     }
 }

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -1,4 +1,4 @@
-function Test-MtBitLockerFullDiskEncryption {
+﻿function Test-MtBitLockerFullDiskEncryption {
     <#
     .SYNOPSIS
     Ensure at least one Intune Disk Encryption policy enforces BitLocker with full disk encryption type.
@@ -8,11 +8,11 @@ function Test-MtBitLockerFullDiskEncryption {
     profiles that enforce full disk encryption rather than "Used space only" encryption.
 
     BitLocker supports two encryption types with very different security implications:
-    - "Full disk encryption" — encrypts the entire drive including free space. This is the secure option.
-    - "Used space only encryption" — only encrypts sectors currently holding data. Previously deleted
+    - "Full disk encryption" -- encrypts the entire drive including free space. This is the secure option.
+    - "Used space only encryption" -- only encrypts sectors currently holding data. Previously deleted
       files that were written before encryption was enabled remain in unencrypted free space and can be
       recovered using data recovery software (e.g., Recuva, PhotoRec, or forensic tools). This is because
-      NTFS marks sectors as free but does not zero them out — the raw data stays on disk until overwritten.
+      NTFS marks sectors as free but does not zero them out -- the raw data stays on disk until overwritten.
 
     This test queries the configurationPolicies Graph API (used by Endpoint Security > Disk Encryption)
     which exposes the actual BitLocker CSP settings including:
@@ -116,7 +116,7 @@ function Test-MtBitLockerFullDiskEncryption {
                     $policyDetail.IsBitLockerPolicy = $true
                     $parentVal = $setting.settingInstance.choiceSettingValue.value
                     if ($parentVal -like '*_1') {
-                        # Enabled — check the child dropdown for the actual encryption type
+                        # Enabled -- check the child dropdown for the actual encryption type
                         $children = $setting.settingInstance.choiceSettingValue.children
                         foreach ($child in $children) {
                             if ($child.settingDefinitionId -eq $osEncryptionTypeDropdownId) {

--- a/tests/Maester/Intune/Test-MtIntunePlatform.Tests.ps1
+++ b/tests/Maester/Intune/Test-MtIntunePlatform.Tests.ps1
@@ -61,4 +61,11 @@ Describe "Maester/Intune" -Tag "Maester", "Intune" {
             $result | Should -Be $true -Because "MDM Authority is set to Intune."
         }
     }
+
+    It "MT.1123: Ensure BitLocker full disk encryption is configured" -Tag "MT.1123" {
+        $result = Test-MtBitLockerFullDiskEncryption
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "at least one Intune Endpoint Security Disk encryption policy enforces BitLocker full disk encryption."
+        }
+    }
 }

--- a/tests/maester-config.json
+++ b/tests/maester-config.json
@@ -1350,6 +1350,11 @@
       "Title": "AI agents should not have orphaned ownership"
     },
     {
+      "Id": "MT.1123",
+      "Severity": "High",
+      "Title": "Ensure BitLocker full disk encryption is configured via Intune"
+    },
+    {
       "Id": "ORCA.100",
       "Severity": "Medium",
       "Title": "Bulk Complaint Level threshold is between 4 and 6."

--- a/website/versioned_docs/version-2.0.0/tests/maester/MT.1123.md
+++ b/website/versioned_docs/version-2.0.0/tests/maester/MT.1123.md
@@ -1,0 +1,42 @@
+---
+title: MT.1123 - Ensure BitLocker full disk encryption is configured via Intune
+description: Checks if at least one Intune Endpoint Security Disk encryption policy enforces BitLocker full disk encryption for OS and fixed data drives.
+slug: /tests/MT.1123
+sidebar_class_name: hidden
+---
+
+# Ensure BitLocker full disk encryption is configured via Intune
+
+## Description
+
+BitLocker Drive Encryption protects data on Windows devices, but the **encryption type** setting is critical:
+
+- **Full disk encryption** — encrypts the entire drive including free space. This is the secure option.
+- **Used space only encryption** — only encrypts sectors currently holding data. Previously deleted files that existed before encryption was enabled remain as raw data in unencrypted free space and **can be recovered using data recovery software** (e.g., Recuva, PhotoRec, forensic imaging tools). This happens because NTFS marks deleted sectors as "free" but does not zero them — the original bytes persist on disk until overwritten.
+
+This test queries the `configurationPolicies` Graph API (the same API used by the Intune admin center's **Endpoint Security > Disk Encryption** blade). It reads the BitLocker CSP settings — specifically `SystemDrivesEncryptionType` and `FixedDrivesEncryptionType` — to verify that at least one Disk Encryption policy enforces **Full encryption** for OS drives. It also reports `RequireDeviceEncryption` status and cipher strength (`EncryptionMethodByDriveType`) for each policy.
+
+The test **passes** only if at least one BitLocker Disk Encryption policy has the OS drive encryption type set to "Full encryption". It **fails** if no policies exist, or if all policies use "Used space only" or "Allow user to choose".
+
+## How to fix
+
+1. Navigate to [Microsoft Intune admin center](https://intune.microsoft.com).
+2. Go to **Endpoint security** > **Disk encryption**.
+3. Click **Create Policy**.
+4. Set **Platform** to **Windows 10 and later**.
+5. Set **Profile** to **BitLocker**.
+6. Under the BitLocker settings, configure:
+   - **Enforce drive encryption type on operating system drives**: **Full encryption** (`SystemDrivesEncryptionType`)
+   - **Enforce drive encryption type on fixed data drives**: **Full encryption** (`FixedDrivesEncryptionType`)
+   - **Require Device Encryption**: **Enabled**
+   - **Choose drive encryption method and cipher strength**: **Enabled**
+     - OS drives: **XTS-AES 256-bit**
+     - Fixed data drives: **XTS-AES 256-bit**
+     - Removable data drives: **AES-CBC 256-bit**
+7. Assign the policy to your device groups.
+
+## Learn more
+
+- [Microsoft Intune - Endpoint Security Disk Encryption](https://intune.microsoft.com/#view/Microsoft_Intune_Workflows/SecurityManagementMenu/~/diskEncryption)
+- [Microsoft Learn - Encrypt devices with BitLocker in Intune](https://learn.microsoft.com/en-us/mem/intune/protect/encrypt-devices)
+- [Microsoft Learn - BitLocker CSP reference](https://learn.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp)

--- a/website/versioned_docs/version-2.0.0/tests/maester/MT.1123.md
+++ b/website/versioned_docs/version-2.0.0/tests/maester/MT.1123.md
@@ -1,6 +1,6 @@
 ---
 title: MT.1123 - Ensure BitLocker full disk encryption is configured via Intune
-description: Checks if at least one Intune Endpoint Security Disk encryption policy enforces BitLocker full disk encryption for OS and fixed data drives.
+description: Checks if at least one Intune Endpoint Security Disk encryption policy enforces BitLocker full disk encryption for OS drives.
 slug: /tests/MT.1123
 sidebar_class_name: hidden
 ---


### PR DESCRIPTION
# Pull Request: Add MT.1123 - BitLocker Full Disk Encryption Check

## Summary

Adds a new Intune test **MT.1123** that verifies at least one Intune **Endpoint Security > Disk Encryption** policy enforces BitLocker with **full disk encryption type** for OS drives — not just that BitLocker is configured, but that the encryption type is explicitly set to protect the entire drive.

## Motivation

BitLocker Drive Encryption is a critical security control, but the **encryption type** setting makes all the difference:

- **Full disk encryption** — encrypts the entire drive including free space. Secure.
- **Used space only encryption** — only encrypts sectors currently holding data. **Dangerous on drives with pre-existing data**, because previously deleted files remain as raw unencrypted data in free space. NTFS marks sectors as "free" but does not zero them out — the original bytes persist on disk until overwritten. This means **data written to the disk before encryption was enabled can be fully recovered using commonly available data recovery software** (Recuva, PhotoRec, forensic imaging tools, etc.).

There is currently no Maester test to verify that BitLocker is configured via Intune, let alone that the encryption type is set correctly. This test fills that gap by:
- Querying the `configurationPolicies` Graph API (Endpoint Security > Disk Encryption blade)
- Filtering to BitLocker policies via `templateReference.templateFamily = "endpointSecurityDiskEncryption"`
- Fetching each policy's settings via `configurationPolicies('{id}')/settings?$expand=settingDefinitions`
- Inspecting the actual BitLocker CSP values: `SystemDrivesEncryptionType`, `FixedDrivesEncryptionType`, `RequireDeviceEncryption`, `EncryptionMethodByDriveType`
- **Directly validating** that the OS drive encryption type is set to "Full encryption" (not "Used space only" or "Allow user to choose")
- Reporting all policies and their settings in a markdown table

### Graph API Approach

This test uses the `configurationPolicies` API (the same API used by the Intune admin center's Endpoint Security > Disk Encryption blade), NOT the older `deviceConfigurations` API. The `configurationPolicies` API exposes the full BitLocker CSP settings including:
- `SystemDrivesEncryptionType` — OS drive encryption type (Full / Used Space Only / Allow user to choose)
- `FixedDrivesEncryptionType` — Fixed drive encryption type
- `RequireDeviceEncryption` — Whether encryption is required
- `EncryptionMethodByDriveType` — Cipher strength (XTS-AES 128/256, AES-CBC 128/256)

This eliminates the previous limitation where the older Endpoint Protection API (`windows10EndpointProtectionConfiguration`) did not expose the encryption type setting.

## Files Changed

| File | Change |
|------|--------|
| `powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1` | **New** — PowerShell function |
| `powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.md` | **New** — Remediation docs |
| `tests/Maester/Intune/Test-MtIntunePlatform.Tests.ps1` | **Modified** — Add `MT.1123` test entry |
| `tests/maester-config.json` | **Modified** — Add `MT.1123` severity config |
| `website/versioned_docs/version-2.0.0/tests/maester/MT.1123.md` | **New** — Documentation page |

## Test Details

- **ID**: MT.1123
- **Category**: Intune / Device Management
- **Severity**: High
- **Tag**: `MT.1123`, `Maester`, `Intune`
- **Required permissions**: `DeviceManagementConfiguration.Read.All`
- **License**: Intune

## What the test checks

1. Queries `deviceManagement/configurationPolicies` via the beta Graph API
2. Filters to BitLocker Disk Encryption policies (`templateReference.templateFamily = "endpointSecurityDiskEncryption"`)
3. For each matching policy, fetches settings via `configurationPolicies('{id}')/settings?$expand=settingDefinitions`
4. Inspects the BitLocker CSP settings:
   - `RequireDeviceEncryption` — whether encryption is required
   - `SystemDrivesEncryptionType` → child dropdown — OS drive encryption type (Full / Used Space Only / Allow user to choose)
   - `FixedDrivesEncryptionType` → child dropdown — Fixed drive encryption type
   - `EncryptionMethodByDriveType` → child dropdowns — cipher strength per drive type
5. **Passes** if at least one policy has OS drive encryption type set to **Full encryption**
6. **Fails** if no BitLocker policies exist, or none enforce full encryption type
7. Outputs a markdown table showing all policies and their actual encryption settings

## Test output example

```
Found 1 BitLocker Disk Encryption policy/policies in Intune.

| Policy | Require Encryption | OS Encryption Type | Fixed Encryption Type | OS Cipher |
| --- | --- | --- | --- | --- |
| Win - OIB - ES - Encryption - D - BitLocker (OS Disk) - v3.7 | Enabled | Full encryption | Not configured | XTS-AES 256-bit |

**Result:** At least one BitLocker policy enforces **Full encryption** for OS drives.
```

## Remediation guidance

The test documentation includes step-by-step instructions to:
1. Create a BitLocker policy under **Endpoint Security > Disk Encryption**
2. Set **Enforce drive encryption type on operating system drives** to **Full encryption**
3. Set **Enforce drive encryption type on fixed data drives** to **Full encryption**
4. Configure XTS-AES 256-bit cipher strength and silent encryption
5. The docs explain why "Used space only" is dangerous: deleted data remains recoverable from unencrypted free space

## Related

- [Microsoft Learn - Encrypt devices with BitLocker in Intune](https://learn.microsoft.com/en-us/mem/intune/protect/encrypt-devices)
- [Microsoft Learn - BitLocker CSP reference](https://learn.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp)
- [CIS Microsoft Intune for Windows Benchmark](https://www.cisecurity.org/benchmark/microsoft_intune_for_windows)

## Checklist

- [x] New PowerShell function follows existing pattern (`Get-MtLicenseInformation`, `Invoke-MtGraphRequest`, `Add-MtTestResultDetail`)
- [x] Comment-based help header inside function body (per #1568)
- [x] Uses `configurationPolicies` API (same as Intune admin center Disk Encryption blade)
- [x] Directly validates encryption type via BitLocker CSP settings (no manual verification needed)
- [x] Markdown remediation doc with `%TestResult%` placeholder
- [x] Test entry in `Test-MtIntunePlatform.Tests.ps1` with proper tag
- [x] Config entry in `maester-config.json`
- [x] `FunctionsToExport` updated in `Maester.psd1`
- [x] Website documentation page with frontmatter
