### PR TITLE
Improve MT.1058 result output formatting

### DIFF
--- a/powershell/public/maester/entra/Test-MtSpExchangeAppAccessPolicy.ps1
+++ b/powershell/public/maester/entra/Test-MtSpExchangeAppAccessPolicy.ps1
@@ -70,33 +70,51 @@
             }
         }
 
-        # Prepare result table showing all apps with Exchange permissions
-        $detailMarkdown = "### Applications with Exchange Permissions`n`n"
-        $detailMarkdown += "| Application | Permissions | Access Policy? |`n"
-        $detailMarkdown += "| --- | --- | --- |`n"
-
         $missingPolicies = @()
+        $appsWithPolicies = @()
         foreach ($sp in $principalsWithExchangePerms) {
             $hasPolicy = $appAccessPolicies.AppId -contains $sp.AppId
-            $policyStatus = if ($hasPolicy) { '✅ Yes' } else { '❌ No' }
             $filteredPermissions = $sp.Permissions -split ', ' | Where-Object { $_ -in $exchangePermissions }
-            $portalLink = Get-MtLinkServicePrincipal -ServicePrincipal $sp -Blade Permissions
-            $detailMarkdown += "| $portalLink | $($filteredPermissions -join ', ') | $policyStatus |`n"
+            $appRecord = [PSCustomObject]@{
+                Id          = $sp.Id
+                DisplayName = $sp.DisplayName
+                AppId       = $sp.AppId
+                Permissions = $filteredPermissions -join ', '
+            }
 
             if (-not $hasPolicy) {
-                $missingPolicies += $sp
+                $missingPolicies += $appRecord
+            } else {
+                $appsWithPolicies += $appRecord
             }
         }
 
+        $appsWithExchangePermissionsCount = ($principalsWithExchangePerms | Measure-Object).Count
         $invalidCount = ($missingPolicies | Measure-Object).Count
         $result = $invalidCount -eq 0
 
-        if ($result) {
-            $testResultMarkdown = 'Well done. We did not find any applications with tenant-wide Exchange permissions to all mailboxes.'
+        if ($appsWithExchangePermissionsCount -eq 0) {
+            $testResultMarkdown = 'Well done. No applications with Exchange permissions were found.'
+        } elseif ($result) {
+            $testResultMarkdown = "Well done. All **$appsWithExchangePermissionsCount** applications with Exchange permissions have Exchange application access policies configured."
         } else {
-            $testResultMarkdown = "Found **$invalidCount** applications with tenant-wide access to all Exchange mailboxes."
+            $testResultMarkdown = "Found **$appsWithExchangePermissionsCount** applications with Exchange permissions. **$invalidCount** application(s) do not have Exchange application access policies configured."
+
+            $missingPoliciesMarkdown = "`n`n### Applications Missing Exchange Application Access Policies`n`n"
+            $missingPoliciesMarkdown += "| Application | Application ID | Exchange Permissions |`n"
+            $missingPoliciesMarkdown += "| --- | --- | --- |`n"
+
+            foreach ($app in ($missingPolicies | Sort-Object -Property DisplayName)) {
+                $portalLink = Get-MtLinkServicePrincipal -ServicePrincipal $app -Blade Permissions
+                $missingPoliciesMarkdown += "| $portalLink | $($app.AppId) | $($app.Permissions) |`n"
+            }
+
+            $testResultMarkdown += $missingPoliciesMarkdown
         }
-        $testResultMarkdown += "`n`n" + $detailMarkdown
+
+        if ($appsWithPolicies.Count -gt 0 -and $invalidCount -gt 0) {
+            $testResultMarkdown += "`n`n**Applications with access policies configured:** $($appsWithPolicies.Count)"
+        }
 
         Add-MtTestResultDetail -Result $testResultMarkdown
         return $result

--- a/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
+++ b/tests/Maester/Entra/Test-AppRegistrations.Tests.ps1
@@ -3,7 +3,11 @@ Describe 'Maester/Entra' -Tag 'App', 'Entra', 'Graph', 'LongRunning', 'Maester' 
         Test-MtAppRegistrationsWithSecrets | Should -Be $true -Because 'app registrations should not use secrets and instead use workload identities or certificate-based authentication'
     }
     It 'MT.1058: Exchange application access policies must be configured. See https://maester.dev/docs/tests/MT.1058' -Tag 'MT.1058' {
-        Test-MtSpExchangeAppAccessPolicy | Should -Be $true -Because 'all applications with Exchange permissions should have access policies configured'
+        $result = Test-MtSpExchangeAppAccessPolicy
+
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because 'all applications with Exchange permissions should have access policies configured'
+        }
     }
     It 'MT.1075: Require explicit assignment of Third Party Entra Apps. See https://maester.dev/docs/tests/MT.1075' -Tag 'MT.1075' {
         Test-MtServicePrincipalsForAllUsers | Should -Be $true -Because 'Third Party Service Principals should require explicit assignment to users'


### PR DESCRIPTION
## Summary
Improve MT.1058 so its results are easier to scan and align better with other Maester tests.

## What changed
- replaced the mixed yes/no status table with a failure-focused table that lists only applications missing Exchange application access policies
- added clearer summary text for the no-apps, all-compliant, and non-compliant result paths
- updated the MT.1058 test assertion to use the null-safe pattern already used by many Maester tests so skipped or error helper outcomes do not add extra assertion noise

## Validation
- reviewed the helper and test changes together against nearby patterns used by MT.1057 and MT.1075
- verified the changed PowerShell files parse cleanly with the PowerShell parser
- confirmed editor diagnostics report no errors for the changed files

Fixes #1695