### PR TITLE
ci: add PR-triggered website build validation

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -1,0 +1,51 @@
+# Validates that the Docusaurus website builds successfully.
+# Runs on PRs that modify website files, and can also be called from other
+# workflows or triggered manually.
+name: "\U0001F3D7️ Build Website"
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: "Node.js version to use."
+        required: false
+        default: "24.x"
+        type: string
+      working_directory:
+        description: "Path to the directory containing package.json (relative to the repository root)."
+        required: false
+        default: "website"
+        type: string
+  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "website/**"
+      - ".github/workflows/build-website.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build Docusaurus website \U0001F3D7️"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: ⚙️ Set up Node.js ${{ inputs.node_version || '24.x' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ inputs.node_version || '24.x' }}
+          cache: "npm"
+          cache-dependency-path: ${{ inputs.working_directory || 'website' }}/package-lock.json
+
+      - name: "\U0001F4E6 Install dependencies"
+        working-directory: ${{ inputs.working_directory || 'website' }}
+        run: npm ci
+
+      - name: "\U0001F3D7️ Build website"
+        working-directory: ${{ inputs.working_directory || 'website' }}
+        run: npm run build


### PR DESCRIPTION
## Add PR-triggered Website Build Validation

Addresses the review comment from [PR #1641](https://github.com/maester365/maester/pull/1641#discussion_r3078313502): no GitHub Actions workflow validates that the Docusaurus website builds on pull requests.

### What this adds

A new workflow (`.github/workflows/build-website.yaml`) that runs `npm ci` + `npm run build` for the Docusaurus website. It triggers on:

- **`pull_request`** to `main` — filtered to `website/**` paths and the workflow file itself
- **`workflow_dispatch`** — for manual runs
- **`workflow_call`** — with optional `node_version` (default: `24.x`) and `working_directory` (default: `website`) inputs, making it reusable from other workflows

### How it works

The single-job workflow on `ubuntu-latest`:
1. Checks out the repository
2. Sets up Node.js 24.x with npm caching
3. Runs `npm ci` in `website/`
4. Runs `npm run build` in `website/`

Docusaurus is configured with `onBrokenLinks: "throw"`, so the build itself catches broken links and YAML front matter errors.

### Design decisions

- **Permissions:** `contents: read` only — build check, no deployment
- **No deploy step:** Cloudflare handles hosting; this only validates the build
- **Separate workflow:** Keeps website validation independent from existing PowerShell/Pester tests (`build-validation.yaml`)
- **Input naming:** Uses underscores (`node_version`, `working_directory`) instead of hyphens to avoid GitHub Actions expression parsing issues with dot-notation
- **Pinned action SHAs:** Matches existing workflows (`actions/checkout@de0fac2e...`, `actions/setup-node@53b83947...`)
- **Fallback defaults in expressions:** `${{ inputs.node_version || '24.x' }}` ensures correct defaults when triggered by `pull_request` or `workflow_dispatch` (which don't receive `workflow_call` inputs)

### Related

- Review comment: https://github.com/maester365/maester/pull/1641#discussion_r3078313502
- Revert of mistaken PR to wrong repo: https://github.com/maester365/maester-action/pull/35