### PR TITLE
Fix MT.1020: Support new OnPremisesDirectorySyncAccount role and service principal-based sync

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -87,7 +87,7 @@
             }
 
             if ( $PolicyIncludesAnyMember -or $PolicyIncludesRole ) {
-                # Skip this policy, because directory synchronization accounts are specifically included and therefor must not be excluded
+                # Skip this policy, because directory synchronization accounts are specifically included and therefore must not be excluded
                 $CurrentResult = $true
                 Write-Verbose "Skipping $($policy.displayName) - $CurrentResult"
                 # Check if excluded by role

--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -73,7 +73,8 @@
 
             $PolicyIncludesAnyMember = $false
             $PolicyIncludesRole = $false
-            $memberIds = @($Members | ForEach-Object { $_.id })
+            #excluding service principals, because they cannot be excluded from policies and therefore do not have to be included in the policies to bypass them.
+            $memberIds = @($Members | Where-Object { $_.'@odata.type' -ne '#microsoft.graph.servicePrincipal' } | ForEach-Object { $_.id })
 
             foreach ($memberId in $memberIds) {
                 if ( $memberId -in $policy.conditions.users.includeUsers ) {
@@ -87,7 +88,7 @@
             }
 
             if ( $PolicyIncludesAnyMember -or $PolicyIncludesRole ) {
-                # Skip this policy, because directory synchronization accounts are specifically included and therefor must not be excluded
+                # Skip this policy, because directory synchronization accounts are specifically included and therefore must not be excluded
                 $CurrentResult = $true
                 Write-Verbose "Skipping $($policy.displayName) - $CurrentResult"
                 # Check if excluded by role

--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -73,7 +73,7 @@
 
             $PolicyIncludesAnyMember = $false
             $PolicyIncludesRole = $false
-            #excluding service principals, because they cannot be excluded from policies and therefore do not have to be included in the policies to bypass them.
+            # Excluding service principals, because they cannot be excluded from policies and therefore do not have to be included in the policies to bypass them.
             $memberIds = @($Members | Where-Object { $_.'@odata.type' -ne '#microsoft.graph.servicePrincipal' } | ForEach-Object { $_.id })
 
             foreach ($memberId in $memberIds) {
@@ -91,10 +91,12 @@
                 # Skip this policy, because directory synchronization accounts are specifically included and therefore must not be excluded
                 $CurrentResult = $true
                 Write-Verbose "Skipping $($policy.displayName) - $CurrentResult"
+                continue
+            } else {
                 # Check if excluded by role
                 $excludedByRole = $DirectorySynchronizationAccountsRole -in $policy.conditions.users.excludeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.excludeRoles
 
-                # Check if all members (users and service principals) are individually excluded
+                # Check if all user members are individually excluded
                 $excludedByMember = $memberIds.Count -gt 0 -and @($memberIds | Where-Object { $_ -notin $policy.conditions.users.excludeUsers }).Count -eq 0
 
                 if ( $excludedByRole -or $excludedByMember ) {

--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -24,26 +24,22 @@
         return $null
     }
 
+    $testDescription = 'It is recommended to exclude directory/OnPremises synchronization accounts from all conditional access policies scoped to all cloud apps.'
+    $testResult = "The following conditional access policies are scoped to all users but don't exclude the directory/OnPremises synchronization accounts:`n`n"
+
     try {
         $DirectorySynchronizationAccountsRole = Get-MtRoleInfo -RoleName "DirectorySynchronizationAccounts"
         $OnPremisesDirectorySyncAccountRole = Get-MtRoleInfo -RoleName "OnPremisesDirectorySyncAccount"
 
-        try {
-            $Members = Get-MtRoleMember -RoleId $DirectorySynchronizationAccountsRole
-            $Members += Get-MtRoleMember -RoleId $OnPremisesDirectorySyncAccountRole
-            if ( $null -eq $Members ) {
-                # Assumes if no accounts has any of those permissions that there is no directory/OnPremises synchronization accounts
-                Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Directory synchronization accounts not found, but directory synchronization is configured. This might be caused by missing permissions to read the directory synchronization accounts.'
-                throw 'Directory synchronization and/or on-premises directory synchronization accounts not found'
-            }
-        } catch {
-            # Directory synchronization account role not found, this tenant does not have directory/OnPremises synchronization accounts
-            Add-MtTestResultDetail -Description $testDescription -Result 'This tenant does not have directory/OnPremises synchronization accounts and therefor this test is not applicable.'
+        $Members = @()
+        $Members += Get-MtRoleMember -RoleId $DirectorySynchronizationAccountsRole
+        $Members += Get-MtRoleMember -RoleId $OnPremisesDirectorySyncAccountRole
+        $Members = @($Members | Where-Object { $null -ne $_ })
+
+        if ( $Members.Count -eq 0 ) {
+            Add-MtTestResultDetail -Description $testDescription -Result 'This tenant does not have directory synchronization accounts and therefore this test is not applicable.'
             return $true
         }
-
-        $testDescription = 'It is recommended to exclude directory/OnPremises synchronization accounts from all conditional access policies scoped to all cloud apps.'
-        $testResult = "The following conditional access policies are scoped to all users but don't exclude the directory/OnPremises synchronization accounts:`n`n"
 
         $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq 'enabled' }
 
@@ -75,13 +71,13 @@
                 continue
             }
 
-            $PolicyIncludesMember = $false
+            $PolicyIncludesAnyMember = $false
             $PolicyIncludesRole = $false
             $memberIds = @($Members | ForEach-Object { $_.id })
 
             foreach ($memberId in $memberIds) {
                 if ( $memberId -in $policy.conditions.users.includeUsers ) {
-                    $PolicyIncludesMember = $true
+                    $PolicyIncludesAnyMember = $true
                     break
                 }
             }
@@ -90,11 +86,10 @@
                 $PolicyIncludesRole = $true
             }
 
-            if ( $PolicyIncludesMember -or $PolicyIncludesRole ) {
+            if ( $PolicyIncludesAnyMember -or $PolicyIncludesRole ) {
                 # Skip this policy, because directory synchronization accounts are specifically included and therefor must not be excluded
                 $CurrentResult = $true
                 Write-Verbose "Skipping $($policy.displayName) - $CurrentResult"
-            } else {
                 # Check if excluded by role
                 $excludedByRole = $DirectorySynchronizationAccountsRole -in $policy.conditions.users.excludeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.excludeRoles
 

--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -15,7 +15,6 @@
     .LINK
     https://maester.dev/docs/commands/Test-MtCaExclusionForDirectorySyncAccount
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'PolicyIncludesAllUsers is used in the condition.')]
     [CmdletBinding()]
     [OutputType([bool])]
     param ()
@@ -26,21 +25,25 @@
     }
 
     try {
-        $testDescription = 'It is recommended to exclude directory synchronization accounts from all conditional access policies scoped to all cloud apps.'
-        $testResult = "The following conditional access policies are scoped to all users but don't exclude the directory synchronization accounts:`n`n"
+        $DirectorySynchronizationAccountsRole = Get-MtRoleInfo -RoleName "DirectorySynchronizationAccounts"
+        $OnPremisesDirectorySyncAccountRole = Get-MtRoleInfo -RoleName "OnPremisesDirectorySyncAccount"
 
-        $DirectorySynchronizationAccountRoleTemplateId = 'd29b2b05-8046-44ba-8758-1e26182fcf32'
         try {
-            $DirectorySynchronizationAccountRoleId = Invoke-MtGraphRequest -RelativeUri "directoryRoles(roleTemplateId='$DirectorySynchronizationAccountRoleTemplateId')" -Select id | Select-Object -ExpandProperty id
-            $DirectorySynchronizationAccounts = Invoke-MtGraphRequest -RelativeUri "directoryRoles/$DirectorySynchronizationAccountRoleId/members" -Select id | Get-ObjectProperty -Property id
-            if ( $null -eq $DirectorySynchronizationAccounts ) {
-                throw 'Directory synchronization accounts not found'
+            $Members = Get-MtRoleMember -RoleId $DirectorySynchronizationAccountsRole
+            $Members += Get-MtRoleMember -RoleId $OnPremisesDirectorySyncAccountRole
+            if ( $null -eq $Members ) {
+                # Assumes if no accounts has any of those permissions that there is no directory/OnPremises synchronization accounts
+                Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Directory synchronization accounts not found, but directory synchronization is configured. This might be caused by missing permissions to read the directory synchronization accounts.'
+                throw 'Directory synchronization and/or on-premises directory synchronization accounts not found'
             }
         } catch {
-            # Directory synchronization account role not found, this tenant does not have directory synchronization accounts
-            Add-MtTestResultDetail -Description $testDescription -Result 'This tenant does not have directory synchronization accounts and therefor this test is not applicable.'
+            # Directory synchronization account role not found, this tenant does not have directory/OnPremises synchronization accounts
+            Add-MtTestResultDetail -Description $testDescription -Result 'This tenant does not have directory/OnPremises synchronization accounts and therefor this test is not applicable.'
             return $true
         }
+
+        $testDescription = 'It is recommended to exclude directory/OnPremises synchronization accounts from all conditional access policies scoped to all cloud apps.'
+        $testResult = "The following conditional access policies are scoped to all users but don't exclude the directory/OnPremises synchronization accounts:`n`n"
 
         $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq 'enabled' }
 
@@ -72,24 +75,33 @@
                 continue
             }
 
-            $PolicyIncludesAllUsers = $false
+            $PolicyIncludesMember = $false
             $PolicyIncludesRole = $false
-            $DirectorySynchronizationAccounts | ForEach-Object {
-                if ( $_ -in $policy.conditions.users.includeUsers  ) {
-                    $PolicyIncludesAllUsers = $true
+            $memberIds = @($Members | ForEach-Object { $_.id })
+
+            foreach ($memberId in $memberIds) {
+                if ( $memberId -in $policy.conditions.users.includeUsers ) {
+                    $PolicyIncludesMember = $true
+                    break
                 }
             }
 
-            if ( $DirectorySynchronizationAccountRoleTemplateId -in $policy.conditions.users.includeRoles ) {
+            if ( $DirectorySynchronizationAccountsRole -in $policy.conditions.users.includeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.includeRoles ) {
                 $PolicyIncludesRole = $true
             }
 
-            if ( $PolicyIncludesAllUsers -or $PolicyIncludesRole ) {
-                # Skip this policy, because all directory synchronization accounts are included and therefor must not be excluded
+            if ( $PolicyIncludesMember -or $PolicyIncludesRole ) {
+                # Skip this policy, because directory synchronization accounts are specifically included and therefor must not be excluded
                 $CurrentResult = $true
                 Write-Verbose "Skipping $($policy.displayName) - $CurrentResult"
             } else {
-                if ( $DirectorySynchronizationAccountRoleTemplateId -in $policy.conditions.users.excludeRoles ) {
+                # Check if excluded by role
+                $excludedByRole = $DirectorySynchronizationAccountsRole -in $policy.conditions.users.excludeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.excludeRoles
+
+                # Check if all members (users and service principals) are individually excluded
+                $excludedByMember = $memberIds.Count -gt 0 -and @($memberIds | Where-Object { $_ -notin $policy.conditions.users.excludeUsers }).Count -eq 0
+
+                if ( $excludedByRole -or $excludedByMember ) {
                     # Directory synchronization accounts are excluded
                     $CurrentResult = $true
                 } else {

--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -92,6 +92,11 @@
                 $CurrentResult = $true
                 Write-Verbose "Skipping $($policy.displayName) - $CurrentResult"
                 continue
+            } elseif ( $memberIds.Count -eq 0 ) {
+                # All members are service principals; they are not subject to CA policies and therefore this policy can be skipped
+                $CurrentResult = $true
+                Write-Verbose "Skipping $($policy.displayName) — only service principal members - $CurrentResult"
+                continue
             } else {
                 # Check if excluded by role
                 $excludedByRole = $DirectorySynchronizationAccountsRole -in $policy.conditions.users.excludeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.excludeRoles

--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -28,8 +28,8 @@
     $testResult = "The following conditional access policies are scoped to all users but don't exclude the directory/OnPremises synchronization accounts:`n`n"
 
     try {
-        $DirectorySynchronizationAccountsRole = Get-MtRoleInfo -RoleName "DirectorySynchronizationAccounts"
-        $OnPremisesDirectorySyncAccountRole = Get-MtRoleInfo -RoleName "OnPremisesDirectorySyncAccount"
+        $DirectorySynchronizationAccountsRole = Get-MtRoleInfo -RoleName 'DirectorySynchronizationAccounts'
+        $OnPremisesDirectorySyncAccountRole = Get-MtRoleInfo -RoleName 'OnPremisesDirectorySyncAccount'
 
         $Members = @()
         $Members += Get-MtRoleMember -RoleId $DirectorySynchronizationAccountsRole

--- a/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
@@ -4,61 +4,61 @@
         Mock -ModuleName Maester Add-MtTestResultDetail {}
 
         # Role template IDs returned by Get-MtRoleInfo
-        $script:DirSyncRoleId   = 'd29b2b05-8046-44ba-8758-1e26182fcf32'
-        $script:OnPremRoleId    = 'a92aed5d-d78a-4d16-b381-09adb37eb3b0'
+        $script:DirSyncRoleId = 'd29b2b05-8046-44ba-8758-1e26182fcf32'
+        $script:OnPremRoleId = 'a92aed5d-d78a-4d16-b381-09adb37eb3b0'
 
         # Sample sync account member IDs
         $script:syncUserId1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         $script:syncUserId2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
-        $script:syncSpId    = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+        $script:syncSpId = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
 
         # Member objects as returned by Get-MtRoleMember
         $script:syncUser1 = [PSCustomObject]@{
-            id              = $script:syncUserId1
-            '@odata.type'   = '#microsoft.graph.user'
+            id            = $script:syncUserId1
+            '@odata.type' = '#microsoft.graph.user'
         }
         $script:syncUser2 = [PSCustomObject]@{
-            id              = $script:syncUserId2
-            '@odata.type'   = '#microsoft.graph.user'
+            id            = $script:syncUserId2
+            '@odata.type' = '#microsoft.graph.user'
         }
         $script:syncServicePrincipal = [PSCustomObject]@{
-            id              = $script:syncSpId
-            '@odata.type'   = '#microsoft.graph.servicePrincipal'
+            id            = $script:syncSpId
+            '@odata.type' = '#microsoft.graph.servicePrincipal'
         }
 
         # Helper: build a minimal enabled CA policy object
         function New-CaPolicy {
             param(
-                [string]   $Id                  = 'policy1',
-                [string]   $DisplayName          = 'Test Policy',
-                [string[]] $IncludeApplications  = @('All'),
-                [string[]] $IncludeUsers          = @('All'),
-                [string[]] $IncludeRoles          = @(),
-                [string[]] $ExcludeUsers          = @(),
-                [string[]] $ExcludeRoles          = @(),
+                [string]   $Id = 'policy1',
+                [string]   $DisplayName = 'Test Policy',
+                [string[]] $IncludeApplications = @('All'),
+                [string[]] $IncludeUsers = @('All'),
+                [string[]] $IncludeRoles = @(),
+                [string[]] $ExcludeUsers = @(),
+                [string[]] $ExcludeRoles = @(),
                 [string]   $IncludeGuestsOrExternalUsers = $null,
-                [string[]] $ClientAppTypes        = @('all'),
-                [string[]] $BuiltInControls       = @()
+                [string[]] $ClientAppTypes = @('all'),
+                [string[]] $BuiltInControls = @()
             )
             [PSCustomObject]@{
-                id             = $Id
-                displayName    = $DisplayName
-                state          = 'enabled'
-                conditions     = [PSCustomObject]@{
-                    applications = [PSCustomObject]@{
+                id            = $Id
+                displayName   = $DisplayName
+                state         = 'enabled'
+                conditions    = [PSCustomObject]@{
+                    applications   = [PSCustomObject]@{
                         includeApplications = $IncludeApplications
                     }
-                    users = [PSCustomObject]@{
-                        includeUsers                  = $IncludeUsers
-                        includeRoles                  = $IncludeRoles
-                        excludeUsers                  = $ExcludeUsers
-                        excludeRoles                  = $ExcludeRoles
-                        includeGroups                 = @()
-                        includeGuestsOrExternalUsers  = $IncludeGuestsOrExternalUsers
+                    users          = [PSCustomObject]@{
+                        includeUsers                 = $IncludeUsers
+                        includeRoles                 = $IncludeRoles
+                        excludeUsers                 = $ExcludeUsers
+                        excludeRoles                 = $ExcludeRoles
+                        includeGroups                = @()
+                        includeGuestsOrExternalUsers = $IncludeGuestsOrExternalUsers
                     }
                     clientAppTypes = $ClientAppTypes
                 }
-                grantControls  = [PSCustomObject]@{
+                grantControls = [PSCustomObject]@{
                     builtInControls = $BuiltInControls
                 }
             }
@@ -69,7 +69,7 @@
             param($RoleName)
             switch ($RoleName) {
                 'DirectorySynchronizationAccounts' { return $script:DirSyncRoleId }
-                'OnPremisesDirectorySyncAccount'   { return $script:OnPremRoleId }
+                'OnPremisesDirectorySyncAccount' { return $script:OnPremRoleId }
             }
         }
     }
@@ -266,7 +266,7 @@
             Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
             Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
                 return @(
-                    New-CaPolicy -Id 'policy-pass' -DisplayName 'Policy With Exclusion'   -ExcludeRoles @($script:DirSyncRoleId),
+                    New-CaPolicy -Id 'policy-pass' -DisplayName 'Policy With Exclusion' -ExcludeRoles @($script:DirSyncRoleId),
                     New-CaPolicy -Id 'policy-fail' -DisplayName 'Policy Without Exclusion' -ExcludeUsers @() -ExcludeRoles @()
                 )
             }
@@ -277,14 +277,14 @@
         }
     }
 
-    Context 'Multiple policies — all pass' {
+    Context 'Multiple policies — all pass (each excluded by a different sync role)' {
 
         BeforeEach {
             Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
             Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
                 return @(
-                    New-CaPolicy -Id 'policy1' -DisplayName 'Excluded By Role' -ExcludeRoles @($script:DirSyncRoleId),
-                    New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By User' -ExcludeUsers @($script:syncUserId1)
+                    New-CaPolicy -Id 'policy1' -DisplayName 'Excluded By DirSync Role' -ExcludeRoles @($script:DirSyncRoleId),
+                    New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By OnPrem Role'  -ExcludeRoles @($script:OnPremRoleId)
                 )
             }
         }

--- a/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
@@ -284,7 +284,7 @@
             Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
                 # Hardcode GUIDs to avoid $script: variable resolution inside -ModuleName mock context
                 $p1 = New-CaPolicy -Id 'policy1' -DisplayName 'Excluded By DirSync Role' -ExcludeRoles @('d29b2b05-8046-44ba-8758-1e26182fcf32')
-                $p2 = New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By OnPrem Role'  -ExcludeRoles @('a92aed5d-d78a-4d16-b381-09adb37eb3b0')
+                $p2 = New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By OnPrem Role' -ExcludeRoles @('a92aed5d-d78a-4d16-b381-09adb37eb3b0')
                 return @($p1, $p2)
             }
         }

--- a/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
@@ -1,0 +1,305 @@
+﻿Describe 'Test-MtCaExclusionForDirectorySyncAccount' {
+    BeforeAll {
+        Mock -ModuleName Maester Get-MtLicenseInformation { return 'P1' }
+        Mock -ModuleName Maester Add-MtTestResultDetail {}
+
+        # Role template IDs returned by Get-MtRoleInfo
+        $script:DirSyncRoleId   = 'd29b2b05-8046-44ba-8758-1e26182fcf32'
+        $script:OnPremRoleId    = 'a92aed5d-d78a-4d16-b381-09adb37eb3b0'
+
+        # Sample sync account member IDs
+        $script:syncUserId1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+        $script:syncUserId2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+        $script:syncSpId    = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+
+        # Member objects as returned by Get-MtRoleMember
+        $script:syncUser1 = [PSCustomObject]@{
+            id              = $script:syncUserId1
+            '@odata.type'   = '#microsoft.graph.user'
+        }
+        $script:syncUser2 = [PSCustomObject]@{
+            id              = $script:syncUserId2
+            '@odata.type'   = '#microsoft.graph.user'
+        }
+        $script:syncServicePrincipal = [PSCustomObject]@{
+            id              = $script:syncSpId
+            '@odata.type'   = '#microsoft.graph.servicePrincipal'
+        }
+
+        # Helper: build a minimal enabled CA policy object
+        function New-CaPolicy {
+            param(
+                [string]   $Id                  = 'policy1',
+                [string]   $DisplayName          = 'Test Policy',
+                [string[]] $IncludeApplications  = @('All'),
+                [string[]] $IncludeUsers          = @('All'),
+                [string[]] $IncludeRoles          = @(),
+                [string[]] $ExcludeUsers          = @(),
+                [string[]] $ExcludeRoles          = @(),
+                [string]   $IncludeGuestsOrExternalUsers = $null,
+                [string[]] $ClientAppTypes        = @('all'),
+                [string[]] $BuiltInControls       = @()
+            )
+            [PSCustomObject]@{
+                id             = $Id
+                displayName    = $DisplayName
+                state          = 'enabled'
+                conditions     = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeApplications = $IncludeApplications
+                    }
+                    users = [PSCustomObject]@{
+                        includeUsers                  = $IncludeUsers
+                        includeRoles                  = $IncludeRoles
+                        excludeUsers                  = $ExcludeUsers
+                        excludeRoles                  = $ExcludeRoles
+                        includeGroups                 = @()
+                        includeGuestsOrExternalUsers  = $IncludeGuestsOrExternalUsers
+                    }
+                    clientAppTypes = $ClientAppTypes
+                }
+                grantControls  = [PSCustomObject]@{
+                    builtInControls = $BuiltInControls
+                }
+            }
+        }
+
+        # Default mock: Get-MtRoleInfo returns the correct GUIDs by role name
+        Mock -ModuleName Maester Get-MtRoleInfo {
+            param($RoleName)
+            switch ($RoleName) {
+                'DirectorySynchronizationAccounts' { return $script:DirSyncRoleId }
+                'OnPremisesDirectorySyncAccount'   { return $script:OnPremRoleId }
+            }
+        }
+    }
+
+    Context 'No sync account members exist in the tenant' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $null }
+        }
+
+        It 'Should return true and mark test as not applicable' {
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return @() }
+
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Service principal-only members (no user members)' {
+
+        BeforeEach {
+            # Only a service principal is in the role — no users to exclude
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncServicePrincipal }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return true because service principals cannot be excluded from CA policies' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy does not target all applications' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -IncludeApplications @('00000002-0000-0ff1-ce00-000000000000') -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return true because policy is not scoped to all apps' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy only targets guests (no internal users)' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -IncludeUsers @() -IncludeGuestsOrExternalUsers 'b2bCollaborationGuest' -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return true because policy does not scope internal users' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy only blocks legacy authentication' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ClientAppTypes @('exchangeActiveSync', 'other') -BuiltInControls @('block') -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return true because policy only blocks legacy auth which sync does not use' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy targets all users and sync account is excluded by DirectorySynchronizationAccounts role' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeRoles @($script:DirSyncRoleId))
+            }
+        }
+
+        It 'Should return true' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy targets all users and sync account is excluded by OnPremisesDirectorySyncAccount role' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeRoles @($script:OnPremRoleId))
+            }
+        }
+
+        It 'Should return true' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy targets all users and all sync user members are individually excluded' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return @($script:syncUser1, $script:syncUser2) }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeUsers @($script:syncUserId1, $script:syncUserId2))
+            }
+        }
+
+        It 'Should return true' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy targets all users and sync account is NOT excluded' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return false' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeFalse
+        }
+    }
+
+    Context 'Policy targets all users and sync accounts are only partially excluded by user IDs' {
+
+        BeforeEach {
+            # Two user members but only one is excluded
+            Mock -ModuleName Maester Get-MtRoleMember { return @($script:syncUser1, $script:syncUser2) }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeUsers @($script:syncUserId1))
+            }
+        }
+
+        It 'Should return false because not all user members are excluded' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeFalse
+        }
+    }
+
+    Context 'Policy targets all users and sync accounts are only partially excluded (service principal skipped, one user excluded)' {
+
+        BeforeEach {
+            # One user + one service principal; only the user is excluded
+            Mock -ModuleName Maester Get-MtRoleMember { return @($script:syncUser1, $script:syncServicePrincipal) }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(New-CaPolicy -ExcludeUsers @($script:syncUserId1))
+            }
+        }
+
+        It 'Should return true because the only user member is excluded and service principals are not subject to CA' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy explicitly includes a sync account by user ID (policy designed for sync accounts)' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                # Policy specifically includes the sync account ID — must not be required to also exclude it
+                return @(New-CaPolicy -IncludeUsers @($script:syncUserId1) -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return true because the policy is scoped specifically to the sync account' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Policy explicitly includes a sync role (policy designed for sync accounts)' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                # Policy scoped to the DirectorySynchronizationAccounts role — not an "all users" policy
+                return @(New-CaPolicy -IncludeUsers @() -IncludeRoles @($script:DirSyncRoleId) -ExcludeUsers @() -ExcludeRoles @())
+            }
+        }
+
+        It 'Should return true because the policy is scoped specifically to the sync role' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Multiple policies — one passes, one fails' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(
+                    New-CaPolicy -Id 'policy-pass' -DisplayName 'Policy With Exclusion'   -ExcludeRoles @($script:DirSyncRoleId),
+                    New-CaPolicy -Id 'policy-fail' -DisplayName 'Policy Without Exclusion' -ExcludeUsers @() -ExcludeRoles @()
+                )
+            }
+        }
+
+        It 'Should return false because at least one policy does not exclude sync accounts' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeFalse
+        }
+    }
+
+    Context 'Multiple policies — all pass' {
+
+        BeforeEach {
+            Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
+                return @(
+                    New-CaPolicy -Id 'policy1' -DisplayName 'Excluded By Role' -ExcludeRoles @($script:DirSyncRoleId),
+                    New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By User' -ExcludeUsers @($script:syncUserId1)
+                )
+            }
+        }
+
+        It 'Should return true because all policies exclude sync accounts' {
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+    }
+
+    Context 'Free Entra ID license' {
+
+        It 'Should return null and skip the test' {
+            Mock -ModuleName Maester Get-MtLicenseInformation { return 'Free' }
+
+            Test-MtCaExclusionForDirectorySyncAccount | Should -BeNull
+        }
+    }
+}

