### PR TITLE
fix: load custom break glass config

### DIFF
--- a/powershell/internal/Get-MtMaesterConfig.ps1
+++ b/powershell/internal/Get-MtMaesterConfig.ps1
@@ -4,7 +4,7 @@ function Get-MtMaesterConfig {
     Reads the Maester config from (usually from the root of the ./tests directory)
 
     .DESCRIPTION
-    This also uses the ./custom/maester-config.json file if it exists and
+    This also uses the ./Custom/maester-config.json file if it exists and
     merges the settings, allowing users to override the default settings.
 
     .EXAMPLE
@@ -34,7 +34,7 @@ function Get-MtMaesterConfig {
             if (Test-Path -Path $candidate) { return $candidate }
 
             # Check tests subfolder
-            $testsCandidate = Join-Path -Path $SearchPath -ChildPath "tests/$FileName"
+            $testsCandidate = Join-Path -Path (Join-Path -Path $SearchPath -ChildPath 'tests') -ChildPath $FileName
             if (Test-Path -Path $testsCandidate) { return $testsCandidate }
 
             # Walk up to 5 parent directories
@@ -45,6 +45,30 @@ function Get-MtMaesterConfig {
                 $currentDir = $parentDir
                 $candidate = Join-Path -Path $currentDir -ChildPath $FileName
                 if (Test-Path -Path $candidate) { return $candidate }
+            }
+        }
+
+        return $null
+    }
+
+    function Find-CustomConfigFile {
+        param([string]$ConfigDirectory)
+
+        foreach ($customDirectoryName in @('Custom', 'custom')) {
+            $customConfigPath = Join-Path -Path (Join-Path -Path $ConfigDirectory -ChildPath $customDirectoryName) -ChildPath 'maester-config.json'
+            if (Test-Path -Path $customConfigPath -PathType Leaf) {
+                return $customConfigPath
+            }
+        }
+
+        $customDirectory = Get-ChildItem -Path $ConfigDirectory -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ieq 'custom' } |
+            Select-Object -First 1
+
+        if ($customDirectory) {
+            $customConfigPath = Join-Path -Path $customDirectory.FullName -ChildPath 'maester-config.json'
+            if (Test-Path -Path $customConfigPath -PathType Leaf) {
+                return $customConfigPath
             }
         }
 
@@ -104,8 +128,8 @@ function Get-MtMaesterConfig {
     }
 
     # Read the custom config file if it exists
