### PR TITLE
`Test-MtCaGroupsRestricted` ignores report-only Conditional Access policies

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaGroupsRestricted.ps1
+++ b/powershell/public/maester/entra/Test-MtCaGroupsRestricted.ps1
@@ -30,7 +30,7 @@
   }
 
   try {
-    $Policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq 'enabled' }
+    $Policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -in @('enabled','enabledForReportingButNotEnforced') }
 
     $Groups = $Policies.conditions.users | Where-Object {
       @($_.includeGroups).Count -gt 0 -or @($_.excludeGroups).Count -gt 0


### PR DESCRIPTION
# Description

**`Test-MtCaGroupsRestricted` ignores report-only Conditional Access policies**

The current implementation of `Test-MtCaGroupsRestricted` only evaluates Conditional Access policies where:

`$_.state -eq 'enabled'`

This means that policies in **report-only mode** (`enabledForReportingButNotEnforced`) are not included in the evaluation.

**Observed behavior**

If a Conditional Access policy:

- is in **enabled** state → unprotected groups are correctly detected → ❌ test fails
- is in **report-only** state → same unprotected groups are ignored → ✅ test passes

**Expected behavior**

Policies in report-only mode should also be evaluated, because:

- They already define intended access control logic
- They can be switched to enabled at any time
- Unprotected groups still represent a potential security gap

<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [x] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [x] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
