### PR TITLE
Fix for #1609 - AZDO tests not skipping

### DIFF
--- a/build/Build-MaesterModule.ps1
+++ b/build/Build-MaesterModule.ps1
@@ -408,6 +408,7 @@ $__MtSession = @{
     ExoCache = @{}
     OrcaCache = @{}
     AIAgentInfo = $null
+    AzureDevOpsConnection = $null
     DataverseApiBase = $null       # Resolved Dataverse OData API base URL (e.g. https://org123.api.crm.dynamics.com/api/data/v9.2)
     DataverseResourceUrl = $null   # Dataverse resource URL for token acquisition (e.g. https://org123.crm.dynamics.com)
     DataverseEnvironmentId = $null # Environment identifier for display (e.g. org123.crm.dynamics.com)

--- a/powershell/internal/Clear-ModuleVariable.ps1
+++ b/powershell/internal/Clear-ModuleVariable.ps1
@@ -20,5 +20,6 @@
     Clear-MtDnsCache
     Clear-MtExoCache
     $__MtSession.AIAgentInfo = $null
+    $__MtSession.AzureDevOpsConnection = $null
     # $__MtSession.Connections = @() # Do not clear connections as they are used to track the connection state. This module variable should only be set by Connect-Maester and Disconnect-Maester.
 }

