### PR TITLE
fix(MT.1024): unwrap OData .value array from Graph response to fix malformed test name

### DIFF
--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -1,6 +1,7 @@
-BeforeDiscovery {
+﻿BeforeDiscovery {
     try {
-        $EntraRecommendations = Invoke-MtGraphRequest -DisableCache -ApiVersion beta -RelativeUri 'directory/recommendations?$expand=impactedResources' -OutputType Hashtable
+        $EntraRecommendationsResponse = Invoke-MtGraphRequest -DisableCache -ApiVersion beta -RelativeUri 'directory/recommendations?$expand=impactedResources' -OutputType Hashtable
+        $EntraRecommendations = @($EntraRecommendationsResponse.value)
         Write-Verbose "Found $($EntraRecommendations.Count) Entra recommendations"
     } catch {
         Write-Verbose 'Authentication needed. Please call Connect-MgGraph.'


### PR DESCRIPTION
## Summary

Fixes the malformed `MT.1024.: .` test entry reported in #1431.

### Root cause

`Invoke-MtGraphRequest` with `-OutputType Hashtable` returns an OData wrapper hashtable:

```powershell
@{
    '@odata.context' = 'https://graph.microsoft.com/...'
    value            = @( <recommendation objects> )
}
```

The previous code assigned this wrapper directly to `$EntraRecommendations` and then iterated it with `Describe -ForEach`. Pester's discovery logic treated the wrapper as a single-item collection, generating one test with empty `$_.id` and `$_.displayName` — producing the name `MT.1024.: .`.

### Fix

Capture the raw response in an intermediate variable and unwrap `.value` before handing the array to Pester's `ForEach`:

```powershell
$EntraRecommendationsResponse = Invoke-MtGraphRequest ... -OutputType Hashtable
$EntraRecommendations = @($EntraRecommendationsResponse.value)
```

`@()` guards against single-item unrolling if only one recommendation is returned.

### Testing

Verified locally with a mocked Pester run:

- **Before:** `ExpandedName: MT.1024.: .` → Failed  
- **After:** `ExpandedName: MT.1024.selfServicePasswordReset: Enable self-service password reset.` → Passed

PSScriptAnalyzer: clean. `git diff --check`: clean.

Closes #1431