### PR TITLE
feat(report): add direct linking to individual test results via URL

### DIFF
--- a/report/src/App.tsx
+++ b/report/src/App.tsx
@@ -14,6 +14,7 @@ import ConfigPage from "@/pages/ConfigPage"
 import ExcelPage from "@/pages/ExcelPage"
 import MarkdownPage from "@/pages/MarkdownPage"
 import PrintPage from "@/pages/PrintPage"
+import { reportMainElementId } from "@/lib/reportLinks"
 
 // Component to scroll to top on route change
 function ScrollToTop({ mainRef }: { mainRef: React.RefObject<HTMLElement | null> }) {
@@ -40,7 +41,7 @@ function App() {
             <Sidebar />
             <div className="flex flex-1 flex-col overflow-hidden">
               <Breadcrumb />
-              <main ref={mainRef} className="flex-1 overflow-auto">
+              <main id={reportMainElementId} ref={mainRef} className="flex-1 overflow-auto">
                 <ScrollToTop mainRef={mainRef} />
                 <div className="p-6">
                   <Routes>
@@ -51,6 +52,7 @@ function App() {
                     <Route path="/view/excel" element={<ExcelPage />} />
                     <Route path="/view/markdown" element={<MarkdownPage />} />
                     <Route path="/view/print" element={<PrintPage />} />
+                    <Route path="/:testResultAnchor" element={<HomePage />} />
                   </Routes>
                 </div>
               </main>

--- a/report/src/App.tsx
+++ b/report/src/App.tsx
@@ -16,11 +16,14 @@ import MarkdownPage from "@/pages/MarkdownPage"
 import PrintPage from "@/pages/PrintPage"
 import { reportMainElementId } from "@/lib/reportLinks"
 
-// Component to scroll to top on route change
+// Component to scroll to top on route change.
+// Skipped when a hash is present because the deep-link scroll will position
+// the viewport to the correct row instead.
 function ScrollToTop({ mainRef }: { mainRef: React.RefObject<HTMLElement | null> }) {
-  const { pathname } = useLocation()
+  const { pathname, hash } = useLocation()
 
   useEffect(() => {
+    if (hash) return
     if (mainRef.current) {
       mainRef.current.scrollTo(0, 0)
     }

--- a/report/src/components/Breadcrumb.tsx
+++ b/report/src/components/Breadcrumb.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation } from "react-router-dom"
 import { useSidebar } from "./Sidebar"
 import { ThemeToggle } from "./ThemeToggle"
 import { useTenant } from "@/context/TenantContext"
+import { scrollReportToTop } from "@/lib/reportLinks"
 
 interface BreadcrumbItem {
   label: string
@@ -64,6 +65,7 @@ export function Breadcrumb() {
                 {item.href ? (
                   <Link
                     to={item.href}
+                    onClick={item.href === "/" ? scrollReportToTop : undefined}
                     className="text-sm tracking-tight text-gray-500 hover:text-gray-900 transition-colors dark:text-gray-400 dark:hover:text-gray-100"
                   >
                     {item.label}

--- a/report/src/components/ResultInfo.jsx
+++ b/report/src/components/ResultInfo.jsx
@@ -67,7 +67,7 @@ export default function ResultInfo({ Item, isPrintView }) {
   }
 
   return (
-    <div className="grid grid-cols-1" id={Item.Id}>
+    <div className="grid grid-cols-1" id={isPrintView ? Item.Id : undefined}>
       <div className="text-right flex justify-end space-x-2 items-center">
         {Item.Severity && (
           <div title="Severity" className="flex items-center">

--- a/report/src/components/Sidebar.tsx
+++ b/report/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import { Link, useLocation } from "react-router-dom"
 import React, { useState, createContext, useContext, useRef, useEffect } from "react"
 import maesterLogo from "@/assets/maester.png"
 import { useTenant } from "@/context/TenantContext"
+import { scrollReportToTop } from "@/lib/reportLinks"
 
 interface SidebarContextType {
   isCollapsed: boolean
@@ -41,6 +42,7 @@ interface NavItemProps {
   label: string
   isActive?: boolean
   isCollapsed?: boolean
+  onClick?: () => void
 }
 
 function NavItem({
@@ -49,10 +51,12 @@ function NavItem({
   label,
   isActive,
   isCollapsed,
+  onClick,
 }: NavItemProps) {
   return (
     <Link
       to={href}
+      onClick={onClick}
       className={cx(
         "group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium tracking-tight transition-all duration-100",
         isActive
@@ -179,7 +183,7 @@ export function Sidebar() {
         "flex h-16 items-center gap-3 border-b border-gray-200 dark:border-gray-800",
         isCollapsed ? "justify-center px-2" : "px-4"
       )}>
-        <Link to="/" aria-label="Home" className="flex items-center gap-3 overflow-hidden">
+        <Link to="/" onClick={scrollReportToTop} aria-label="Home" className="flex items-center gap-3 overflow-hidden">
           <span className="sr-only">Maester Logo (go home)</span>
           <img
             src={maesterLogo}
@@ -254,6 +258,7 @@ export function Sidebar() {
           label="Home"
           isActive={pathname === "/"}
           isCollapsed={isCollapsed}
+          onClick={scrollReportToTop}
         />
 
         <NavGroup

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -203,6 +203,10 @@ export default function TestResultsTable(props) {
 
     if (!linkedResultIsVisible) return;
 
+    // Consume the anchor immediately so that subsequent user-driven filter or
+    // sort changes do not re-scroll and re-open the flyout.
+    setLinkedAnchorId(null);
+
     window.requestAnimationFrame(() => {
       document.getElementById(linkedAnchorId)?.scrollIntoView({
         behavior: "smooth",

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback, lazy, Suspense, useMemo } from "react";
 import { Flex, Card, Table, TableRow, TableCell, TableHead, TableHeaderCell, TableBody, MultiSelect, MultiSelectItem, TextInput } from "@tremor/react";
 import StatusLabel from "./StatusLabel";
 import SeverityBadge from "./SeverityBadge";
@@ -35,6 +35,7 @@ export default function TestResultsTable(props) {
   const [selectedItem, setSelectedItem] = useState(null);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [linkedAnchorId, setLinkedAnchorId] = useState(null);
+  const lastRelaxedLinkedAnchorId = useRef(null);
   const testResults = props.TestResults;
   const linkedTestResultId = useMemo(() => getLinkedTestResultId(location), [location]);
   const linkedTestResult = useMemo(() => {
@@ -84,6 +85,9 @@ export default function TestResultsTable(props) {
 
     const anchorId = getTestResultAnchorId(linkedTestResult);
     if (!anchorId) return;
+    if (lastRelaxedLinkedAnchorId.current === anchorId) return;
+
+    lastRelaxedLinkedAnchorId.current = anchorId;
 
     setLinkedAnchorId(anchorId);
 

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -3,12 +3,24 @@ import { Flex, Card, Table, TableRow, TableCell, TableHead, TableHeaderCell, Tab
 import StatusLabel from "./StatusLabel";
 import SeverityBadge from "./SeverityBadge";
 import { ArrowDownIcon, ArrowUpIcon, MagnifyingGlassIcon } from "@heroicons/react/24/solid";
+import { useLocation, useNavigate } from "react-router-dom";
+import { getLinkedTestResultId, getTestResultAnchorHash, getTestResultAnchorId } from "@/lib/reportLinks";
 
 // Lazy load the ResultInfoSheet component
 const ResultInfoSheet = lazy(() => import("./ResultInfoSheet"));
+const defaultSelectedStatus = ['Passed', 'Failed', 'Skipped', 'Investigate', 'NotRun', 'Error'];
+
+function testMatchesSearch(item, searchQuery) {
+  if (!searchQuery) return true;
+
+  const normalizedSearchQuery = searchQuery.toLowerCase();
+  return (item.Id && item.Id.toLowerCase().includes(normalizedSearchQuery)) ||
+    (item.Title && item.Title.toLowerCase().includes(normalizedSearchQuery));
+}
 
 export default function TestResultsTable(props) {
-  const defaultSelectedStatus = ['Passed', 'Failed', 'Skipped', 'Investigate', 'NotRun', 'Error'];
+  const location = useLocation();
+  const navigate = useNavigate();
   const [internalSelectedStatus, setInternalSelectedStatus] = useState(
     props.selectedStatus ?? defaultSelectedStatus
   );
@@ -22,12 +34,31 @@ export default function TestResultsTable(props) {
   const [sortDirection, setSortDirection] = useState("asc");
   const [selectedItem, setSelectedItem] = useState(null);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [linkedAnchorId, setLinkedAnchorId] = useState(null);
   const testResults = props.TestResults;
+  const linkedTestResultId = useMemo(() => getLinkedTestResultId(location), [location]);
+  const linkedTestResult = useMemo(() => {
+    if (!linkedTestResultId) return null;
+    return testResults.Tests.find((item) => getTestResultAnchorId(item) === linkedTestResultId) ?? null;
+  }, [linkedTestResultId, testResults.Tests]);
 
   const handleOpenSheet = useCallback((item) => {
     setSelectedItem(item);
     setIsSheetOpen(true);
   }, []);
+
+  const handleOpenLinkedSheet = useCallback((item) => {
+    const anchorId = getTestResultAnchorId(item);
+
+    if (anchorId) {
+      navigate({
+        pathname: "/",
+        hash: getTestResultAnchorHash(anchorId),
+      });
+    }
+
+    handleOpenSheet(item);
+  }, [handleOpenSheet, navigate]);
 
   const handleCloseSheet = useCallback(() => {
     setIsSheetOpen(false);
@@ -35,9 +66,7 @@ export default function TestResultsTable(props) {
   }, []);
 
   const isStatusSelected = useCallback((item) => {
-    const matchesSearch = !searchQuery ||
-      (item.Id && item.Id.toLowerCase().includes(searchQuery.toLowerCase())) ||
-      (item.Title && item.Title.toLowerCase().includes(searchQuery.toLowerCase()));
+    const matchesSearch = testMatchesSearch(item, searchQuery);
 
     const matchesSeverity = selectedSeverity.length === 0 ||
       selectedSeverity.includes(item.Severity) ||
@@ -49,6 +78,55 @@ export default function TestResultsTable(props) {
       matchesSeverity &&
       matchesSearch;
   }, [searchQuery, selectedStatus, selectedBlock, selectedTag, selectedSeverity]);
+
+  useEffect(() => {
+    if (!linkedTestResult || props.isPrintView) return;
+
+    const anchorId = getTestResultAnchorId(linkedTestResult);
+    if (!anchorId) return;
+
+    setLinkedAnchorId(anchorId);
+
+    if (!location.hash) {
+      navigate({
+        pathname: "/",
+        hash: getTestResultAnchorHash(anchorId),
+      }, { replace: true });
+    }
+
+    if (linkedTestResult.Result && selectedStatus.length > 0 && !selectedStatus.includes(linkedTestResult.Result)) {
+      setSelectedStatus([...selectedStatus, linkedTestResult.Result]);
+    }
+
+    if (selectedBlock.length > 0 && !selectedBlock.includes(linkedTestResult.Block)) {
+      setSelectedBlock([]);
+    }
+
+    const linkedTags = linkedTestResult.Tag || [];
+    if (selectedTag.length > 0 && !linkedTags.some((tag) => selectedTag.includes(tag))) {
+      setSelectedTag([]);
+    }
+
+    const linkedSeverity = linkedTestResult.Severity || "None";
+    if (selectedSeverity.length > 0 && !selectedSeverity.includes(linkedSeverity)) {
+      setSelectedSeverity([]);
+    }
+
+    if (searchQuery && !testMatchesSearch(linkedTestResult, searchQuery)) {
+      setSearchQuery("");
+    }
+  }, [
+    linkedTestResult,
+    location.hash,
+    navigate,
+    props.isPrintView,
+    searchQuery,
+    selectedBlock,
+    selectedSeverity,
+    selectedStatus,
+    selectedTag,
+    setSelectedStatus,
+  ]);
 
   const handleSort = (column) => {
     if (sortColumn === column) {
@@ -116,6 +194,24 @@ export default function TestResultsTable(props) {
     }
   }, [selectedItem, filteredSortedData]);
 
+  useEffect(() => {
+    if (!linkedAnchorId || !linkedTestResult || props.isPrintView) return;
+
+    const linkedResultIsVisible = filteredSortedData.some(
+      (item) => getTestResultAnchorId(item) === linkedAnchorId
+    );
+
+    if (!linkedResultIsVisible) return;
+
+    window.requestAnimationFrame(() => {
+      document.getElementById(linkedAnchorId)?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+      handleOpenSheet(linkedTestResult);
+    });
+  }, [filteredSortedData, handleOpenSheet, linkedAnchorId, linkedTestResult, props.isPrintView]);
+
   const handleNavigateToNext = useCallback(() => {
     if (currentFilteredIndex === -1 || currentFilteredIndex >= filteredSortedData.length - 1) {
       return;
@@ -162,6 +258,7 @@ export default function TestResultsTable(props) {
             <TextInput
               icon={MagnifyingGlassIcon}
               placeholder="Search by ID or Title..."
+              value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="w-1/3"
             />
@@ -249,8 +346,9 @@ export default function TestResultsTable(props) {
 
             return (<TableRow
               key={`${item.Index}-${item.Id || index}`}
-              className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
-              onClick={() => !props.isPrintView && handleOpenSheet(item)}
+              id={getTestResultAnchorId(item)}
+              className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer scroll-mt-4"
+              onClick={() => !props.isPrintView && handleOpenLinkedSheet(item)}
             >
               <TableCell className="text-xs text-zinc-600 dark:text-zinc-300 whitespace-nowrap max-w-[12rem]">
                 {props.isPrintView ? (

--- a/report/src/components/TestResultsTable.jsx
+++ b/report/src/components/TestResultsTable.jsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef, useCallback, lazy, Suspense, useMemo } from "react";
-import { Flex, Card, Table, TableRow, TableCell, TableHead, TableHeaderCell, TableBody, MultiSelect, MultiSelectItem, TextInput, Grid, Button } from "@tremor/react";
+import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from "react";
+import { Flex, Card, Table, TableRow, TableCell, TableHead, TableHeaderCell, TableBody, MultiSelect, MultiSelectItem, TextInput } from "@tremor/react";
 import StatusLabel from "./StatusLabel";
 import SeverityBadge from "./SeverityBadge";
 import { ArrowDownIcon, ArrowUpIcon, MagnifyingGlassIcon } from "@heroicons/react/24/solid";
 import { useLocation, useNavigate } from "react-router-dom";
-import { getLinkedTestResultId, getTestResultAnchorHash, getTestResultAnchorId } from "@/lib/reportLinks";
+import { getLinkedTestResultId, getPreferredScrollBehavior, getTestResultAnchorHash, getTestResultAnchorId } from "@/lib/reportLinks";
 
 // Lazy load the ResultInfoSheet component
 const ResultInfoSheet = lazy(() => import("./ResultInfoSheet"));
@@ -74,7 +74,7 @@ export default function TestResultsTable(props) {
 
     return (selectedStatus.length === 0 || selectedStatus.includes(item.Result)) &&
       (selectedBlock.length === 0 || selectedBlock.includes(item.Block)) &&
-      (selectedTag.length === 0 || item.Tag.some(tag => selectedTag.includes(tag))) &&
+      (selectedTag.length === 0 || (item.Tag || []).some(tag => selectedTag.includes(tag))) &&
       matchesSeverity &&
       matchesSearch;
   }, [searchQuery, selectedStatus, selectedBlock, selectedTag, selectedSeverity]);
@@ -209,7 +209,7 @@ export default function TestResultsTable(props) {
 
     window.requestAnimationFrame(() => {
       document.getElementById(linkedAnchorId)?.scrollIntoView({
-        behavior: "smooth",
+        behavior: getPreferredScrollBehavior(),
         block: "center",
       });
       handleOpenSheet(linkedTestResult);

--- a/report/src/lib/reportLinks.ts
+++ b/report/src/lib/reportLinks.ts
@@ -16,7 +16,9 @@ function safeDecodeURIComponent(value: string) {
 
 export function getTestResultAnchorId(testResult: { Id?: unknown } | null | undefined) {
   const id = typeof testResult?.Id === "string" ? testResult.Id.trim() : ""
-  return id || undefined
+  // HTML id values must not contain whitespace; replace any interior spaces so
+  // getElementById and URL fragments remain reliable for non-standard test IDs.
+  return id ? id.replace(/\s+/g, "-") : undefined
 }
 
 export function getTestResultAnchorHash(anchorId: string) {

--- a/report/src/lib/reportLinks.ts
+++ b/report/src/lib/reportLinks.ts
@@ -25,12 +25,16 @@ export function getTestResultAnchorHash(anchorId: string) {
   return `#${encodeURIComponent(anchorId)}`
 }
 
+export function getPreferredScrollBehavior(): ScrollBehavior {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth"
+}
+
 export function getLinkedTestResultId(location: ReportLocation) {
   if (location.hash.length > 1) {
     return safeDecodeURIComponent(location.hash.slice(1))
   }
 
-  const path = location.pathname.replace(/^\/+/, "")
+  const path = location.pathname.replace(/^\/+|\/+$/g, "")
 
   if (!path || knownReportPaths.has(path) || path.startsWith("view/")) {
     return undefined
@@ -42,6 +46,6 @@ export function getLinkedTestResultId(location: ReportLocation) {
 export function scrollReportToTop() {
   document.getElementById(reportMainElementId)?.scrollTo({
     top: 0,
-    behavior: "smooth",
+    behavior: getPreferredScrollBehavior(),
   })
 }

--- a/report/src/lib/reportLinks.ts
+++ b/report/src/lib/reportLinks.ts
@@ -1,0 +1,45 @@
+type ReportLocation = {
+  pathname: string
+  hash: string
+}
+
+const knownReportPaths = new Set(["", "settings", "system", "config"])
+export const reportMainElementId = "report-main"
+
+function safeDecodeURIComponent(value: string) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export function getTestResultAnchorId(testResult: { Id?: unknown } | null | undefined) {
+  const id = typeof testResult?.Id === "string" ? testResult.Id.trim() : ""
+  return id || undefined
+}
+
+export function getTestResultAnchorHash(anchorId: string) {
+  return `#${encodeURIComponent(anchorId)}`
+}
+
+export function getLinkedTestResultId(location: ReportLocation) {
+  if (location.hash.length > 1) {
+    return safeDecodeURIComponent(location.hash.slice(1))
+  }
+
+  const path = location.pathname.replace(/^\/+/, "")
+
+  if (!path || knownReportPaths.has(path) || path.startsWith("view/")) {
+    return undefined
+  }
+
+  return safeDecodeURIComponent(path)
+}
+
+export function scrollReportToTop() {
+  document.getElementById(reportMainElementId)?.scrollTo({
+    top: 0,
+    behavior: "smooth",
+  })
+}


### PR DESCRIPTION
## Summary

Resolves #1677

Adds support for sharing a direct URL to any individual test result in the Maester HTML report. The anchor is placed on the `<tr>` row element rather than on a cell, which means:

- No visible underlined hyperlink text is introduced
- The existing row-click flyout behavior is fully preserved
- The browser scrolls to the correct position (the full row) rather than to a cell offset

## How it works

**URL formats supported**

The report uses React Router's `HashRouter`, so the URL generated when a user opens a row uses a router hash plus an inner fragment:

```
Report.html#/#AZDO.1001
```

Path-style direct links are also supported for manually authored URLs:

```
Report.html#/AZDO.1001
```

Both formats navigate directly to test `AZDO.1001`.

**On page load with a direct link**
1. The report resolves the linked test result by its `Id`
2. If any active filter (Status, Severity, Category, Tag) or search query would hide the result, that filter is relaxed so the result is always visible
3. The row is scrolled into view and the details flyout opens automatically

**On row click**
- The URL is updated to the HashRouter-safe `#/#<test-id>` format so the current result is immediately bookmarkable and shareable

**Filter behaviour**
- If the linked result passes all current filters, nothing changes — the URL just updates
- If a filter would hide it, the report clears/expands only the blocking filter(s), leaving unaffected filters in place

## Additional fix

The **Home** links (sidebar nav item, Maester logo, breadcrumb) now explicitly scroll the report's main container back to the top when clicked, even when already on the homepage (where the router sees no route change and `ScrollToTop` does not fire).

## Files changed

| File | Change |
|---|---|
| `report/src/lib/reportLinks.ts` | New shared helpers: anchor id/hash, linked result resolver, `scrollReportToTop` |
| `report/src/components/TestResultsTable.jsx` | Row `id` attribute, linked-result auto-scroll + flyout, filter relaxation, controlled search input, URL hash update on click |
| `report/src/components/ResultInfo.jsx` | Remove duplicate `id` in interactive mode (print view keeps its own anchor) |
| `report/src/App.tsx` | Wire `id` to `<main>` for scroll target; add catch-all route for path-style links |
| `report/src/components/Breadcrumb.tsx` | Call `scrollReportToTop` on Home link click |
| `report/src/components/Sidebar.tsx` | Call `scrollReportToTop` on logo and Home nav item click |

## Not affected

- Excel export (`/view/excel`)
- Markdown export (`/view/markdown`)
- Print view (`/view/print`)
- PowerShell report generation pipeline