--- a/powershell/internal/Get-MtSkippedReason.ps1
+++ b/powershell/internal/Get-MtSkippedReason.ps1
@@ -13,6 +13,7 @@
         "NotConnectedExchange" { "Not connected to Exchange Online. See [Connecting to Exchange Online](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
         "NotConnectedSecurityCompliance" { "Not connected to Security & Compliance. See [Connecting to Security & Compliance](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
         "NotConnectedTeams" { "Not connected to Teams. See [Connecting to Teams](https://maester.dev/docs/connect-maester/#connect-to-azure-exchange-online-and-teams)"; break}
+        "NotConnectedAzureDevOps" { "Not connected to Azure DevOps. See [Connecting to Azure DevOps](https://maester.dev/docs/connect-maester/#connect-to-azure-devops-optional)"; break}
         "NotConnectedGraph" { "Not connected to Graph. See [Connect-Maester](https://maester.dev/docs/commands/Connect-Maester#examples)"; break}
         "NotDotGovDomain" { "This test is only for federal, executive branch, departments and agencies. To override use [Test-MtCisaDmarcAggregateCisa -Force](https://maester.dev/docs/commands/Test-MtCisaDmarcAggregateCisa)"; break}
         "NotLicensedEntraIDP1" { "This test is for tenants that are licensed for Entra ID P1. See [Entra ID licensing](https://learn.microsoft.com/entra/fundamentals/licensing)"; break}

--- a/powershell/public/core/Test-MtConnection.ps1
+++ b/powershell/public/core/Test-MtConnection.ps1
@@ -7,7 +7,7 @@
     Tests the connection for each service and returns $true if the session is connected to the specified service.
 
     .PARAMETER Service
-    The service to check the connection for. Valid values are 'All', 'Azure', 'ExchangeOnline', 'Graph', 'SecurityCompliance' (or 'EOP'), and 'Teams'. Default is 'All'.
+    The service to check the connection for. Valid values are 'All', 'Azure', 'AzureDevOps', 'ExchangeOnline', 'Graph', 'SecurityCompliance' (or 'EOP'), and 'Teams'. Default is 'All'.
 
     .PARAMETER Details
     Return the full details of all connections instead of just a boolean value.
@@ -35,7 +35,7 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', 'AvoidUsingWriteHost', Justification = 'Sending colorful output to host in addition to rich object output.')]
     param(
         # Checks if the current session is connected to the specified service
-        [ValidateSet('All', 'Azure', 'ExchangeOnline', 'EOP', 'Graph', 'SecurityCompliance', 'Teams')]
+        [ValidateSet('All', 'Azure', 'AzureDevOps', 'ExchangeOnline', 'EOP', 'Graph', 'SecurityCompliance', 'Teams')]
         [Parameter(Position = 0)]
         [string[]]$Service = 'Graph',
 
@@ -48,6 +48,7 @@
         $MtConnections = [PSCustomObject]@{
             PSTypeName  = 'Maester.Connections'
             Azure = $null
+            AzureDevOps = $null
             Graph = $null
             ExchangeOnline = $null
             ExchangeOnlineProtection = $null
@@ -145,6 +146,40 @@
             if (!$IsConnected) { $ConnectionState = $false }
         }
         #endregion Teams
+
+        #region AzureDevOps
+        if ($Service -contains 'AzureDevOps' -or $Service -contains 'All') {
+            $IsConnected = $false
+            if ($null -ne $__MtSession.AzureDevOpsConnection) {
+                # Use cached probe result to avoid re-running the connection check on every test.
+                if ($__MtSession.AzureDevOpsConnection -is [string] -and $__MtSession.AzureDevOpsConnection -eq 'NotConnected') {
+                    $IsConnected = $false
+                } else {
+                    $MtConnections.AzureDevOps = $__MtSession.AzureDevOpsConnection
+                    $IsConnected = $true
+                }
+            } else {
+                try {
+                    if ($null -ne (Get-Command -Name Get-ADOPSConnection -ErrorAction Stop)) {
+                        $connection = Get-ADOPSConnection
+                        if ($null -ne $connection -and $null -ne $connection['Organization']) {
+                            $MtConnections.AzureDevOps = $connection
+                            $__MtSession.AzureDevOpsConnection = $connection
+                            $IsConnected = $true
+                        }
+                    }
+                } catch {
+                    Write-Debug "AzureDevOps: $false"
+                }
+                if (-not $IsConnected) {
+                    # Cache negative result so subsequent calls skip the probe.
+                    $__MtSession.AzureDevOpsConnection = 'NotConnected'
+                }
+            }
+            Write-Verbose "AzureDevOps: $IsConnected"
+            if (!$IsConnected) { $ConnectionState = $false }
+        }
+        #endregion AzureDevOps
 
         if ($IsConnected) {
             $MtConnections.AllConnected = $true

--- a/powershell/public/core/Test-MtConnection.ps1
+++ b/powershell/public/core/Test-MtConnection.ps1
@@ -7,7 +7,7 @@
     Tests the connection for each service and returns $true if the session is connected to the specified service.
 
     .PARAMETER Service
-    The service to check the connection for. Valid values are 'All', 'Azure', 'AzureDevOps', 'ExchangeOnline', 'Graph', 'SecurityCompliance' (or 'EOP'), and 'Teams'. Default is 'All'.
+    The service to check the connection for. Valid values are 'All', 'Azure', 'AzureDevOps', 'ExchangeOnline', 'Graph', 'SecurityCompliance' (or 'EOP'), and 'Teams'. Default is 'Graph'.
 
     .PARAMETER Details
     Return the full details of all connections instead of just a boolean value.
@@ -18,7 +18,7 @@
     Checks if the current session is connected to all services including Azure, Microsoft Graph, Exchange Online, Exchange Online Protection (SecurityCompliance), and Microsoft Teams. Returns a Boolean value.
 
     .EXAMPLE
-    Test-MtConnection -Details
+    Test-MtConnection -Service All -Details
 
     Checks if the current session is connected to all services including Azure, Microsoft Graph, Exchange Online, Exchange Online Protection (SecurityCompliance), and Microsoft Teams. Returns a custom object that contains the connection details for all services.
 
@@ -181,9 +181,7 @@
         }
         #endregion AzureDevOps
 
-        if ($IsConnected) {
-            $MtConnections.AllConnected = $true
-        }
+        $MtConnections.AllConnected = $ConnectionState
 
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowExtensionsLocalNetworkAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowExtensionsLocalNetworkAccess.ps1
@@ -22,6 +22,8 @@ function Test-AzdoAllowExtensionsLocalNetworkAccess {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoAllowExtensionsLocalNetworkAccess"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowExtensionsLocalNetworkAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowExtensionsLocalNetworkAccess.ps1
@@ -22,9 +22,8 @@ function Test-AzdoAllowExtensionsLocalNetworkAccess {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowExtensionsLocalNetworkAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowExtensionsLocalNetworkAccess.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowRequestAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowRequestAccessToken.ps1
@@ -25,6 +25,8 @@ function Test-AzdoAllowRequestAccessToken {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoAllowRequestAccessToken"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowRequestAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowRequestAccessToken.ps1
@@ -25,9 +25,8 @@ function Test-AzdoAllowRequestAccessToken {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowRequestAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowRequestAccessToken.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowTeamAdminsInvitationsAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowTeamAdminsInvitationsAccessToken.ps1
@@ -26,9 +26,8 @@ function Test-AzdoAllowTeamAdminsInvitationsAccessToken {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowTeamAdminsInvitationsAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowTeamAdminsInvitationsAccessToken.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAllowTeamAdminsInvitationsAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAllowTeamAdminsInvitationsAccessToken.ps1
@@ -26,6 +26,8 @@ function Test-AzdoAllowTeamAdminsInvitationsAccessToken {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoAllowTeamAdminsInvitationsAccessToken"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoArtifactsExternalPackageProtectionToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoArtifactsExternalPackageProtectionToken.ps1
@@ -25,9 +25,8 @@ function Test-AzdoArtifactsExternalPackageProtectionToken {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoArtifactsExternalPackageProtectionToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoArtifactsExternalPackageProtectionToken.ps1
@@ -25,6 +25,8 @@ function Test-AzdoArtifactsExternalPackageProtectionToken {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoArtifactsExternalPackageProtectionToken"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoArtifactsExternalPackageProtectionToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoArtifactsExternalPackageProtectionToken.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAuditStream.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAuditStream.ps1
@@ -26,9 +26,8 @@ function Test-AzdoAuditStream {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoAuditStream.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAuditStream.ps1
@@ -26,6 +26,8 @@ function Test-AzdoAuditStream {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoAuditStream"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoAuditStream.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoAuditStream.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoDisableGlobalPATCreation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoDisableGlobalPATCreation.ps1
@@ -27,6 +27,8 @@ function Test-AzdoDisableGlobalPATCreation {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoDisableGlobalPATCreation"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoDisableGlobalPATCreation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoDisableGlobalPATCreation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 
@@ -48,7 +48,7 @@ function Test-AzdoDisableGlobalPATCreation {
         else {
             $resultMarkdown = "Your tenant does not have Global Personal Access Token creation disabled."
         }
-    
+
         Add-MtTestResultDetail -Result $resultMarkdown
         return $result
     }

--- a/powershell/public/maester/azuredevops/Test-AzdoDisableGlobalPATCreation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoDisableGlobalPATCreation.ps1
@@ -27,9 +27,8 @@ function Test-AzdoDisableGlobalPATCreation {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoDisablePATCreation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoDisablePATCreation.ps1
@@ -22,6 +22,8 @@ function Test-AzdoDisablePATCreation {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoDisablePATCreation"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoDisablePATCreation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoDisablePATCreation.ps1
@@ -22,9 +22,8 @@ function Test-AzdoDisablePATCreation {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoDisablePATCreation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoDisablePATCreation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation.ps1
@@ -27,6 +27,8 @@ function Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 
@@ -48,9 +48,9 @@ function Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation {
         else {
             $resultMarkdown = "Your tenant does not have leaked Personal Access Token auto-revocation enabled."
         }
-    
+
         Add-MtTestResultDetail -Result $resultMarkdown
-    
+
         return $result
     }
 }

--- a/powershell/public/maester/azuredevops/Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation.ps1
@@ -27,9 +27,8 @@ function Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoEnforceAADConditionalAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoEnforceAADConditionalAccess.ps1
@@ -23,6 +23,8 @@ function Test-AzdoEnforceAADConditionalAccess {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoEnforceAADConditionalAccess"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoEnforceAADConditionalAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoEnforceAADConditionalAccess.ps1
@@ -23,9 +23,8 @@ function Test-AzdoEnforceAADConditionalAccess {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoEnforceAADConditionalAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoEnforceAADConditionalAccess.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoExternalGuestAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoExternalGuestAccess.ps1
@@ -22,6 +22,8 @@ function Test-AzdoExternalGuestAccess {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoExternalGuestAccess"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoExternalGuestAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoExternalGuestAccess.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoExternalGuestAccess.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoExternalGuestAccess.ps1
@@ -22,9 +22,8 @@ function Test-AzdoExternalGuestAccess {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoFeedbackCollection.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoFeedbackCollection.ps1
@@ -24,6 +24,8 @@ function Test-AzdoFeedbackCollection {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoFeedbackCollection"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoFeedbackCollection.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoFeedbackCollection.ps1
@@ -24,9 +24,8 @@ function Test-AzdoFeedbackCollection {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoFeedbackCollection.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoFeedbackCollection.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoLogAuditEvent.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoLogAuditEvent.ps1
@@ -25,9 +25,8 @@ function Test-AzdoLogAuditEvent {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoLogAuditEvent.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoLogAuditEvent.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoLogAuditEvent.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoLogAuditEvent.ps1
@@ -25,6 +25,8 @@ function Test-AzdoLogAuditEvent {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoLogAuditEvent"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
     $result = (Get-ADOPSOrganizationAdvancedSecurity).enableOnCreate

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationBadgesArePrivate.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationBadgesArePrivate.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationBadgesArePrivate {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationBadgesArePrivate"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationBadgesArePrivate.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationBadgesArePrivate.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationBadgesArePrivate {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationBadgesArePrivate.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationBadgesArePrivate.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicBuildPipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicBuildPipeline.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationCreationClassicBuildPipeline {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicBuildPipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicBuildPipeline.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationCreationClassicBuildPipeline {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationCreationClassicBuildPipeline"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicBuildPipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicBuildPipeline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicReleasePipeline.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationCreationClassicReleasePipeline {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationCreationClassicReleasePipeline"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicReleasePipeline.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationCreationClassicReleasePipeline {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationClassicReleasePipeline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationRestriction.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationRestriction.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 
@@ -47,9 +47,9 @@ function Test-AzdoOrganizationCreationRestriction {
         else {
             $resultMarkdown = "Your tenant does not have organization creation restricted."
         }
-    
+
         Add-MtTestResultDetail -Result $resultMarkdown
-    
+
         return $result
     }
 }

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationRestriction.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationRestriction.ps1
@@ -27,9 +27,8 @@ function Test-AzdoOrganizationCreationRestriction {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationRestriction.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationCreationRestriction.ps1
@@ -27,6 +27,8 @@ function Test-AzdoOrganizationCreationRestriction {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationCreationRestriction"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitVariablesAtQueueTime.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitVariablesAtQueueTime.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationLimitVariablesAtQueueTime {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationLimitVariablesAtQueueTime"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitVariablesAtQueueTime.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitVariablesAtQueueTime.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationLimitVariablesAtQueueTime {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitVariablesAtQueueTime.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationLimitVariablesAtQueueTime.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationOwner.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationOwner.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationOwner {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationOwner.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationOwner.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationOwner {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationOwner"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationOwner.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationOwner.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationProtectAccessToRepository.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationProtectAccessToRepository.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationProtectAccessToRepository {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationProtectAccessToRepository"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationProtectAccessToRepository.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationProtectAccessToRepository.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationProtectAccessToRepository {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationProtectAccessToRepository.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationProtectAccessToRepository.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsGravatarImage.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsGravatarImage.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationRepositorySettingsGravatarImage {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsGravatarImage.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsGravatarImage.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationRepositorySettingsGravatarImage {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationRepositorySettingsGravatarImage"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsGravatarImage.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationRepositorySettingsGravatarImage.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationStageChooser.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationStageChooser.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationStageChooser {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationStageChooser.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationStageChooser.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationStageChooser {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationStageChooser"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationStageChooser.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationStageChooser.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationStorageUsage.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationStorageUsage.ps1
@@ -26,9 +26,8 @@ function Test-AzdoOrganizationStorageUsage {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationStorageUsage.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationStorageUsage.ps1
@@ -26,6 +26,8 @@ function Test-AzdoOrganizationStorageUsage {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationStorageUsage"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationStorageUsage.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationStorageUsage.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableNode6Task.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableNode6Task.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationTaskRestrictionsDisableNode6Task {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationTaskRestrictionsDisableNode6Task"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableNode6Task.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableNode6Task.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationTaskRestrictionsDisableNode6Task {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableNode6Task.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsDisableNode6Task.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation.ps1
@@ -23,9 +23,8 @@ function Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation.ps1
@@ -23,6 +23,8 @@ function Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTriggerPullRequestGitHubRepository.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTriggerPullRequestGitHubRepository.ps1
@@ -22,6 +22,8 @@ function Test-AzdoOrganizationTriggerPullRequestGitHubRepository {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoOrganizationTriggerPullRequestGitHubRepository"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTriggerPullRequestGitHubRepository.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTriggerPullRequestGitHubRepository.ps1
@@ -22,9 +22,8 @@ function Test-AzdoOrganizationTriggerPullRequestGitHubRepository {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoOrganizationTriggerPullRequestGitHubRepository.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoOrganizationTriggerPullRequestGitHubRepository.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoProjectCollectionAdministrator.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoProjectCollectionAdministrator.ps1
@@ -22,6 +22,8 @@ function Test-AzdoProjectCollectionAdministrator {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoProjectCollectionAdministrator"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoProjectCollectionAdministrator.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoProjectCollectionAdministrator.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a list of all Project Collection Administrators.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoProjectCollectionAdministrator.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoProjectCollectionAdministrator.ps1
@@ -22,9 +22,8 @@ function Test-AzdoProjectCollectionAdministrator {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoPublicProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoPublicProject.ps1
@@ -23,9 +23,8 @@ function Test-AzdoPublicProject {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoPublicProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoPublicProject.ps1
@@ -23,6 +23,8 @@ function Test-AzdoPublicProject {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoPublicProject"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoPublicProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoPublicProject.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoResourceUsageProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoResourceUsageProject.ps1
@@ -22,9 +22,8 @@ function Test-AzdoResourceUsageProject {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoResourceUsageProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoResourceUsageProject.ps1
@@ -22,6 +22,8 @@ function Test-AzdoResourceUsageProject {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoResourceUsageProject"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoResourceUsageProject.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoResourceUsageProject.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoResourceUsageWorkItemTag.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoResourceUsageWorkItemTag.ps1
@@ -22,9 +22,8 @@ function Test-AzdoResourceUsageWorkItemTag {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoResourceUsageWorkItemTag.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoResourceUsageWorkItemTag.ps1
@@ -22,6 +22,8 @@ function Test-AzdoResourceUsageWorkItemTag {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoResourceUsageWorkItemTag"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoResourceUsageWorkItemTag.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoResourceUsageWorkItemTag.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoRestrictFullScopePersonalAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoRestrictFullScopePersonalAccessToken.ps1
@@ -24,6 +24,8 @@ function Test-AzdoRestrictFullScopePersonalAccessToken {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoRestrictFullScopePersonalAccessToken"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoRestrictFullScopePersonalAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoRestrictFullScopePersonalAccessToken.ps1
@@ -24,9 +24,8 @@ function Test-AzdoRestrictFullScopePersonalAccessToken {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoRestrictFullScopePersonalAccessToken.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoRestrictFullScopePersonalAccessToken.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 
@@ -44,9 +44,9 @@ function Test-AzdoRestrictFullScopePersonalAccessToken {
         else {
             $resultMarkdown = "Your tenant does not have Personal Access Token full scope restrictions enabled."
         }
-    
+
         Add-MtTestResultDetail -Result $resultMarkdown
-    
+
         return $result
     }
 }

--- a/powershell/public/maester/azuredevops/Test-AzdoRestrictPersonalAccessTokenLifespan.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoRestrictPersonalAccessTokenLifespan.ps1
@@ -24,6 +24,8 @@ function Test-AzdoRestrictPersonalAccessTokenLifespan {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoRestrictPersonalAccessTokenLifespan"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoRestrictPersonalAccessTokenLifespan.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoRestrictPersonalAccessTokenLifespan.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 
@@ -50,9 +50,9 @@ function Test-AzdoRestrictPersonalAccessTokenLifespan {
         else {
             $resultMarkdown = "Your tenant does not have Personal Access Token lifespan restrictions enabled."
         }
-    
+
         Add-MtTestResultDetail -Result $resultMarkdown
-    
+
         return $result
     }
 }

--- a/powershell/public/maester/azuredevops/Test-AzdoRestrictPersonalAccessTokenLifespan.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoRestrictPersonalAccessTokenLifespan.ps1
@@ -24,9 +24,8 @@ function Test-AzdoRestrictPersonalAccessTokenLifespan {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoSSHAuthentication.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoSSHAuthentication.ps1
@@ -23,6 +23,8 @@ function Test-AzdoSSHAuthentication {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoSSHAuthentication"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoSSHAuthentication.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoSSHAuthentication.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoSSHAuthentication.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoSSHAuthentication.ps1
@@ -23,9 +23,8 @@ function Test-AzdoSSHAuthentication {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoThirdPartyAccessViaOauth.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoThirdPartyAccessViaOauth.ps1
@@ -24,9 +24,8 @@ function Test-AzdoThirdPartyAccessViaOauth {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoThirdPartyAccessViaOauth.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoThirdPartyAccessViaOauth.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/powershell/public/maester/azuredevops/Test-AzdoThirdPartyAccessViaOauth.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoThirdPartyAccessViaOauth.ps1
@@ -24,6 +24,8 @@ function Test-AzdoThirdPartyAccessViaOauth {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoThirdPartyAccessViaOauth"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoValidateSshKeyExpiration.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoValidateSshKeyExpiration.ps1
@@ -24,9 +24,8 @@ function Test-AzdoValidateSshKeyExpiration {
     [OutputType([bool])]
     param()
 
-    if ($null -eq (Get-ADOPSConnection)['Organization']) {
-        Write-Verbose 'Not connected to Azure DevOps'
-        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
+    if (-not (Test-MtConnection AzureDevOps)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null
     }
 

--- a/powershell/public/maester/azuredevops/Test-AzdoValidateSshKeyExpiration.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoValidateSshKeyExpiration.ps1
@@ -24,6 +24,8 @@ function Test-AzdoValidateSshKeyExpiration {
     [OutputType([bool])]
     param()
 
+    Write-Verbose "Running Test-AzdoValidateSshKeyExpiration"
+
     if (-not (Test-MtConnection AzureDevOps)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
         return $null

--- a/powershell/public/maester/azuredevops/Test-AzdoValidateSshKeyExpiration.ps1
+++ b/powershell/public/maester/azuredevops/Test-AzdoValidateSshKeyExpiration.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns a boolean depending on the configuration.
 

--- a/tests/Maester/AzureDevOps/Test-Azdo.Tests.ps1
+++ b/tests/Maester/AzureDevOps/Test-Azdo.Tests.ps1
@@ -1,197 +1,275 @@
-Describe "Azure DevOps" -Tag "AZDO" {
+﻿Describe "Azure DevOps" -Tag "AZDO" {
 
     It "AZDO.1000: Azure DevOps OAuth apps can access resources in your organization through OAuth. See https://aka.ms/vstspolicyoauth" -Tag "AZDO.1000" {
         $result = Test-AzdoThirdPartyAccessViaOauth
-        $result | Should -Be $true -Because "Your tenant should restrict Azure DevOps OAuth apps from accessing resources in your organization through OAuth."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Your tenant should restrict Azure DevOps OAuth apps from accessing resources in your organization through OAuth."
+        }
     }
 
     It "AZDO.1001: Identities can connect to your organization's Git repos through SSH. See https://aka.ms/vstspolicyssh" -Tag "AZDO.1001" {
         $result = Test-AzdoSSHAuthentication
-        $result | Should -Be $true -Because "Authentication towards your tenant should only be by Entra, do not allow developers to connect to your Git repos through SSH on macOS, Linux, or Windows to connect with Azure DevOps"
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Authentication towards your tenant should only be by Entra, do not allow developers to connect to your Git repos through SSH on macOS, Linux, or Windows to connect with Azure DevOps"
+        }
     }
 
     It "AZDO.1002: Log Audit Events. See https://learn.microsoft.com/en-us/azure/devops/organizations/audit/azure-devops-auditing?view=azure-devops&tabs=preview-page#enable-and-disable-auditing" -Tag "AZDO.1002" {
         $result = Test-AzdoLogAuditEvent
-        $result | Should -Be $true -Because "Auditing should be enabled for Azure DevOps"
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Auditing should be enabled for Azure DevOps"
+        }
     }
 
     It "AZDO.1003: Restrict public projects. See https://aka.ms/vsts-anon-access" -Tag "AZDO.1003" {
         $result = Test-AzdoPublicProject
-        $result | Should -Be $false -Because "Public projects should be disabled for Azure DevOps"
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Public projects should be disabled for Azure DevOps"
+        }
     }
 
     It "AZDO.1004: Additional protections when using public package registries. See https://devblogs.microsoft.com/devops/changes-to-azure-artifact-upstream-behavior/" -Tag "AZDO.1004" {
         $result = Test-AzdoArtifactsExternalPackageProtectionToken
-        $result | Should -Be $true -Because "Limiting access to externally sourced packages when internally sourced packages are already present in Azure DevOps"
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Limiting access to externally sourced packages when internally sourced packages are already present in Azure DevOps"
+        }
     }
 
     It "AZDO.1005: IP Conditional Access policy validation. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/change-application-access-policies?view=azure-devops#cap-support-on-azure-devops" -Tag "AZDO.1005" {
         $result = Test-AzdoEnforceAADConditionalAccess
-        $result | Should -Be $true -Because "Microsoft Entra ID should always perform validation for any Conditional Access Policies (CAPs) set by tenant administrators."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Microsoft Entra ID should always perform validation for any Conditional Access Policies (CAPs) set by tenant administrators."
+        }
     }
 
     It "AZDO.1006: External Users access. See https://learn.microsoft.com/en-us/azure/devops/organizations/security/security-overview?view=azure-devops#manage-external-guest-access" -Tag "AZDO.1006" {
         $result = Test-AzdoExternalGuestAccess
-        $result | Should -Be $true -Because "External users should not be allowed access to your Azure DevOps organization"
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "External users should not be allowed access to your Azure DevOps organization"
+        }
     }
 
     It "AZDO.1007: Team and project administrator are allowed to invite new users. See https://aka.ms/azure-devops-invitations-policy" -Tag "AZDO.1007" {
         $result = Test-AzdoAllowTeamAdminsInvitationsAccessToken
-        $result | Should -Be $false -Because "Enrolling to your Azure DevOps organization should be a controlled process."
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Enrolling to your Azure DevOps organization should be a controlled process."
+        }
     }
 
     It "AZDO.1008: Request access to Azure DevOps by e-mail notifications to administrators. See https://go.microsoft.com/fwlink/?linkid=2113172" -Tag "AZDO.1008" {
         $result = Test-AzdoAllowRequestAccessToken
-        $result | Should -Be $false -Because "You should prevent users from requesting access to your organization or projects"
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "You should prevent users from requesting access to your organization or projects"
+        }
     }
 
     It "AZDO.1009: Feedback Collection. See https://aka.ms/ADOPrivacyPolicy" -Tag "AZDO.1009" {
         $result = Test-AzdoFeedbackCollection
-        $result | Should -Be $true -Because "You should have confidence that we're handling your data appropriately and for legitimate uses. Part of that assurance involves carefully restricting usage."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "You should have confidence that we're handling your data appropriately and for legitimate uses. Part of that assurance involves carefully restricting usage."
+        }
     }
 
     It "AZDO.1010: Audit streaming. See https://learn.microsoft.com/en-us/azure/devops/organizations/audit/auditing-streaming?view=azure-devops" -Tag "AZDO.1010" {
         $result = Test-AzdoAuditStream
-        $result | Should -Be $true -Because "Setting up a stream also allows you to store more than 90-days worth of auditing data."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Setting up a stream also allows you to store more than 90-days worth of auditing data."
+        }
     }
 
     It "AZDO.1011: Project Resource Limits. See https://learn.microsoft.com/en-us/azure/devops/organizations/projects/about-projects?view=azure-devops" -Tag "AZDO.1011" {
         $result = Test-AzdoResourceUsageProject
-        $result | Should -Be $true -Because "Azure DevOps supports up to 1,000 projects within an organization."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Azure DevOps supports up to 1,000 projects within an organization."
+        }
     }
 
     It "AZDO.1012: Work Items Tags Limits. See https://learn.microsoft.com/en-us/azure/devops/organizations/settings/work/object-limits?view=azure-devops" -Tag "AZDO.1012" {
         $result = Test-AzdoResourceUsageWorkItemTag
-        $result | Should -Be $true -Because "Azure DevOps supports up to 150,000 tag definitions per organization or collection."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Azure DevOps supports up to 150,000 tag definitions per organization or collection."
+        }
     }
 
     It "AZDO.1013: Organization Owner should not be an individual. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/change-organization-ownership?view=azure-devops" -Tag "AZDO.1013" {
         $result = Test-AzdoOrganizationOwner
-        $result | Should -Be $true -Because "Organization owners are automatically members of the 'Project Collection Administrators' group. As roles and responsibilities change, you can change the owner for your organization."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Organization owners are automatically members of the 'Project Collection Administrators' group. As roles and responsibilities change, you can change the owner for your organization."
+        }
     }
 
     It "AZDO.1014: Anonymous access to pipeline badges. See https://learn.microsoft.com/en-us/azure/devops/pipelines/create-first-pipeline?view=azure-devops&tabs=net%2Cbrowser#add-a-status-badge-to-your-repository" -Tag "AZDO.1014" {
         $result = Test-AzdoOrganizationBadgesArePrivate
-        $result | Should -Be $true -Because "Even in a private project, anonymous badge access is enabled by default. With anonymous badge access enabled, users outside your organization might be able to query information such as project names, branch names, job names, and build status through the badge status API."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Even in a private project, anonymous badge access is enabled by default. With anonymous badge access enabled, users outside your organization might be able to query information such as project names, branch names, job names, and build status through the badge status API."
+        }
     }
 
     It "AZDO.1015: Limit variables that can be set at queue time. See https://learn.microsoft.com/en-us/azure/devops/pipelines/security/inputs?view=azure-devops#limit-variables-that-can-be-set-at-queue-time" -Tag "AZDO.1015" {
         $result = Test-AzdoOrganizationLimitVariablesAtQueueTime
-        $result | Should -Be $true -Because "Only those variables explicitly marked as 'Settable at queue time' can be set. In other words, you can set any variables at queue time unless this setting is turned on."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Only those variables explicitly marked as 'Settable at queue time' can be set. In other words, you can set any variables at queue time unless this setting is turned on."
+        }
     }
 
     It "AZDO.1016: Limit job authorization scope to current project for non-release pipelines. See https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#job-authorization-scope" -Tag "AZDO.1016" {
         $result = Test-AzdoOrganizationLimitJobAuthorizationScopeNonReleasePipeline
-        $result | Should -Be $true -Because "With this option enabled, you can reduce the scope of access for all non-release pipelines to the current project."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "With this option enabled, you can reduce the scope of access for all non-release pipelines to the current project."
+        }
     }
 
     It "AZDO.1017: Limit job authorization scope to current project for classic release pipelines. See https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#job-authorization-scope" -Tag "AZDO.1017" {
         $result = Test-AzdoOrganizationLimitJobAuthorizationScopeReleasePipeline
-        $result | Should -Be $true -Because "With this option enabled, you can reduce the scope of access for all classic pipelines to the current project."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "With this option enabled, you can reduce the scope of access for all classic pipelines to the current project."
+        }
     }
 
     It "AZDO.1018: Protect access to repositories in YAML pipelines. See https://learn.microsoft.com/en-us/azure/devops/pipelines/security/overview?view=azure-devops#restrict-project-repository-and-service-connection-access" -Tag "AZDO.1018" {
         $result = Test-AzdoOrganizationProtectAccessToRepository
-        $result | Should -Be $true -Because "Apply checks and approvals when accessing repositories from YAML pipelines. Also, generate a job access token that is scoped to repositories that are explicitly referenced in the YAML pipeline."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Apply checks and approvals when accessing repositories from YAML pipelines. Also, generate a job access token that is scoped to repositories that are explicitly referenced in the YAML pipeline."
+        }
     }
 
     It "AZDO.1019: Stage chooser. See https://learn.microsoft.com/en-us/azure/devops/pipelines/security/overview?view=azure-devops" -Tag "AZDO.1019" {
         $result = Test-AzdoOrganizationStageChooser
-        $result | Should -Be $false -Because "Users should not be able to select stages to skip from the Queue Pipeline panel"
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Users should not be able to select stages to skip from the Queue Pipeline panel"
+        }
     }
 
     It "AZDO.1020: Creation of classic build pipelines. See https://devblogs.microsoft.com/devops/disable-creation-of-classic-pipelines/" -Tag "AZDO.1020" {
         $result = Test-AzdoOrganizationCreationClassicBuildPipeline
-        $result | Should -Be $false -Because "Creating classic build pipelines should not be allowed."
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Creating classic build pipelines should not be allowed."
+        }
     }
 
     It "AZDO.1021: Creation of classic release pipelines. See https://devblogs.microsoft.com/devops/disable-creation-of-classic-pipelines/" -Tag "AZDO.1021" {
         $result = Test-AzdoOrganizationCreationClassicReleasePipeline
-        $result | Should -Be $false -Because "Creating classic release pipelines should not be allowed."
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Creating classic release pipelines should not be allowed."
+        }
     }
 
     It "AZDO.1022: Limit building pull requests from forked GitHub repositories. See https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#validate-contributions-from-forks" -Tag "AZDO.1022" {
         $result = Test-AzdoOrganizationTriggerPullRequestGitHubRepository
-        $result | Should -Be $true -Because "Azure Pipelines can automatically build and validate every pull request and commit to your GitHub repository. This should be configured according to your organizations requirements."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Azure Pipelines can automatically build and validate every pull request and commit to your GitHub repository. This should be configured according to your organizations requirements."
+        }
     }
 
     It "AZDO.1023: Disable Marketplace tasks. See https://learn.microsoft.com/en-us/azure/devops/pipelines/security/overview?view=azure-devops#prevent-malicious-code-execution" -Tag "AZDO.1023" {
         $result = Test-AzdoOrganizationTaskRestrictionsDisableMarketplaceTask
-        $result | Should -Be $true -Because "Disable the ability to install and run tasks from the Marketplace, which gives you greater control over the code that executes in a pipeline."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Disable the ability to install and run tasks from the Marketplace, which gives you greater control over the code that executes in a pipeline."
+        }
     }
 
     It "AZDO.1024: Disable Node 6 tasks. See https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/2022/no-node-6-on-hosted-agents" -Tag "AZDO.1024" {
         $result = Test-AzdoOrganizationTaskRestrictionsDisableNode6Task
-        $result | Should -Be $true -Because "With this enabled, pipelines will fail if they utilize a task with a Node 6 execution handler."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "With this enabled, pipelines will fail if they utilize a task with a Node 6 execution handler."
+        }
     }
 
     It "AZDO.1025: Enable shell tasks arguments validation. See https://learn.microsoft.com/en-us/azure/devops/pipelines/security/inputs?view=azure-devops#shellTasksValidation" -Tag "AZDO.1025" {
         $result = Test-AzdoOrganizationTaskRestrictionsShellTaskArgumentValidation
-        $result | Should -Be $true -Because "When this is enabled, argument parameters for built-in shell tasks are validated to check for inputs that can inject commands into scripts."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "When this is enabled, argument parameters for built-in shell tasks are validated to check for inputs that can inject commands into scripts."
+        }
     }
 
     It "AZDO.1026: Enable automatic enrollment to Advanced Security for Azure DevOps. See https://learn.microsoft.com/en-us/azure/devops/repos/security/configure-github-advanced-security-features?view=azure-devops&tabs=yaml#organization-level-onboarding" -Tag "AZDO.1026" {
         $result = Test-AzdoOrganizationAutomaticEnrollmentAdvancedSecurityNewProject
-        $result | Should -Be $true -Because "Enable automatic enrollment for new git repositories to use GitHub Advanced Security for Azure DevOps. It adds GitHub Advanced Security's suite of security features to Azure Repos."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Enable automatic enrollment for new git repositories to use GitHub Advanced Security for Azure DevOps. It adds GitHub Advanced Security's suite of security features to Azure Repos."
+        }
     }
 
     It "AZDO.1027: Disable showing Gravatar images for users outside of your enterprise. See https://learn.microsoft.com/en-us/azure/devops/repos/git/repository-settings?view=azure-devops&tabs=browser#gravatar-images" -Tag "AZDO.1027" {
         $result = Test-AzdoOrganizationRepositorySettingsGravatarImage
-        $result | Should -Be $false -Because "Gravatar images should not be exposed outside of your enterprise."
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Gravatar images should not be exposed outside of your enterprise."
+        }
     }
 
     It "AZDO.1028: Disable creation of TFVC repositories. See https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/2024/no-tfvc-in-new-projects" -Tag "AZDO.1028" {
         $result = Test-AzdoOrganizationRepositorySettingsDisableCreationTFVCRepo
-        $result | Should -Be $true -Because "Team Foundation Version Control (TFVC) has been deprecated."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Team Foundation Version Control (TFVC) has been deprecated."
+        }
     }
 
     It "AZDO.1029: Storage Usage Limit. See https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/limits?view=azure-devops" -Tag "AZDO.1029" {
         $result = Test-AzdoOrganizationStorageUsage
-        $result | Should -Be $true -Because "Storage Usage Limit should not be reached."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Storage Usage Limit should not be reached."
+        }
     }
 
     It "AZDO.1030: Project Collection Administrators. See https://learn.microsoft.com/en-us/azure/devops/organizations/security/about-permissions?view=azure-devops&tabs=preview-page#permissions" -Tag "AZDO.1030" {
         $result = Test-AzdoProjectCollectionAdministrator
-        $result | Should -Be $true -Because "Users should not be directly assigned to 'Project Collection Administrator' as it is the most privileged role within Azure DevOps."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Users should not be directly assigned to 'Project Collection Administrator' as it is the most privileged role within Azure DevOps."
+        }
     }
 
     It "AZDO.1031: Validate SSH Key Expiration. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/change-application-access-policies?view=azure-devops#ssh-key-policies" -Tag "AZDO.1031" {
         $result = Test-AzdoValidateSshKeyExpiration
-        $result | Should -Be $true -Because "SSH keys should be validated for expiration."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "SSH keys should be validated for expiration."
+        }
     }
 
     It "AZDO.1032: (Tenant) Restrict creation of global Personal Access Tokens. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-pats-with-policies-for-administrators?view=azure-devops#restrict-creation-of-global-pats-tenant-policy" -Tag "AZDO.1032" {
         $result = Test-AzdoDisableGlobalPATCreation
-        $result | Should -Be $true -Because "Global Personal Access Tokens (PATs) should be restricted at the tenant level."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Global Personal Access Tokens (PATs) should be restricted at the tenant level."
+        }
     }
 
     It "AZDO.1033: (Tenant) Enable automatic revocation of leaked Personal Access Tokens. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-pats-with-policies-for-administrators?view=azure-devops#automatic-revocation-of-leaked-tokens" -Tag "AZDO.1033" {
         $result = Test-AzdoEnableLeakedPersonalAccessTokenAutoRevocation
-        $result | Should -Be $true -Because "Leaked Personal Access Tokens (PATs) should be automatically revoked at the tenant level."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Leaked Personal Access Tokens (PATs) should be automatically revoked at the tenant level."
+        }
     }
 
     It "AZDO.1034: (Tenant) Restrict creation of new Azure DevOps organizations. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation?view=azure-devops#turn-on-the-policy" -Tag "AZDO.1034" {
         $result = Test-AzdoOrganizationCreationRestriction
-        $result | Should -Be $true -Because "Organization creation should be restricted at the tenant level to maintain governance and control."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Organization creation should be restricted at the tenant level to maintain governance and control."
+        }
     }
 
     It "AZDO.1035: (Tenant) Restrict Personal Access Token lifespan. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-pats-with-policies-for-administrators?view=azure-devops#restrict-personal-access-token-lifespan" -Tag "AZDO.1035" {
         $result = Test-AzdoRestrictPersonalAccessTokenLifespan
-        $result | Should -Be $true -Because "Personal Access Tokens (PATs) should have a restricted lifespan at the tenant level."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Personal Access Tokens (PATs) should have a restricted lifespan at the tenant level."
+        }
     }
 
     It "AZDO.1036: (Tenant) Restrict Personal Access Token full scope. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-pats-with-policies-for-administrators?view=azure-devops#restrict-creation-of-full-scoped-pats-tenant-policy" -Tag "AZDO.1036" {
         $result = Test-AzdoRestrictFullScopePersonalAccessToken
-        $result | Should -Be $true -Because "Personal Access Tokens (PATs) should have a restricted scope at the tenant level."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Personal Access Tokens (PATs) should have a restricted scope at the tenant level."
+        }
     }
 
     It "AZDO.1037: (Organization) Restrict Personal Access Token creation. See https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-pats-with-policies-for-administrators?view=azure-devops" -Tag "AZDO.1037" {
         $result = Test-AzdoDisablePATCreation
-        $result | Should -Be $true -Because "Personal Access Token creation should be restricted at the organization level."
+        if ($null -ne $result) {
+            $result | Should -Be $true -Because "Personal Access Token creation should be restricted at the organization level."
+        }
     }
 
     It "AZDO.1038: (Organization) Disallow extensions from accessing resources on the local network. See https://learn.microsoft.com/en-us/azure/devops/marketplace/allow-extensions-local-network?view=azure-devops" -Tag "AZDO.1038" {
         $result = Test-AzdoAllowExtensionsLocalNetworkAccess
-        $result | Should -Be $false -Because "Extensions should not be allowed to access resources on the local network to prevent SSRF attacks."
+        if ($null -ne $result) {
+            $result | Should -Be $false -Because "Extensions should not be allowed to access resources on the local network to prevent SSRF attacks."
+        }
     }
 }

--- a/tests/Maester/AzureDevOps/Test-Azdo.Tests.ps1
+++ b/tests/Maester/AzureDevOps/Test-Azdo.Tests.ps1
@@ -1,25 +1,4 @@
-BeforeAll {
-    $script:ADOPSConnected = $false
-    try {
-        if ($null -ne (Get-Command -Name Get-ADOPSConnection -ErrorAction Stop)) {
-            $connection = Get-ADOPSConnection
-            if ($null -ne $connection['Organization']) {
-                $script:ADOPSConnected = $true
-            }
-        }
-    } catch {
-        Write-Verbose "ADOPS module is not installed or not connected to Azure DevOps"
-        Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
-    }
-}
-
-Describe "Azure DevOps" -Tag "Azure DevOps" {
-
-    BeforeEach {
-        if (-not $script:ADOPSConnected) {
-            Set-ItResult -Skipped -Because "ADOPS module is not installed or not connected to Azure DevOps"
-        }
-    }
+Describe "Azure DevOps" -Tag "AZDO" {
 
     It "AZDO.1000: Azure DevOps OAuth apps can access resources in your organization through OAuth. See https://aka.ms/vstspolicyoauth" -Tag "AZDO.1000" {
         $result = Test-AzdoThirdPartyAccessViaOauth


### PR DESCRIPTION
## 📑 Description
Fix for #1609 

Problem

The Azure DevOps test suite (Test-Azdo.Tests.ps1) failed with errors instead of skipping gracefully when the user wasn't connected to Azure DevOps (e.g., ADOPS module not installed or Connect-ADOPS not run). The existing BeforeAll + BeforeEach skip logic was unique to this test file, inconsistent with the rest of the codebase, and the per-cmdlet Get-ADOPSConnection guard threw when the ADOPS module was missing entirely.

Changes
Test-MtConnection now supports AzureDevOps
- Added 'AzureDevOps' to the [ValidateSet] and $MtConnections object in powershell/public/core/Test-MtConnection.ps1.
- New region probes Get-ADOPSConnection safely (guarded by Get-Command + try/catch) so a missing ADOPS module no longer throws.
- Result is cached in $__MtSession.AzureDevOpsConnection (with 'NotConnected' as the negative-result sentinel) so the probe runs only once per session instead of for every test.
Module session state
- Added AzureDevOpsConnection = $null to $__MtSession in build/Build-MaesterModule.ps1.
- Added the corresponding reset in powershell/internal/Clear-ModuleVariable.ps1.
Standardized skip pattern across all 39 AzDo cmdlets
Replaced the fragile guard:
if ($null -eq (Get-ADOPSConnection)['Organization']) {
    Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'Not connected to Azure DevOps'
    return $null
}
with the standard pattern used by Teams/Exchange cmdlets:
if (-not (Test-MtConnection AzureDevOps)) {
    Add-MtTestResultDetail -SkippedBecause NotConnectedAzureDevOps
    return $null
}
Helpful skip reason with docs link
Added a NotConnectedAzureDevOps case to Get-MtSkippedReason.ps1 so the report shows:
> Not connected to Azure DevOps. See Connecting to Azure DevOps (https://maester.dev/docs/connect-maester/#connect-to-azure-devops-optional)
Cleaned up the test file
Removed the BeforeAll connection-probe block and the BeforeEach skip block from tests/Maester/AzureDevOps/Test-Azdo.Tests.ps1. The 39 It blocks remain unchanged — skipping is now handled uniformly inside each cmdlet.
Result
- AzDo tests skip cleanly (instead of failing) when ADOPS isn't installed or not connected.
- Skip reason shown in the report links the user directly to the docs explaining how to connect.
- Connection probe runs once per session (cached), not once per test.
- Pattern now matches Teams/Exchange/Graph elsewhere in the codebase.