--- a/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
@@ -282,10 +282,10 @@
         BeforeEach {
             Mock -ModuleName Maester Get-MtRoleMember { return $script:syncUser1 }
             Mock -ModuleName Maester Get-MtConditionalAccessPolicy {
-                return @(
-                    New-CaPolicy -Id 'policy1' -DisplayName 'Excluded By DirSync Role' -ExcludeRoles @($script:DirSyncRoleId),
-                    New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By OnPrem Role'  -ExcludeRoles @($script:OnPremRoleId)
-                )
+                # Hardcode GUIDs to avoid $script: variable resolution inside -ModuleName mock context
+                $p1 = New-CaPolicy -Id 'policy1' -DisplayName 'Excluded By DirSync Role' -ExcludeRoles @('d29b2b05-8046-44ba-8758-1e26182fcf32')
+                $p2 = New-CaPolicy -Id 'policy2' -DisplayName 'Excluded By OnPrem Role'  -ExcludeRoles @('a92aed5d-d78a-4d16-b381-09adb37eb3b0')
+                return @($p1, $p2)
             }
         }
 

--- a/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
+++ b/tests/Maester/Entra/Test-ConditionalAccessBaseline.Tests.ps1
@@ -53,8 +53,8 @@
     It "MT.1019: At least one Conditional Access policy is configured to enable application enforced restrictions. See https://maester.dev/docs/tests/MT.1019" -Tag "MT.1019" {
         Test-MtCaApplicationEnforcedRestriction | Should -Be $true -Because "there is no policy that enables application enforced restrictions"
     }