-    $customConfigPath = Join-Path -Path (Split-Path -Path $ConfigFilePath -Parent) -ChildPath 'Custom' | Join-Path -ChildPath 'maester-config.json'
-    if (Test-Path $customConfigPath) {
+    $customConfigPath = Find-CustomConfigFile -ConfigDirectory (Split-Path -Path $ConfigFilePath -Parent)
+    if ($customConfigPath -and (Test-Path -Path $customConfigPath -PathType Leaf)) {
         Write-Verbose "Custom config file found at $customConfigPath. Merging with main config."
         $customConfig = Get-Content -Path $customConfigPath -Raw | ConvertFrom-Json
 

--- a/powershell/internal/Get-MtMaesterConfig.ps1
+++ b/powershell/internal/Get-MtMaesterConfig.ps1
@@ -6,6 +6,7 @@ function Get-MtMaesterConfig {
     .DESCRIPTION
     This also uses the ./Custom/maester-config.json file if it exists and
     merges the settings, allowing users to override the default settings.
+    The Custom directory name is matched case-insensitively.
 
     .EXAMPLE
     $maesterConfig = Get-MtMaesterConfig -ConfigFilePath 'C:\path\to\maester-config.json'

--- a/powershell/internal/Get-MtMaesterConfig.ps1
+++ b/powershell/internal/Get-MtMaesterConfig.ps1
@@ -6,7 +6,7 @@ function Get-MtMaesterConfig {
     .DESCRIPTION
     This also uses the ./Custom/maester-config.json file if it exists and
     merges the settings, allowing users to override the default settings.
-    The Custom directory name is matched case-insensitively.
+    The Custom/custom directory name is matched case-insensitively.
 
     .EXAMPLE
     $maesterConfig = Get-MtMaesterConfig -ConfigFilePath 'C:\path\to\maester-config.json'

--- a/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
+++ b/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
@@ -143,6 +143,11 @@
             $EmergencyAccessAccountsUserCount = @($ResolvedEmergencyAccessUsers).Count
             $EmergencyAccessAccountsGroupCount = @($ResolvedEmergencyAccessGroups).Count
 
+            if ($EmergencyAccessAccountsUserCount -eq 0 -and $EmergencyAccessAccountsGroupCount -eq 0) {
+                Add-MtTestResultDetail -Result "Emergency access accounts or groups are configured in maester-config.json, but none could be resolved. Verify the configured Id or UserPrincipalName values."
+                return $false
+            }
+
             # Find policies that are missing ANY of the configured emergency access accounts or groups
             $policiesWithoutEmergency = $policies | Where-Object {
                 $CurrentPolicy = $_

--- a/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
+++ b/powershell/public/maester/entra/Test-MtCaEmergencyAccessExists.ps1
@@ -128,6 +128,16 @@
                 }
             }
             Write-Verbose "Emergency access accounts or groups defined in the Maester config: $($EmergencyAccessAccounts.Count) entries"
+            $UniqueResolvedEmergencyAccessAccounts = @()
+            $ResolvedEmergencyAccessAccountKeys = @{}
+            foreach ($account in $ResolvedEmergencyAccessAccounts) {
+                $accountKey = "$($account.type):$($account.ObjectId)"
+                if (-not $ResolvedEmergencyAccessAccountKeys.ContainsKey($accountKey)) {
+                    $ResolvedEmergencyAccessAccountKeys[$accountKey] = $true
+                    $UniqueResolvedEmergencyAccessAccounts += $account
+                }
+            }
+            $ResolvedEmergencyAccessAccounts = $UniqueResolvedEmergencyAccessAccounts
             $ResolvedEmergencyAccessUsers = $ResolvedEmergencyAccessAccounts | Where-Object { $_.type -eq 'user' }
             $ResolvedEmergencyAccessGroups = $ResolvedEmergencyAccessAccounts | Where-Object { $_.type -eq 'group' }
             $EmergencyAccessAccountsUserCount = @($ResolvedEmergencyAccessUsers).Count

--- a/powershell/tests/functions/Get-MtHtmlReport.Tests.ps1
+++ b/powershell/tests/functions/Get-MtHtmlReport.Tests.ps1
@@ -29,6 +29,17 @@ Describe 'Get-MtHtmlReport' {
             LoadedModules  = @()
             InvokeCommand  = 'Invoke-Maester'
             MgContext      = [PSCustomObject]@{ TenantId = 'single-tenant-id' }
+            MaesterConfig  = [PSCustomObject]@{
+                GlobalSettings = [PSCustomObject]@{
+                    EmergencyAccessAccounts = @(
+                        [PSCustomObject]@{
+                            Type              = 'User'
+                            UserPrincipalName = 'BreakGlass1@contoso.com'
+                        }
+                    )
+                }
+                TestSettings   = @()
+            }
             Tests          = @(
                 [PSCustomObject]@{
                     Index = 1; Id = 'MT.1001'; Title = 'Test One'
@@ -116,6 +127,12 @@ Describe 'Get-MtHtmlReport' {
             $html = Get-MtHtmlReport -MaesterResults $singleTenant
 
             $html | Should -BeLike '*MT.1001*'
+        }
+
+        It 'Should contain emergency access account config data' {
+            $html = Get-MtHtmlReport -MaesterResults $singleTenant
+
+            $html | Should -BeLike '*BreakGlass1@contoso.com*'
         }
 
         It 'Should not contain sample data from the template' {

--- a/powershell/tests/functions/Get-MtMaesterConfig.Tests.ps1
+++ b/powershell/tests/functions/Get-MtMaesterConfig.Tests.ps1
@@ -1,11 +1,13 @@
 ﻿Describe 'Get-MtMaesterConfig' {
     BeforeAll {
+        Import-Module $PSScriptRoot/../../Maester.psd1 -Force
         $maesterTestsPath = Join-Path $PSScriptRoot '../../../tests'
 
         # Copy default config to test location to ensure it exists for the tests
         $testFolder = Join-Path 'TestDrive:' 'maester-config-tests'
         $null = New-Item -Path $testFolder -ItemType Directory
-        Copy-Item -Path "$maesterTestsPath/maester-config.json" -Destination "$testFolder/maester-config.json"
+        Copy-Item -Path (Join-Path -Path $maesterTestsPath -ChildPath 'maester-config.json') -Destination (Join-Path -Path $testFolder -ChildPath 'maester-config.json')
+
     }
 
     It 'Finds and reads a default config' {
@@ -114,30 +116,48 @@
     }
 
     Context 'Using custom config' {
-        BeforeAll {
-            $customFolderPath = Join-Path $testFolder 'Custom'
-            $null = New-Item -Path $customFolderPath -ItemType Directory
-            Set-Content -Path "$customFolderPath/maester-config.json" -Value (@{
+        It 'Merges custom config from <CustomFolderName>\maester-config.json' -ForEach @(
+            @{
+                ScenarioName     = 'uppercase'
+                CustomFolderName = 'Custom'
+                AccountId        = '11111111-1111-1111-1111-111111111111'
+            }
+            @{
+                ScenarioName     = 'lowercase'
+                CustomFolderName = 'custom'
+                AccountId        = '22222222-2222-2222-2222-222222222222'
+            }
+            @{
+                ScenarioName     = 'mixedcase'
+                CustomFolderName = 'CUSTOM'
+                AccountId        = '33333333-3333-3333-3333-333333333333'
+            }
+        ) {
+            $customTestFolder = Join-Path -Path 'TestDrive:' -ChildPath "maester-config-tests-$ScenarioName"
+            $null = New-Item -Path $customTestFolder -ItemType Directory -Force
+            Copy-Item -Path (Join-Path -Path $maesterTestsPath -ChildPath 'maester-config.json') -Destination (Join-Path -Path $customTestFolder -ChildPath 'maester-config.json')
+
+            $customFolderPath = Join-Path -Path $customTestFolder -ChildPath $CustomFolderName
+            $null = New-Item -Path $customFolderPath -ItemType Directory -Force
+            Set-Content -Path (Join-Path -Path $customFolderPath -ChildPath 'maester-config.json') -Value (@{
                 GlobalSettings = @{
                     EmergencyAccessAccounts = @(
                         @{
                             Type = 'User'
-                            Id = '11111111-1111-1111-1111-111111111111'
+                            Id   = $AccountId
                         }
                     )
                 }
-                TestSettings = @(
+                TestSettings   = @(
                     @{
-                        Id = 'MT.1001'
+                        Id       = 'MT.1001'
                         Severity = 'Info'
-                        Title = 'Overridden Title from Custom Config'
+                        Title    = 'Overridden Title from Custom Config'
                     }
                 )
             } | ConvertTo-Json -Depth 5)
-        }
 
-        It 'Merges custom config' {
-            $result = InModuleScope -ModuleName 'Maester' -Parameters @{ testFolder = $testFolder } {
+            $result = InModuleScope -ModuleName 'Maester' -Parameters @{ testFolder = $customTestFolder } {
                 Get-MtMaesterConfig -Path $testFolder
             }
 
@@ -148,7 +168,7 @@
             $result.GlobalSettings | Should -Not -BeNullOrEmpty
             $result.GlobalSettings.EmergencyAccessAccounts.Count | Should -BeGreaterThan 0
             $result.GlobalSettings.EmergencyAccessAccounts[0].Type | Should -Be 'User'
-            $result.GlobalSettings.EmergencyAccessAccounts[0].Id | Should -Be '11111111-1111-1111-1111-111111111111'
+            $result.GlobalSettings.EmergencyAccessAccounts[0].Id | Should -Be $AccountId
 
             $sample = $result.TestSettings | Where-Object Id -eq 'MT.1001'
             $sample.Severity | Should -Be 'Info'

--- a/powershell/tests/functions/Test-MtCaEmergencyAccessExists.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaEmergencyAccessExists.Tests.ps1
@@ -456,6 +456,22 @@
             $script:capturedResult | Should -BeLike '*Configured emergency access accounts or groups*'
             $script:capturedResult | Should -Not -BeLike '*Automatically detected emergency access*'
         }
+
+        It 'Should fail when configured emergency access entries cannot be resolved' {
+            $policy = Get-PolicyWithUserExclusion -UserIds @($emergencyUserId1)
+            $config = @(@{ UserPrincipalName = "invalid-identifier"; Type = "User" })
+            $script:capturedResult = $null
+
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+            Mock -ModuleName Maester Get-MtMaesterConfigGlobalSetting { return $config }
+            Mock -ModuleName Maester Add-MtTestResultDetail {
+                param($Result)
+                $script:capturedResult = $Result
+            }
+
+            Test-MtCaEmergencyAccessExists -WarningAction SilentlyContinue | Should -BeFalse
+            $script:capturedResult | Should -BeLike '*none could be resolved*'
+        }
     }
 
     Context "Agent Identity and Service Principal policies" {

--- a/powershell/tests/functions/Test-MtCaEmergencyAccessExists.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaEmergencyAccessExists.Tests.ps1
@@ -426,6 +426,36 @@
 
             Test-MtCaEmergencyAccessExists | Should -BeTrue
         }
+
+        It 'Should pass when duplicate configured UPN entries resolve to one excluded user' {
+            $policy = Get-PolicyWithUserExclusion -UserIds @($emergencyUserId1)
+            $config = @(
+                @{ UserPrincipalName = "emergency@contoso.com"; Type = "User" },
+                @{ UserPrincipalName = "emergency@contoso.com"; Type = "User" }
+            )
+
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+            Mock -ModuleName Maester Get-MtMaesterConfigGlobalSetting { return $config }
+
+            Test-MtCaEmergencyAccessExists | Should -BeTrue
+        }
+
+        It 'Should use configured-account result text when emergency access config is present' {
+            $policy = Get-PolicyWithNoExclusions
+            $config = @(@{ UserPrincipalName = "emergency@contoso.com"; Type = "User" })
+            $script:capturedResult = $null
+
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+            Mock -ModuleName Maester Get-MtMaesterConfigGlobalSetting { return $config }
+            Mock -ModuleName Maester Add-MtTestResultDetail {
+                param($Result)
+                $script:capturedResult = $Result
+            }
+
+            Test-MtCaEmergencyAccessExists | Should -BeFalse
+            $script:capturedResult | Should -BeLike '*Configured emergency access accounts or groups*'
+            $script:capturedResult | Should -Not -BeLike '*Automatically detected emergency access*'
+        }
     }
 
     Context "Agent Identity and Service Principal policies" {


### PR DESCRIPTION
## Summary
- make custom maester-config.json discovery case-tolerant for Custom, custom, and other case variants
- keep MT.1005 on the configured break-glass-account path when custom emergency access accounts are loaded
- de-duplicate resolved emergency access accounts before evaluating Conditional Access exclusions
- add regression coverage for custom config loading, MT.1005 configured-account output, duplicate entries, and report config serialization

Closes #1717

## Validation
- Invoke-Pester -Path 'powershell\\tests\\functions\\Get-MtMaesterConfig.Tests.ps1','powershell\\tests\\functions\\Test-MtCaEmergencyAccessExists.Tests.ps1','powershell\\tests\\functions\\Get-MtHtmlReport.Tests.ps1' -Output Detailed
- npm run build in report
- git diff --check