### PR TITLE
fix: strip blockquote prefixes when parsing 'All roles' table in update-role-definitions workflow

### DIFF
--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -59,6 +59,9 @@ function Get-RoleDataFromMarkdown {
         $contentAfterHeading
     }
 
+    # Strip blockquote prefixes (the docs render the table inside '> | ... |' blockquote lines)
+    $sectionBody = [regex]::Replace($sectionBody, '(?m)^>\s?', '')
+
     # Validate that the section contains a Markdown table header separator row with at least 3 columns
     $allSectionLines = $($sectionBody -split '\r?\n') | Where-Object { $_ -ne '' }
     $separatorLine = $allSectionLines | Where-Object { $_ -match '^\s*\|[\s\-|]+\|\s*$' -and $_ -match '\-{3,}' } | Select-Object -First 1

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -59,8 +59,10 @@ function Get-RoleDataFromMarkdown {
         $contentAfterHeading
     }
 
-    # Strip blockquote prefixes (the docs render the table inside '> | ... |' blockquote lines)
-    $sectionBody = [regex]::Replace($sectionBody, '(?m)^>\s?', '')
+    # Strip blockquote prefixes only from table rows (lines where '>' precedes a '|').
+    # GFM allows up to 3 spaces of indentation before '>'; the lookahead (?=\s*\|) ensures
+    # non-table blockquote lines (e.g. '> [!div ...]' directives) are left intact.
+    $sectionBody = [regex]::Replace($sectionBody, '(?m)^ {0,3}>\s?(?=\s*\|)', '')
 
     # Validate that the section contains a Markdown table header separator row with at least 3 columns
     $allSectionLines = $($sectionBody -split '\r?\n') | Where-Object { $_ -ne '' }

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -83,8 +83,8 @@ function Get-RoleDataFromMarkdown {
 
         <#
         Just providing some context/clarity on how our data looks at this point:
-        $line looks like this at this point:
-        > | [Agent ID Administrator](#agent-id-administrator) | Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent service principals, agent identities, and agentic users.<br/>[![Privileged label icon.](./media/permissions-reference/privileged-label.png)](privileged-roles-permissions.md) | db506228-d27e-4b7d-95e5-295956d6615f |
+        $line looks like this at this point (blockquote prefixes have already been stripped above):
+        | [Agent ID Administrator](#agent-id-administrator) | Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent service principals, agent identities, and agentic users.<br/>[![Privileged label icon.](./media/permissions-reference/privileged-label.png)](privileged-roles-permissions.md) | db506228-d27e-4b7d-95e5-295956d6615f |
         #>
         $entry = $line.Split('|')
         if ($entry.Count -lt 4) { continue }

--- a/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
+++ b/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
@@ -31,6 +31,40 @@ Describe 'Get-RoleDataFromMarkdown' {
         }
     }
 
+    Context 'Blockquote-formatted table (GFM > | ... | syntax)' {
+        It 'parses roles and IsPrivileged correctly when table rows use > prefix' {
+            $md = @'
+## All roles
+
+> [!div class="mx-tableFixed"]
+> | Role | Description | ID |
+> | --- | --- | --- |
+> | [Global Administrator](#global-administrator) | Can manage all aspects of Azure AD. [![Privileged label icon.](./media/permissions-reference/privileged-label.png)](privileged-roles-permissions.md) | 62e90394-69f5-4237-9190-012177145e10 |
+> | [Reports Reader](#reports-reader) | Can read sign-in and audit reports. | 4a5d8f65-41da-4de4-8968-e035b65339cf |
+'@
+            $result = Get-RoleDataFromMarkdown -Markdown $md
+            $result.Count | Should -Be 2
+            $privileged = @($result | Where-Object { $_.IsPrivileged })
+            $privileged.Count | Should -Be 1
+            $privileged[0].Name | Should -Be 'GlobalAdministrator'
+            ($result | Where-Object { $_.Name -eq 'ReportsReader' }).IsPrivileged | Should -BeFalse
+        }
+
+        It 'parses roles correctly when blockquote rows use up to 3 spaces of indentation' {
+            $md = @'
+## All roles
+
+   > | Role | Description | ID |
+   > | --- | --- | --- |
+   > | [Global Administrator](#global-administrator) | Description | 62e90394-69f5-4237-9190-012177145e10 |
+'@
+            # Wrap in @() to prevent PowerShell from unwrapping a single-item list to a bare hashtable
+            $result = @(Get-RoleDataFromMarkdown -Markdown $md)
+            $result.Count | Should -Be 1
+            $result[0].Name | Should -Be 'GlobalAdministrator'
+        }
+    }
+
     Context 'Missing All roles heading' {
         It 'throws an error mentioning All roles' {
             $md = @'


### PR DESCRIPTION
## Summary

The `update-role-definitions` workflow ([run #24935954471](https://github.com/maester365/maester/actions/runs/24935954471/job/73021434809)) failed on its first run with:

```
Could not find a Markdown table header separator row in the 'All roles' section. Document structure may have changed.
```

## Root Cause

The `MicrosoftDocs/entra-docs` `permissions-reference.md` document now wraps the 'All roles' table in GitHub Flavored Markdown blockquote notation:

```markdown
> | Role | Description | Template ID |
> | --- | --- | --- |
> | [Agent ID Administrator](#agent-id-administrator) | ... | guid |
```

The separator-line validation regex (`^\s*\|[\s\-|]+\|\s*$`) required lines to begin with `|`, so `> | --- | --- | --- |` never matched.

## Fix

Strip leading `> ` blockquote prefixes from the extracted section body immediately after slicing it out, before any table parsing:

```powershell
# Strip blockquote prefixes (the docs render the table inside '> | ... |' blockquote lines)
$sectionBody = [regex]::Replace($sectionBody, '(?m)^>\s?', '')
```

All existing validation and role-parsing logic then works unchanged. Tested against the live document — separator detected correctly, 130 roles parsed successfully.

## Related

- Fixes failing `update-role-definitions` workflow introduced in #1665 / #1685