-    It "MT.1020: All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. See https://maester.dev/docs/tests/MT.1020" -Tag "MT.1020" {
-        Test-MtCaExclusionForDirectorySyncAccount | Should -Be $true -Because "there is no policy that excludes directory synchronization accounts"
+    It "MT.1020: All Conditional Access policies are configured to exclude Directory/OnPremises synchronization accounts or do not scope them. See https://maester.dev/docs/tests/MT.1020" -Tag "MT.1020" {
+        Test-MtCaExclusionForDirectorySyncAccount | Should -Be $true -Because "there is no policy that excludes Directory/OnPremises synchronization accounts"
     }
     It "MT.1035: All security groups assigned to Conditional Access Policies should be protected by RMAU. See https://maester.dev/docs/tests/MT.1035" -Tag "MT.1035" {
         Test-MtCaGroupsRestricted | Should -Be $true -Because "there are one or more policies without protection of included or excluded groups"


### PR DESCRIPTION
# Description
Fix issue 
#699
#582

Following PR's can be closed
#1642
#1643

Fix MT.1020: update tests to ensure exclusion of Directory/OnPremises synchronization accounts in Conditional Access policies


<!-- End Description -->
## Contribution Checklist

Before submitting this PR, please confirm you have completed the following:

- [ X ] 📖 Read the [guidelines for contributing](https://maester.dev/docs/contributing) to this repository.
- [ X ] 🧪 Ensure the build and unit tests pass by running `/powershell/tests/pester.ps1` on your local system.

<!--

Please see additional instructions and a checklist for creating tests at <https://maester.dev/docs/contributing#checklist-for-writing-good-tests>.

We really appreciate your contributions! We will try to review your pull request as soon as possible. If you have any queries or need any help, please visit the repository discussions or jump on Discord.

While you wait for a review, why not spread some Maester love on social media? Thank you! 💖

-->
&nbsp;

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) 💬 or [Entra Discord](https://discord.maester.dev/) 🧑‍💻 for more help and conversations!
