### PR TITLE
fix: follow-up issues from MtRoleInfo auto-update (PRs #1624 / #1665)

### DIFF
--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -200,6 +200,7 @@ function Get-ExistingRoles {
 
     $preservedRoles = [System.Collections.Generic.List[hashtable]]::new()
     $newRoleNames = $NewRoles | ForEach-Object { $_.Name }
+        $newRoleGuids = $NewRoles | ForEach-Object { $_.Id }
 
     # Parse existing hashtable entries: 'RoleName' = [MtRoleDefinition]::new('guid', $true/$false)
     $entryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(true|false)\)'
@@ -210,11 +211,21 @@ function Get-ExistingRoles {
         if ($name -in $newRoleNames) { continue }
 
         $guid = $entry.Groups[2].Value
-        $isPriv = if ($entry.Groups[3].Value -eq 'true') { $true } else { $false }
+            $guid = $guid.ToLower()
+            # Skip if this GUID is already covered by a renamed role in the new data.
+            # Example: 'AzureADJoinedDeviceLocalAdministrator' was renamed to
+            # 'MicrosoftEntraJoinedDeviceLocalAdministrator' in the public docs.
+            # Preserving the old name would create two hashtable keys for the same GUID.
+            if ($guid -in $newRoleGuids) {
+                Write-Verbose "Skipping preserved role '$name' ($guid) - GUID is already present under a new name in the updated data."
+                continue
+            }
+
+            $isPriv = if ($entry.Groups[3].Value -eq 'true') { $true } else { $false }
 
         $preservedRoles.Add(@{
                 Name         = $name
-                Id           = $guid.ToLower()
+                    Id           = $guid
                 IsPrivileged = $isPriv
                 DisplayName  = $name
             })

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -200,7 +200,7 @@ function Get-ExistingRoles {
 
     $preservedRoles = [System.Collections.Generic.List[hashtable]]::new()
     $newRoleNames = $NewRoles | ForEach-Object { $_.Name }
-        $newRoleGuids = $NewRoles | ForEach-Object { $_.Id }
+    $newRoleGuids = $NewRoles | ForEach-Object { $_.Id }
 
     # Parse existing hashtable entries: 'RoleName' = [MtRoleDefinition]::new('guid', $true/$false)
     $entryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(true|false)\)'
@@ -211,21 +211,21 @@ function Get-ExistingRoles {
         if ($name -in $newRoleNames) { continue }
 
         $guid = $entry.Groups[2].Value
-            $guid = $guid.ToLower()
-            # Skip if this GUID is already covered by a renamed role in the new data.
-            # Example: 'AzureADJoinedDeviceLocalAdministrator' was renamed to
-            # 'MicrosoftEntraJoinedDeviceLocalAdministrator' in the public docs.
-            # Preserving the old name would create two hashtable keys for the same GUID.
-            if ($guid -in $newRoleGuids) {
-                Write-Verbose "Skipping preserved role '$name' ($guid) - GUID is already present under a new name in the updated data."
-                continue
-            }
+        $guid = $guid.ToLower()
+        # Skip if this GUID is already covered by a renamed role in the new data.
+        # Example: 'AzureADJoinedDeviceLocalAdministrator' was renamed to
+        # 'MicrosoftEntraJoinedDeviceLocalAdministrator' in the public docs.
+        # Preserving the old name would create two hashtable keys for the same GUID.
+        if ($guid -in $newRoleGuids) {
+            Write-Verbose "Skipping preserved role '$name' ($guid) - GUID is already present under a new name in the updated data."
+            continue
+        }
 
-            $isPriv = if ($entry.Groups[3].Value -eq 'true') { $true } else { $false }
+        $isPriv = if ($entry.Groups[3].Value -eq 'true') { $true } else { $false }
 
         $preservedRoles.Add(@{
                 Name         = $name
-                    Id           = $guid
+                Id           = $guid
                 IsPrivileged = $isPriv
                 DisplayName  = $name
             })

--- a/powershell/public/Get-MtRoleMember.ps1
+++ b/powershell/public/Get-MtRoleMember.ps1
@@ -120,7 +120,9 @@ function Get-MtRoleMember {
     }
 
     if ($Role) {
-        $RoleId = $Role | ForEach-Object { (Get-MtRoleInfo -RoleName $_) }
+        # Resolve role names to GUIDs via MtRoleDefinition.ToString(), then explicitly cast to [guid[]]
+        # to avoid relying on implicit coercion from MtRoleDefinition through the typed parameter variable.
+        $RoleId = [guid[]]($Role | ForEach-Object { (Get-MtRoleInfo -RoleName $_).ToString() })
     }
 
     $EntraIDPlan = Get-MtLicenseInformation -Product EntraID

--- a/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
+++ b/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
@@ -126,7 +126,7 @@ Describe 'Test-KnownRolesPresent' {
                 @{ Name = 'GlobalAdministrator';   Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true;  DisplayName = 'Global Administrator' }
                 @{ Name = 'SecurityAdministrator'; Id = '194ae4cb-b126-40b2-bd5b-6091b380977d'; IsPrivileged = $true;  DisplayName = 'Security Administrator' }
                 @{ Name = 'UserAdministrator';     Id = 'fe930be7-5e62-47db-91af-98c3a49a38b1'; IsPrivileged = $true;  DisplayName = 'User Administrator' }
-                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $false; DisplayName = 'Helpdesk Administrator' }
+                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $true;  DisplayName = 'Helpdesk Administrator' }
                 @{ Name = 'ExchangeAdministrator'; Id = '29232cdf-9323-42fd-ade2-1d097af3e4de'; IsPrivileged = $false; DisplayName = 'Exchange Administrator' }
             ) | ForEach-Object { $roles.Add($_) }
 
@@ -142,7 +142,7 @@ Describe 'Test-KnownRolesPresent' {
                 @{ Name = 'GlobalAdministrator';   Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true;  DisplayName = 'Global Administrator' }
                 @{ Name = 'SecurityAdministrator'; Id = '194ae4cb-b126-40b2-bd5b-6091b380977d'; IsPrivileged = $true;  DisplayName = 'Security Administrator' }
                 # UserAdministrator intentionally omitted
-                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $false; DisplayName = 'Helpdesk Administrator' }
+                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $true;  DisplayName = 'Helpdesk Administrator' }
                 @{ Name = 'ExchangeAdministrator'; Id = '29232cdf-9323-42fd-ade2-1d097af3e4de'; IsPrivileged = $false; DisplayName = 'Exchange Administrator' }
             ) | ForEach-Object { $roles.Add($_) }
 
