### PR TITLE
Fix: Silently skip external GDAP groups in global admin role member checks

### DIFF
--- a/powershell/public/Get-MtGroupMember.ps1
+++ b/powershell/public/Get-MtGroupMember.ps1
@@ -31,11 +31,15 @@
   try {
     $group = Invoke-MtGraphRequest -RelativeUri "groups/$GroupId/" -ApiVersion v1.0
     if (-not $group) {
-      Write-Error "Group with ID '$GroupId' not found in tenant."
+      Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This is expected for external partner groups assigned via GDAP."
       return $null
     }
   } catch {
-    Write-Error "Error obtaining group ($GroupId) from Microsoft Graph. Confirm the group exists in your tenant. Details: $($_.Exception.Message)"
+    if ($_.Exception.Message -match 'NotFound|404') {
+      Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This is expected for external partner groups assigned via GDAP. Details: $($_.Exception.Message)"
+    } else {
+      Write-Warning "Error obtaining group ($GroupId) from Microsoft Graph. Confirm the group exists in your tenant. Details: $($_.Exception.Message)"
+    }
     return $null
   }
 

--- a/powershell/public/Get-MtGroupMember.ps1
+++ b/powershell/public/Get-MtGroupMember.ps1
@@ -31,12 +31,15 @@
   try {
     $group = Invoke-MtGraphRequest -RelativeUri "groups/$GroupId/" -ApiVersion v1.0
     if (-not $group) {
-      Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This is expected for external partner groups assigned via GDAP."
+      Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This may be an external partner group assigned via GDAP, or the group may have been deleted."
       return $null
     }
   } catch {
-    if ($_.Exception.Message -match 'NotFound|404') {
-      Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This is expected for external partner groups assigned via GDAP. Details: $($_.Exception.Message)"
+    # Prefer checking the typed StatusCode property (.NET 5+/PS7); fall back to message matching for older runtimes.
+    $is404 = ($_.Exception.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or
+             ($_.Exception.Message -match 'NotFound|404')
+    if ($is404) {
+      Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This may be an external partner group assigned via GDAP, or the group may have been deleted. Details: $($_.Exception.Message)"
     } else {
       Write-Warning "Error obtaining group ($GroupId) from Microsoft Graph. Confirm the group exists in your tenant. Details: $($_.Exception.Message)"
     }

--- a/powershell/public/Get-MtRoleMember.ps1
+++ b/powershell/public/Get-MtRoleMember.ps1
@@ -100,7 +100,7 @@ function Get-MtRoleMember {
         $groups = $assignments | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.group' }
         $groups | ForEach-Object {
             #5/10/2024 - Entra ID Role Enabled Security Groups do not currently support nesting
-            # External partner groups assigned via GDAP will return $null (not found in local tenant) and are skipped.
+            # Get-MtGroupMember returns $null when a group cannot be resolved (e.g., GDAP external groups, deleted groups). Skip null results.
             $groupMembers = Get-MtGroupMember -GroupId $_.id
             if ($null -ne $groupMembers) {
                 $assignments += $groupMembers

--- a/powershell/public/Get-MtRoleMember.ps1
+++ b/powershell/public/Get-MtRoleMember.ps1
@@ -100,7 +100,11 @@ function Get-MtRoleMember {
         $groups = $assignments | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.group' }
         $groups | ForEach-Object {
             #5/10/2024 - Entra ID Role Enabled Security Groups do not currently support nesting
-            $assignments += Get-MtGroupMember -GroupId $_.id
+            # External partner groups assigned via GDAP will return $null (not found in local tenant) and are skipped.
+            $groupMembers = Get-MtGroupMember -GroupId $_.id
+            if ($null -ne $groupMembers) {
+                $assignments += $groupMembers
+            }
         }
 
         # Append the type of assignment


### PR DESCRIPTION
## Summary

Fixes #1412

When a tenant has a GDAP (Granular Delegated Admin Privileges) relationship with a partner, the partner's security groups may appear in role assignments (e.g., Global Administrator). These groups exist in the partner's tenant, not in the local tenant, so fetching them via the Microsoft Graph API returns `404 Not Found`.

Previously, `Get-MtGroupMember` called `Write-Error` on any failure to look up a group, producing noisy and misleading output for a scenario that is entirely expected: external GDAP partner groups simply do not exist in the local tenant's directory.

## Changes

### Get-MtGroupMember.ps1
- Detect `404/NotFound` responses when looking up a group by ID and downgrade the output from `Write-Error` to `Write-Verbose` with a descriptive message indicating the group may be an external GDAP partner group.
- Change the `if (-not )` branch (empty-result path) from `Write-Error` to `Write-Verbose` for the same reason.
- Other (unexpected) error types still emit `Write-Warning` so genuine failures remain visible.

### Get-MtRoleMember.ps1 (Get-UsersInRole)
- Add a `\` guard when accumulating group members so that a `\` return from `Get-MtGroupMember` (external/missing group) is not appended to the assignments collection, preventing null entries from propagating through downstream processing (e.g., `Add-Member`, `Sort-Object`).

## Behavior

| Scenario | Before | After |
|---|---|---|
| Local tenant group in role | Works correctly | No change |
| External GDAP partner group in role | Emits `Write-Error`, group is skipped | Emits `Write-Verbose` only, group is skipped |
| Unexpected Graph API error | Emits `Write-Error` | Emits `Write-Warning` |

External GDAP groups are already excluded from counts in the test functions (which filter for `#microsoft.graph.user` type). This fix eliminates the confusing error output when those groups are encountered during member expansion.