### PR TITLE
fix: correct NotRunCount and InvestigateCount variable references in mail/Teams alerts

### DIFF
--- a/powershell/public/Send-MtMail.ps1
+++ b/powershell/public/Send-MtMail.ps1
@@ -103,7 +103,7 @@
     $skippedCount = $MaesterResults.SkippedCount
     if ([string]::IsNullOrEmpty($MaesterResults.SkippedCount)) { $skippedCount = "-" }
     $investigateCount = $MaesterResults.investigateCount
-    if ([string]::IsNullOrEmpty($MaesterResults.SkippedCount)) { $investigateCount = "-" }
+    if ([string]::IsNullOrEmpty($MaesterResults.investigateCount)) { $investigateCount = "-" }
 
     $emailTemplate = $emailTemplate -replace "%TenantName%", $MaesterResults.TenantName
     $emailTemplate = $emailTemplate -replace "%TenantId%", $MaesterResults.TenantId

--- a/powershell/public/Send-MtTeamsMessage.ps1
+++ b/powershell/public/Send-MtTeamsMessage.ps1
@@ -98,12 +98,12 @@
         "$currentVersion"
     }
 
-    $NotRunCount = $MaesterResults.SkippedCount
-    if ([string]::IsNullOrEmpty($MaesterResults.SkippedCount)) { $NotRunCount = "-" }
+    $NotRunCount = $MaesterResults.NotRunCount
+    if ([string]::IsNullOrEmpty($MaesterResults.NotRunCount)) { $NotRunCount = "-" }
     $skippedCount = $MaesterResults.SkippedCount
     if ([string]::IsNullOrEmpty($MaesterResults.SkippedCount)) { $skippedCount = "-" }
     $investigateCount = $MaesterResults.investigateCount
-    if ([string]::IsNullOrEmpty($MaesterResults.SkippedCount)) { $investigateCount = "-" }
+    if ([string]::IsNullOrEmpty($MaesterResults.investigateCount)) { $investigateCount = "-" }
     $adaptiveCardData = @{
         title       = $Subject
         description = "Results for Maester Test run of $($MaesterResults.ExecutedAt)"


### PR DESCRIPTION
## Summary

Fixes the variable reference bugs causing Skipped and Not Run counts (and Investigate counts) to display incorrectly or identically in email and Teams alert messages.

## Bugs Fixed

### `Send-MtTeamsMessage.ps1`
- **Line 101**: `\` was assigned from `\.SkippedCount` instead of `\.NotRunCount`. Both `\` and `\` showed the same Skipped value; the actual NotRun count was silently dropped.
- **Line 102**: The null-guard for `\` checked `SkippedCount` instead of `NotRunCount`.
- **Line 106**: The null-guard for `\` checked `SkippedCount` instead of `investigateCount`.

### `Send-MtMail.ps1`
- **Line 106**: The null-guard for `\` checked `SkippedCount` instead of `investigateCount`, causing the Investigate count to show `-` whenever SkippedCount was null/empty.

## Testing

Verified by code review; the property names now correctly match the `\` object properties (`NotRunCount`, `SkippedCount`, `investigateCount`) for all three variables in both files.

Closes #858