@@ -193,6 +193,26 @@ Describe 'Get-ExistingRoles' {
             $preserved = @(Get-ExistingRoles -FileContent $fileContent -NewRoles $newRoles)
             @($preserved).Count | Should -Be 1
             $preserved[0].Name | Should -Be 'SystemRole'
+
+            Context 'Existing role has same GUID as a renamed new role' {
+                It 'does not preserve the old-name entry when its GUID is already covered by a new role' {
+                    # Simulates: old name 'OldRoleName' was renamed to 'NewRoleName' in public docs.
+                    # Both share the same GUID. The old entry should NOT be preserved, to avoid
+                    # two hashtable keys mapping to the same underlying Entra ID role.
+                    $fileContent = @"
+            'OldRoleName' = [MtRoleDefinition]::new('9f06204d-73c1-4d4c-880a-6edb90606fd8', `$false)
+            'SystemRole'  = [MtRoleDefinition]::new('aaaabbbb-cccc-dddd-eeee-ffffffffffff', `$false)
+        "@
+                    $newRoles = [System.Collections.Generic.List[hashtable]]::new()
+                    # New data contains the renamed role (same GUID, new name)
+                    $newRoles.Add(@{ Name = 'NewRoleName'; Id = '9f06204d-73c1-4d4c-880a-6edb90606fd8'; IsPrivileged = $false; DisplayName = 'New Role Name' })
+
+                    $preserved = @(Get-ExistingRoles -FileContent $fileContent -NewRoles $newRoles)
+                    # Only SystemRole should be preserved; OldRoleName should be skipped (GUID already in new data)
+                    @($preserved).Count | Should -Be 1
+                    $preserved[0].Name | Should -Be 'SystemRole'
+                }
+            }
         }
     }
 }

