### PR TITLE
fix: Remove invalid TimeGenerated column from OAuthAppInfo KQL projection (MT.1077-MT.1081)

### DIFF
--- a/powershell/internal/xspm/Get-MtXspmUnifiedIdentityInfo.ps1
+++ b/powershell/internal/xspm/Get-MtXspmUnifiedIdentityInfo.ps1
@@ -270,7 +270,7 @@
             | extend CriticalityLevel = toint(parse_json(XspmCriticalAssetDetails)['criticalityLevel'])
             | project-away XspmGraphNodeId, XspmGraphNodeId1, ServicePrincipalId1, ServicePrincipalId2, XspmGraphNodeId1, XspmGraphNodeId2, TargetNodeId, XspmGraphOAuthAppNodeId, XspmGraphOAuthAppNodeId1
             | sort by ServicePrincipalName asc
-            | project Timestamp, TimeGenerated, ServicePrincipalName, ServicePrincipalId, OAuthAppId, CriticalityLevel, AddedOnTime, LastModifiedTime, AppStatus, VerifiedPublisher, IsAdminConsented, AppOrigin, AppOwnerTenantId, ApiPermissions, AssignedAzureRoles, AssignedEntraRoles, AuthenticatedBy, OwnedBy, AccountStatus
+            | project Timestamp, ServicePrincipalName, ServicePrincipalId, OAuthAppId, CriticalityLevel, AddedOnTime, LastModifiedTime, AppStatus, VerifiedPublisher, IsAdminConsented, AppOrigin, AppOwnerTenantId, ApiPermissions, AssignedAzureRoles, AssignedEntraRoles, AuthenticatedBy, OwnedBy, AccountStatus
             | extend Classification = case(
                 AssignedEntraRoles has 'ControlPlane' or ApiPermissions has 'ControlPlane', 'ControlPlane',
                 AssignedEntraRoles has 'ManagementPlane' or ApiPermissions has 'ManagementPlane', 'ManagementPlane',


### PR DESCRIPTION
## Summary

Fixes #1675

Tests MT.1077-MT.1081 fail with a KQL semantic error when App Governance is enabled and the `OAuthAppInfo` table is available in Microsoft Defender XDR Advanced Hunting.

## Root Cause

In `powershell/internal/xspm/Get-MtXspmUnifiedIdentityInfo.ps1`, the `Int_WorkloadIdentityInfoXdr` KQL function incorrectly included `TimeGenerated` in the final `project` statement.

The `OAuthAppInfo` table in Defender XDR Advanced Hunting uses `Timestamp` as its time column, not `TimeGenerated` (which is the Azure Monitor/Log Analytics convention). The query pipeline:

1. The base `IdentityInfo` query projects away all columns early
2. Subsequent `lookup` blocks add columns from `OAuthAppInfo` (which has `Timestamp`, not `TimeGenerated`)
3. The final `project Timestamp, TimeGenerated, ...` fails because `TimeGenerated` was never in scope

## Fix

Removed `TimeGenerated` from the `project` statement in `Int_WorkloadIdentityInfoXdr`.

## Affected Tests

| Test ID | Function |
|---------|----------|
| MT.1077 | Test-MtXspmAppRegWithPrivilegedApiAndOwners |
| MT.1078 | Test-MtXspmAppRegWithPrivilegedRolesAndOwners |
| MT.1079 | Test-MtXspmAppRegWithPrivilegedUnusedPermissions |
| MT.1080 | Test-MtXspmExposedCredentialsForPrivilegedUsers |
| MT.1081 | Test-MtXspmHybridUsersWithAssignedEntraIdRoles |

## Files Changed

- `powershell/internal/xspm/Get-MtXspmUnifiedIdentityInfo.ps1` - removed `TimeGenerated` from the `project` statement in `Int_WorkloadIdentityInfoXdr`