### PR TITLE
Fix: Improve 404 detection to use Response.StatusCode (follow-up to #1688)

### DIFF
--- a/powershell/public/Get-MtGroupMember.ps1
+++ b/powershell/public/Get-MtGroupMember.ps1
@@ -35,8 +35,10 @@
       return $null
     }
   } catch {
-    # Prefer checking the typed StatusCode property (.NET 5+/PS7); fall back to message matching for older runtimes.
-    $is404 = ($_.Exception.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or
+    # Check status code via Response.StatusCode (Invoke-MgGraphRequest pattern used in this repo),
+    # then via the typed StatusCode property (.NET 5+/PS7), then fall back to message matching.
+    $is404 = ($_.Exception.Response.StatusCode -eq 404) -or
+             ($_.Exception.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or
              ($_.Exception.Message -match 'NotFound|404')
     if ($is404) {
       Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This may be an external partner group assigned via GDAP, or the group may have been deleted. Details: $($_.Exception.Message)"

--- a/powershell/public/Get-MtGroupMember.ps1
+++ b/powershell/public/Get-MtGroupMember.ps1
@@ -36,9 +36,14 @@
     }
   } catch {
     # Check status code via Response.StatusCode (Invoke-MgGraphRequest pattern used in this repo),
-    # then via the typed StatusCode property (.NET 5+/PS7), then fall back to message matching.
-    $is404 = ($_.Exception.Response.StatusCode -eq 404) -or
-             ($_.Exception.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or
+    # including enum, string ('NotFound'), and integer (404) forms; then via the typed StatusCode
+    # property (.NET 5+/PS7); then fall back to message matching for older runtimes.
+    $responseStatusCode = $_.Exception.Response.StatusCode
+    $exceptionStatusCode = $_.Exception.StatusCode
+    $is404 = ($responseStatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or
+             ($responseStatusCode -eq 'NotFound') -or
+             ($responseStatusCode -eq 404) -or
+             ($exceptionStatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or
              ($_.Exception.Message -match 'NotFound|404')
     if ($is404) {
       Write-Verbose "Group ($GroupId) was not found in the tenant and will be skipped. This may be an external partner group assigned via GDAP, or the group may have been deleted. Details: $($_.Exception.Message)"


### PR DESCRIPTION
## Summary

Follow-up to #1688 (merged), addressing a review comment added after merge.

When detecting a 404 from `Invoke-MgGraphRequest` in `Get-MtGroupMember`, the previous commit relied on `$_.Exception.StatusCode` (.NET 5+) and message-text matching. However, as noted in `Send-MtMail.ps1`, exceptions from `Invoke-MgGraphRequest` in this codebase commonly expose the HTTP status under `$_.Exception.Response.StatusCode`.

## Change

The `$is404` check in `Get-MtGroupMember` now checks all three properties in order of reliability:

```powershell
$is404 = ($_.Exception.Response.StatusCode -eq 404) -or          # repo pattern (Invoke-MgGraphRequest)
         ($_.Exception.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) -or  # .NET 5+/PS7
         ($_.Exception.Message -match 'NotFound|404')             # older runtime fallback
```

This ensures real 404s are correctly classified as benign (GDAP/deleted group) regardless of runtime version or exception message localization.

Closes #1412