--- a/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
+++ b/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Get-RoleDataFromMarkdown' {
 
     Context 'Valid table with 3 roles including 1 privileged' {
         It 'returns 3 entries with correct IsPrivileged flag' {
-            $md = @"
+            $md = @'
 ## All roles
 
 | Role | Description | ID |
@@ -22,7 +22,7 @@ Describe 'Get-RoleDataFromMarkdown' {
 | [Global Administrator](#global-administrator) | Can manage all aspects of Azure AD. [![Privileged label icon.](./media/permissions-reference/privileged-label.png)](privileged-roles-permissions.md) | 62e90394-69f5-4237-9190-012177145e10 |
 | [Reports Reader](#reports-reader) | Can read sign-in and audit reports. | 4a5d8f65-41da-4de4-8968-e035b65339cf |
 | [Search Administrator](#search-administrator) | Can create and manage all aspects of Microsoft Search settings. | 0964bb5e-9bdb-4d7b-ac29-58e794862a40 |
-"@
+'@
             $result = Get-RoleDataFromMarkdown -Markdown $md
             $result.Count | Should -Be 3
             $privileged = @($result | Where-Object { $_.IsPrivileged })
@@ -33,52 +33,52 @@ Describe 'Get-RoleDataFromMarkdown' {
 
     Context 'Missing All roles heading' {
         It 'throws an error mentioning All roles' {
-            $md = @"
+            $md = @'
 ## Other Section
 
 | Role | Description | ID |
 | --- | --- | --- |
 | [Some Role](#some-role) | Description | 62e90394-69f5-4237-9190-012177145e10 |
-"@
-            { Get-RoleDataFromMarkdown -Markdown $md } | Should -Throw -ExpectedMessage "*All roles*"
+'@
+            { Get-RoleDataFromMarkdown -Markdown $md } | Should -Throw -ExpectedMessage '*All roles*'
         }
     }
 
     Context 'Missing table header separator row' {
         It 'throws an error about the header separator' {
-            $md = @"
+            $md = @'
 ## All roles
 
 | Role | Description | ID |
 | [Global Administrator](#global-administrator) | Description | 62e90394-69f5-4237-9190-012177145e10 |
-"@
-            { Get-RoleDataFromMarkdown -Markdown $md } | Should -Throw -ExpectedMessage "*table header separator*"
+'@
+            { Get-RoleDataFromMarkdown -Markdown $md } | Should -Throw -ExpectedMessage '*table header separator*'
         }
     }
 
     Context 'Table header has fewer than 3 columns' {
         It 'throws an error about column count' {
-            $md = @"
+            $md = @'
 ## All roles
 
 | Role | ID |
 | --- | --- |
 | [Global Administrator](#global-administrator) | 62e90394-69f5-4237-9190-012177145e10 |
-"@
-            { Get-RoleDataFromMarkdown -Markdown $md } | Should -Throw -ExpectedMessage "*column*"
+'@
+            { Get-RoleDataFromMarkdown -Markdown $md } | Should -Throw -ExpectedMessage '*column*'
         }
     }
 
     Context 'Row missing pipe delimiters (too few columns)' {
         It 'skips the malformed row without a terminating error' {
-            $md = @"
+            $md = @'
 ## All roles
 
 | Role | Description | ID |
 | --- | --- | --- |
 | [Global Administrator](#global-administrator) | Description | 62e90394-69f5-4237-9190-012177145e10 |
 This is a prose line with a guid 11111111-1111-1111-1111-111111111111 but no pipes
-"@
+'@
             $result = @(Get-RoleDataFromMarkdown -Markdown $md)
             @($result).Count | Should -Be 1
             $result[0].Name | Should -Be 'GlobalAdministrator'
@@ -87,14 +87,14 @@ This is a prose line with a guid 11111111-1111-1111-1111-111111111111 but no pip
 
     Context 'Duplicate role names' {
         It 'is handled by the caller deduplication (both entries returned from parser)' {
-            $md = @"
+            $md = @'
 ## All roles
 
 | Role | Description | ID |
 | --- | --- | --- |
 | [Global Administrator](#global-administrator) | First | 62e90394-69f5-4237-9190-012177145e10 |
 | [Global Administrator](#global-administrator) | Duplicate | 62e90394-69f5-4237-9190-012177145e10 |
-"@
+'@
             # Parser returns duplicates; caller is responsible for dedup
             $result = Get-RoleDataFromMarkdown -Markdown $md
             $result.Count | Should -Be 2
@@ -103,13 +103,13 @@ This is a prose line with a guid 11111111-1111-1111-1111-111111111111 but no pip
 
     Context 'GUID normalization' {
         It 'normalizes parsed GUIDs to lowercase' {
-            $md = @"
+            $md = @'
 ## All roles
 
 | Role | Description | ID |
 | --- | --- | --- |
 | [Global Administrator](#global-administrator) | Description | 62e90394-69f5-4237-9190-012177145e10 |
-"@
+'@
             $result = @(Get-RoleDataFromMarkdown -Markdown $md)
             # GUIDs from the source document are already lowercase; .ToLower() is a no-op safeguard
             $result[0].Id | Should -Be '62e90394-69f5-4237-9190-012177145e10'
@@ -123,10 +123,10 @@ Describe 'Test-KnownRolesPresent' {
         It 'returns true' {
             $roles = [System.Collections.Generic.List[hashtable]]::new()
             @(
-                @{ Name = 'GlobalAdministrator';   Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true;  DisplayName = 'Global Administrator' }
-                @{ Name = 'SecurityAdministrator'; Id = '194ae4cb-b126-40b2-bd5b-6091b380977d'; IsPrivileged = $true;  DisplayName = 'Security Administrator' }
-                @{ Name = 'UserAdministrator';     Id = 'fe930be7-5e62-47db-91af-98c3a49a38b1'; IsPrivileged = $true;  DisplayName = 'User Administrator' }
-                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $true;  DisplayName = 'Helpdesk Administrator' }
+                @{ Name = 'GlobalAdministrator'; Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true; DisplayName = 'Global Administrator' }
+                @{ Name = 'SecurityAdministrator'; Id = '194ae4cb-b126-40b2-bd5b-6091b380977d'; IsPrivileged = $true; DisplayName = 'Security Administrator' }
+                @{ Name = 'UserAdministrator'; Id = 'fe930be7-5e62-47db-91af-98c3a49a38b1'; IsPrivileged = $true; DisplayName = 'User Administrator' }
+                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $true; DisplayName = 'Helpdesk Administrator' }
                 @{ Name = 'ExchangeAdministrator'; Id = '29232cdf-9323-42fd-ade2-1d097af3e4de'; IsPrivileged = $false; DisplayName = 'Exchange Administrator' }
             ) | ForEach-Object { $roles.Add($_) }
 
@@ -139,10 +139,10 @@ Describe 'Test-KnownRolesPresent' {
         It 'returns false and emits a warning' {
             $roles = [System.Collections.Generic.List[hashtable]]::new()
             @(
-                @{ Name = 'GlobalAdministrator';   Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true;  DisplayName = 'Global Administrator' }
-                @{ Name = 'SecurityAdministrator'; Id = '194ae4cb-b126-40b2-bd5b-6091b380977d'; IsPrivileged = $true;  DisplayName = 'Security Administrator' }
+                @{ Name = 'GlobalAdministrator'; Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true; DisplayName = 'Global Administrator' }
+                @{ Name = 'SecurityAdministrator'; Id = '194ae4cb-b126-40b2-bd5b-6091b380977d'; IsPrivileged = $true; DisplayName = 'Security Administrator' }
                 # UserAdministrator intentionally omitted
-                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $true;  DisplayName = 'Helpdesk Administrator' }
+                @{ Name = 'HelpdeskAdministrator'; Id = '729827e3-9c14-49f7-bb1b-9608f156bbb8'; IsPrivileged = $true; DisplayName = 'Helpdesk Administrator' }
                 @{ Name = 'ExchangeAdministrator'; Id = '29232cdf-9323-42fd-ade2-1d097af3e4de'; IsPrivileged = $false; DisplayName = 'Exchange Administrator' }
             ) | ForEach-Object { $roles.Add($_) }
 
@@ -169,7 +169,7 @@ Describe 'Test-AllGuidsValid' {
         It 'returns false and emits a warning' {
             $roles = [System.Collections.Generic.List[hashtable]]::new()
             $roles.Add(@{ Name = 'GoodRole'; Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $false; DisplayName = 'Good Role' })
-            $roles.Add(@{ Name = 'BadRole';  Id = 'not-a-valid-guid';                     IsPrivileged = $false; DisplayName = 'Bad Role' })
+            $roles.Add(@{ Name = 'BadRole'; Id = 'not-a-valid-guid'; IsPrivileged = $false; DisplayName = 'Bad Role' })
 
             $result = Test-AllGuidsValid -Roles $roles 3>&1
             ($result | Where-Object { $_ -is [bool] }) | Should -BeFalse
@@ -187,8 +187,8 @@ Describe 'Get-ExistingRoles' {
     'SystemRole' = [MtRoleDefinition]::new('aaaabbbb-cccc-dddd-eeee-ffffffffffff', `$false)
 "@
             $newRoles = [System.Collections.Generic.List[hashtable]]::new()
-            $newRoles.Add(@{ Name = 'GlobalAdministrator'; Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true;  DisplayName = 'Global Administrator' })
-            $newRoles.Add(@{ Name = 'ReportsReader';       Id = '4a5d8f65-41da-4de4-8968-e035b65339cf'; IsPrivileged = $false; DisplayName = 'Reports Reader' })
+            $newRoles.Add(@{ Name = 'GlobalAdministrator'; Id = '62e90394-69f5-4237-9190-012177145e10'; IsPrivileged = $true; DisplayName = 'Global Administrator' })
+            $newRoles.Add(@{ Name = 'ReportsReader'; Id = '4a5d8f65-41da-4de4-8968-e035b65339cf'; IsPrivileged = $false; DisplayName = 'Reports Reader' })
 
             $preserved = @(Get-ExistingRoles -FileContent $fileContent -NewRoles $newRoles)
             @($preserved).Count | Should -Be 1
@@ -222,13 +222,13 @@ Describe 'Update-FileSection' {
     Context 'Marker present in file' {
         It 'replaces content between markers' {
             $tmpFile = [System.IO.Path]::GetTempFileName()
-            Set-Content -Path $tmpFile -Value @"
+            Set-Content -Path $tmpFile -Value @'
 before
 # BEGIN MARKER
 old content
 # END MARKER
 after
-"@
+'@
             Update-FileSection -FilePath $tmpFile `
                 -BeginMarker '# BEGIN MARKER' `
                 -EndMarker '# END MARKER' `
@@ -244,12 +244,12 @@ after
     Context 'Begin marker missing' {
         It 'throws an error containing the begin marker text' {
             $tmpFile = [System.IO.Path]::GetTempFileName()
-            Set-Content -Path $tmpFile -Value "no markers here"
+            Set-Content -Path $tmpFile -Value 'no markers here'
 
             { Update-FileSection -FilePath $tmpFile `
-                -BeginMarker '# BEGIN MARKER' `
-                -EndMarker '# END MARKER' `
-                -NewContent 'new content' } | Should -Throw -ExpectedMessage "*BEGIN MARKER*"
+                    -BeginMarker '# BEGIN MARKER' `
+                    -EndMarker '# END MARKER' `
+                    -NewContent 'new content' } | Should -Throw -ExpectedMessage '*BEGIN MARKER*'
 
             Remove-Item $tmpFile -Force
         }

--- a/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
+++ b/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
@@ -193,26 +193,26 @@ Describe 'Get-ExistingRoles' {
             $preserved = @(Get-ExistingRoles -FileContent $fileContent -NewRoles $newRoles)
             @($preserved).Count | Should -Be 1
             $preserved[0].Name | Should -Be 'SystemRole'
+        }
+    }
 
-            Context 'Existing role has same GUID as a renamed new role' {
-                It 'does not preserve the old-name entry when its GUID is already covered by a new role' {
-                    # Simulates: old name 'OldRoleName' was renamed to 'NewRoleName' in public docs.
-                    # Both share the same GUID. The old entry should NOT be preserved, to avoid
-                    # two hashtable keys mapping to the same underlying Entra ID role.
-                    $fileContent = @"
-            'OldRoleName' = [MtRoleDefinition]::new('9f06204d-73c1-4d4c-880a-6edb90606fd8', `$false)
-            'SystemRole'  = [MtRoleDefinition]::new('aaaabbbb-cccc-dddd-eeee-ffffffffffff', `$false)
-        "@
-                    $newRoles = [System.Collections.Generic.List[hashtable]]::new()
-                    # New data contains the renamed role (same GUID, new name)
-                    $newRoles.Add(@{ Name = 'NewRoleName'; Id = '9f06204d-73c1-4d4c-880a-6edb90606fd8'; IsPrivileged = $false; DisplayName = 'New Role Name' })
+    Context 'Existing role has same GUID as a renamed new role' {
+        It 'does not preserve the old-name entry when its GUID is already covered by a new role' {
+            # Simulates: old name 'OldRoleName' was renamed to 'NewRoleName' in public docs.
+            # Both share the same GUID. The old entry should NOT be preserved, to avoid
+            # two hashtable keys mapping to the same underlying Entra ID role.
+            $fileContent = @"
+    'OldRoleName' = [MtRoleDefinition]::new('9f06204d-73c1-4d4c-880a-6edb90606fd8', `$false)
+    'SystemRole'  = [MtRoleDefinition]::new('aaaabbbb-cccc-dddd-eeee-ffffffffffff', `$false)
+"@
+            $newRoles = [System.Collections.Generic.List[hashtable]]::new()
+            # New data contains the renamed role (same GUID, new name)
+            $newRoles.Add(@{ Name = 'NewRoleName'; Id = '9f06204d-73c1-4d4c-880a-6edb90606fd8'; IsPrivileged = $false; DisplayName = 'New Role Name' })
 
-                    $preserved = @(Get-ExistingRoles -FileContent $fileContent -NewRoles $newRoles)
-                    # Only SystemRole should be preserved; OldRoleName should be skipped (GUID already in new data)
-                    @($preserved).Count | Should -Be 1
-                    $preserved[0].Name | Should -Be 'SystemRole'
-                }
-            }
+            $preserved = @(Get-ExistingRoles -FileContent $fileContent -NewRoles $newRoles)
+            # Only SystemRole should be preserved; OldRoleName should be skipped (GUID already in new data)
+            @($preserved).Count | Should -Be 1
+            $preserved[0].Name | Should -Be 'SystemRole'
         }
     }
 }


### PR DESCRIPTION
Closes #1684

Addresses three follow-up issues found during a review of the implementation from PRs #1624 and #1665.

cc @SamErde @Mynster9361

---

## Changes

### 1. `build/Update-MtRoleDefinitions.ps1` — prevent duplicate GUID keys on role rename

`Get-ExistingRoles` previously preserved any existing hashtable entry whose name was absent from the fresh Microsoft docs data. It did not check whether the entry's **GUID** was already covered by a renamed role in the new data.

**Before:** When Microsoft renames a role (e.g., `AzureADJoinedDeviceLocalAdministrator` → `MicrosoftEntraJoinedDeviceLocalAdministrator`), the old name continues to be preserved on every subsequent automated run, resulting in two hashtable keys sharing the same GUID indefinitely.

**After:** `Get-ExistingRoles` now builds a set of GUIDs already present in the new data and skips preservation of any entry whose GUID appears in that set. A `Write-Verbose` message identifies the skipped entry and its replacement. This allows the automated update to naturally clean up old names once their GUIDs are accounted for by a new entry.

```powershell
$newRoleGuids = $NewRoles | ForEach-Object { $_.Id }
...
if ($guid -in $newRoleGuids) {
    Write-Verbose "Skipping preserved role '$name' ($guid) - GUID is already present under a new name in the updated data."
    continue
}
```

### 2. `powershell/public/Get-MtRoleMember.ps1` — explicit cast instead of implicit coercion

```powershell
# Before
$RoleId = $Role | ForEach-Object { (Get-MtRoleInfo -RoleName $_) }

# After
$RoleId = [guid[]]($Role | ForEach-Object { (Get-MtRoleInfo -RoleName $_).ToString() })
```

`Get-MtRoleInfo` returns `[MtRoleDefinition]` objects. Re-assigning to `$RoleId` (declared `[guid[]]` at the parameter level) relied on PowerShell implicitly calling `MtRoleDefinition.ToString()` to coerce to `[guid]`. The explicit cast through `ToString()` makes the intent clear and removes the dependency on an undocumented coercion path.

### 3. `powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1` — fix test data and add coverage

- **`HelpdeskAdministrator` `IsPrivileged` corrected from `$false` to `$true`** in both the "All 5 expected roles present" and "One expected role missing" test contexts. Helpdesk Administrator is a privileged role per the Microsoft permissions reference and the production `$script:MtRoles` hashtable.

- **New test context added** for `Get-ExistingRoles`: "Existing role has same GUID as a renamed new role" verifies that the old-name entry is not preserved when its GUID is already present in the new data, and that genuinely system-only roles (different GUID) are still preserved correctly.

---

## Testing

All existing tests in `Update-MtRoleDefinitions.Tests.ps1` continue to pass. The new test context exercises the GUID-deduplication path directly.