### PR TITLE
fix: streamline regex processing for role definitions in Update-MtRoleDefinitions.ps1

### DIFF
--- a/.github/workflows/update-role-definitions.yaml
+++ b/.github/workflows/update-role-definitions.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update Entra ID role definitions
+        id: update
         run: ./build/Update-MtRoleDefinitions.ps1
         shell: pwsh
 
@@ -36,6 +37,10 @@ jobs:
 
             Updates:
             - `powershell/internal/Get-MtRoleInfo.ps1` (role hashtable with GUIDs and privileged flags)
+
+            ## Diff summary
+
+            ${{ steps.update.outputs.diff_summary }}
 
             Please review any added/removed roles before merging.
           branch: auto/update-role-definitions

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -316,6 +316,120 @@ function Get-RoleAliases {
     return $roleAliases
 }
 
+function Get-RoleDiffSummaryMarkdown {
+    <#
+    .SYNOPSIS
+    Builds a Markdown summary of role-definition differences for PR output.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string] $BaselineContent,
+
+        [Parameter(Mandatory)]
+        [object[]] $Roles,
+
+        [Parameter(Mandatory)]
+        [object[]] $RoleAliases,
+
+        [Parameter(Mandatory)]
+        [int] $PrivilegedCount
+    )
+
+    $summaryLines = [System.Collections.Generic.List[string]]::new()
+    $summaryGuidPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(?:true|false)\)'
+
+    $baselineRoleMap = @{}
+    [regex]::Matches($BaselineContent, $summaryGuidPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+    ForEach-Object { $baselineRoleMap[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
+
+    $newRoleMap = @{}
+    foreach ($role in $Roles) {
+        $newRoleMap[$role.Name] = $role.Id
+    }
+
+    $newNames = @($newRoleMap.Keys)
+    $baselineRoleNames = @($baselineRoleMap.Keys)
+    $summaryAddedRoles = $newNames | Where-Object { $_ -notin $baselineRoleNames }
+    $aliasNames = $RoleAliases | ForEach-Object { $_.Name }
+    $deletedRoles = $baselineRoleNames | Where-Object { ($_ -notin $newNames) -and ($_ -notin $aliasNames) }
+
+    # Compare alias mappings against baseline so unchanged compatibility aliases
+    # are not reported repeatedly in every run.
+    $baselineAliasPattern = '''([A-Za-z0-9]+)''\s*=\s*''([A-Za-z0-9]+)'''
+    $baselineAliasMap = @{}
+    [regex]::Matches($BaselineContent, $baselineAliasPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+    ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
+
+    $newAliasMap = @{}
+    foreach ($alias in $RoleAliases) {
+        $newAliasMap[$alias.Name] = $alias.CanonicalName
+    }
+
+    $renamedRoleChanges = [System.Collections.Generic.List[string]]::new()
+    foreach ($aliasName in ($newAliasMap.Keys | Sort-Object)) {
+        if (-not $baselineAliasMap.ContainsKey($aliasName)) {
+            $renamedRoleChanges.Add("- $aliasName → $($newAliasMap[$aliasName])")
+        } elseif ($baselineAliasMap[$aliasName] -ne $newAliasMap[$aliasName]) {
+            $renamedRoleChanges.Add("- ${aliasName}: $($baselineAliasMap[$aliasName]) → $($newAliasMap[$aliasName])")
+        }
+    }
+
+    if ($summaryAddedRoles) {
+        $summaryLines.Add("### Added roles ($(@($summaryAddedRoles).Count))")
+        $summaryAddedRoles | Sort-Object | ForEach-Object { $summaryLines.Add("- $_ ($($newRoleMap[$_]))") }
+        $summaryLines.Add('')
+    }
+
+    if ($deletedRoles) {
+        $summaryLines.Add("### Deleted roles ($(@($deletedRoles).Count))")
+        $deletedRoles | Sort-Object | ForEach-Object { $summaryLines.Add("- $_ ($($baselineRoleMap[$_]))") }
+        $summaryLines.Add('')
+    }
+
+    if ($renamedRoleChanges.Count -gt 0) {
+        $summaryLines.Add("### Renamed roles ($($renamedRoleChanges.Count))")
+        $renamedRoleChanges | ForEach-Object { $summaryLines.Add($_) }
+        $summaryLines.Add('')
+    }
+
+    # Compute privilege classification changes
+    $existingPrivMap = @{}
+    $privEntryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''[0-9a-f-]+'',\s*\$(true|false)\)'
+    [regex]::Matches($BaselineContent, $privEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+    ForEach-Object { $existingPrivMap[$_.Groups[1].Value] = ($_.Groups[2].Value -eq 'true') }
+
+    $newPrivMap = @{}
+    foreach ($role in $Roles) {
+        $newPrivMap[$role.Name] = $role.IsPrivileged
+    }
+
+    $privilegeChanges = [System.Collections.Generic.List[string]]::new()
+    foreach ($kv in $existingPrivMap.GetEnumerator()) {
+        if ($newPrivMap.ContainsKey($kv.Key) -and $newPrivMap[$kv.Key] -ne $kv.Value) {
+            $direction = if ($newPrivMap[$kv.Key]) { 'standard → privileged' } else { 'privileged → standard' }
+            $privilegeChanges.Add("- $($kv.Key): $direction")
+        }
+    }
+
+    if ($privilegeChanges.Count -gt 0) {
+        $summaryLines.Add("### Privilege classification changes ($($privilegeChanges.Count))")
+        $privilegeChanges | ForEach-Object { $summaryLines.Add($_) }
+        $summaryLines.Add('')
+    }
+
+    if ($summaryLines.Count -eq 0) {
+        $summaryLines.Add('_No role additions, deletions, renames, or privilege classification changes._')
+        $summaryLines.Add('')
+    }
+
+    $totalRoles = @($Roles).Count
+    $summaryLines.Add("**Total roles:** $totalRoles ($PrivilegedCount privileged, $($totalRoles - $PrivilegedCount) standard)")
+
+    return ($summaryLines -join "`n")
+}
+
 function Update-FileSection {
     <#
     .SYNOPSIS
@@ -446,18 +560,18 @@ if ($env:GITHUB_OUTPUT) {
     }
 }
 
+# Parse existing role definitions once (MtRoles entries only)
+$guidEntryPattern = "'([A-Za-z0-9]+)'\s*=\s*\[MtRoleDefinition\]::new\('([0-9a-f-]+)'"
+$existingRoleGuids = @{}
+[regex]::Matches($roleInfoContent, $guidEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+ForEach-Object { $existingRoleGuids[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
+
 # Safeguard: if more than 20% of existing roles would be new preservations, something may be wrong
-$existingNames = [regex]::Matches($roleInfoContent, "'([A-Za-z0-9]+)'\s*=") |
-ForEach-Object { $_.Groups[1].Value }
-if ($existingNames.Count -gt 0 -and $preservedRoles.Count -gt ($existingNames.Count * 0.2)) {
-    throw "Too many existing roles ($($preservedRoles.Count) of $($existingNames.Count)) not found in public docs. Possible parsing issue."
+if ($existingRoleGuids.Count -gt 0 -and $preservedRoles.Count -gt ($existingRoleGuids.Count * 0.2)) {
+    throw "Too many existing roles ($($preservedRoles.Count) of $($existingRoleGuids.Count)) not found in public docs. Possible parsing issue."
 }
 
 # Safeguard: max GUID change rate (no more than 10% of existing role->GUID pairs may change)
-$existingRoleGuids = @{}
-$guidEntryPattern = "'([A-Za-z0-9]+)'\s*=\s*\[MtRoleDefinition\]::new\('([0-9a-f-]+)'"
-[regex]::Matches($roleInfoContent, $guidEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-ForEach-Object { $existingRoleGuids[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
 $newRoleGuidMap = @{}
 foreach ($r in $roles) { $newRoleGuidMap[$r.Name] = $r.Id }
 $changedGuidCount = 0
@@ -533,86 +647,7 @@ if ($addedRoles) {
 
 # Output diff summary for GitHub Actions PR body
 if ($env:GITHUB_OUTPUT) {
-    $summaryLines = [System.Collections.Generic.List[string]]::new()
-
-    $summaryGuidPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(?:true|false)\)'
-    $baselineRoleMap = @{}
-    [regex]::Matches($summaryBaselineContent, $summaryGuidPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $baselineRoleMap[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
-    $baselineRoleNames = $baselineRoleMap.Keys
-    $newRoleMap = @{}
-    foreach ($role in $roles) {
-        $newRoleMap[$role.Name] = $role.Id
-    }
-    $summaryAddedRoles = $newNames | Where-Object { $_ -notin $baselineRoleNames }
-    $aliasNames = $roleAliases | ForEach-Object { $_.Name }
-    $deletedRoles = $baselineRoleNames | Where-Object { ($_ -notin $newNames) -and ($_ -notin $aliasNames) }
-
-    # Compare alias mappings against baseline so unchanged compatibility aliases
-    # are not reported repeatedly in every run.
-    $baselineAliasPattern = '''([A-Za-z0-9]+)''\s*=\s*''([A-Za-z0-9]+)'''
-    $baselineAliasMap = @{}
-    [regex]::Matches($summaryBaselineContent, $baselineAliasPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
-    $newAliasMap = @{}
-    foreach ($alias in $roleAliases) {
-        $newAliasMap[$alias.Name] = $alias.CanonicalName
-    }
-    $renamedRoleChanges = [System.Collections.Generic.List[string]]::new()
-    foreach ($aliasName in ($newAliasMap.Keys | Sort-Object)) {
-        if (-not $baselineAliasMap.ContainsKey($aliasName)) {
-            $renamedRoleChanges.Add("- $aliasName → $($newAliasMap[$aliasName])")
-        } elseif ($baselineAliasMap[$aliasName] -ne $newAliasMap[$aliasName]) {
-            $renamedRoleChanges.Add("- ${aliasName}: $($baselineAliasMap[$aliasName]) → $($newAliasMap[$aliasName])")
-        }
-    }
-
-    if ($summaryAddedRoles) {
-        $summaryLines.Add("### Added roles ($(@($summaryAddedRoles).Count))")
-        $summaryAddedRoles | Sort-Object | ForEach-Object { $summaryLines.Add("- $_ ($($newRoleMap[$_]))") }
-        $summaryLines.Add('')
-    }
-
-    if ($deletedRoles) {
-        $summaryLines.Add("### Deleted roles ($(@($deletedRoles).Count))")
-        $deletedRoles | Sort-Object | ForEach-Object { $summaryLines.Add("- $_ ($($baselineRoleMap[$_]))") }
-        $summaryLines.Add('')
-    }
-
-    if ($renamedRoleChanges.Count -gt 0) {
-        $summaryLines.Add("### Renamed roles ($($renamedRoleChanges.Count))")
-        $renamedRoleChanges | ForEach-Object { $summaryLines.Add($_) }
-        $summaryLines.Add('')
-    }
-
-    # Compute privilege classification changes
-    $existingPrivMap = @{}
-    $privEntryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''[0-9a-f-]+'',\s*\$(true|false)\)'
-    [regex]::Matches($summaryBaselineContent, $privEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $existingPrivMap[$_.Groups[1].Value] = ($_.Groups[2].Value -eq 'true') }
-    $newPrivMap = @{}
-    foreach ($r in $roles) { $newPrivMap[$r.Name] = $r.IsPrivileged }
-    $privilegeChanges = [System.Collections.Generic.List[string]]::new()
-    foreach ($kv in $existingPrivMap.GetEnumerator()) {
-        if ($newPrivMap.ContainsKey($kv.Key) -and $newPrivMap[$kv.Key] -ne $kv.Value) {
-            $direction = if ($newPrivMap[$kv.Key]) { 'standard → privileged' } else { 'privileged → standard' }
-            $privilegeChanges.Add("- $($kv.Key): $direction")
-        }
-    }
-    if ($privilegeChanges.Count -gt 0) {
-        $summaryLines.Add("### Privilege classification changes ($($privilegeChanges.Count))")
-        $privilegeChanges | ForEach-Object { $summaryLines.Add($_) }
-        $summaryLines.Add('')
-    }
-
-    if ($summaryLines.Count -eq 0) {
-        $summaryLines.Add('_No role additions, deletions, renames, or privilege classification changes._')
-        $summaryLines.Add('')
-    }
-
-    $summaryLines.Add("**Total roles:** $($roles.Count) ($privilegedCount privileged, $($roles.Count - $privilegedCount) standard)")
-
-    $summary = $summaryLines -join "`n"
+    $summary = Get-RoleDiffSummaryMarkdown -BaselineContent $summaryBaselineContent -Roles $roles -RoleAliases $roleAliases -PrivilegedCount $privilegedCount
     # Multi-line output via heredoc-style EOF delimiter (GitHub Actions requirement)
     "diff_summary<<DIFF_EOF`n$summary`nDIFF_EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 }

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -420,6 +420,32 @@ if ($roleAliases.Count -gt 0) {
     Write-Host "Adding $($roleAliases.Count) compatibility aliases for renamed roles: $($roleAliases.Name -join ', ')" -ForegroundColor Yellow
 }
 
+# For CI summary output, prefer comparing against HEAD so local reruns still reflect
+# the pending Git diff until changes are committed.
+$summaryBaselineContent = $roleInfoContent
+if ($env:GITHUB_OUTPUT) {
+    try {
+        $repoRoot = (git -C $PSScriptRoot rev-parse --show-toplevel 2>$null)
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($repoRoot)) {
+            $resolvedRoleInfoPath = (Resolve-Path $RoleInfoPath).ProviderPath
+            Push-Location $repoRoot
+            try {
+                $relativeRoleInfoPath = Resolve-Path -LiteralPath $resolvedRoleInfoPath -Relative
+            } finally {
+                Pop-Location
+            }
+
+            $relativeRoleInfoPath = $relativeRoleInfoPath -replace '^[.][\\/]', '' -replace '\\', '/'
+            $headRoleInfo = (git -C $repoRoot show "HEAD:$relativeRoleInfoPath" 2>$null | Out-String)
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($headRoleInfo)) {
+                $summaryBaselineContent = $headRoleInfo
+            }
+        }
+    } catch {
+        Write-Verbose "Unable to resolve HEAD baseline for summary output. Falling back to current file content. $_"
+    }
+}
+
 # Safeguard: if more than 20% of existing roles would be new preservations, something may be wrong
 $existingNames = [regex]::Matches($roleInfoContent, "'([A-Za-z0-9]+)'\s*=") |
     ForEach-Object { $_.Groups[1].Value }
@@ -500,9 +526,95 @@ if ($roleAliases.Count -gt 0) {
 
 # Report new roles (roles in new data that weren't in the old file)
 $newNames = $roles | ForEach-Object { $_.Name }
-$addedRoles = $newNames | Where-Object { $_ -notin $existingNames }
+$addedRoles = $newNames | Where-Object { $_ -notin $existingRoleGuids.Keys }
 if ($addedRoles) {
     Write-Host "  New roles:   $($addedRoles -join ', ')" -ForegroundColor Yellow
+}
+
+# Output diff summary for GitHub Actions PR body
+if ($env:GITHUB_OUTPUT) {
+    $summaryLines = [System.Collections.Generic.List[string]]::new()
+
+    $summaryGuidPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(?:true|false)\)'
+    $baselineRoleMap = @{}
+    [regex]::Matches($summaryBaselineContent, $summaryGuidPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+        ForEach-Object { $baselineRoleMap[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
+    $baselineRoleNames = $baselineRoleMap.Keys
+    $newRoleMap = @{}
+    foreach ($role in $roles) {
+        $newRoleMap[$role.Name] = $role.Id
+    }
+    $summaryAddedRoles = $newNames | Where-Object { $_ -notin $baselineRoleNames }
+    $aliasNames = $roleAliases | ForEach-Object { $_.Name }
+    $deletedRoles = $baselineRoleNames | Where-Object { ($_ -notin $newNames) -and ($_ -notin $aliasNames) }
+
+    # Compare alias mappings against baseline so unchanged compatibility aliases
+    # are not reported repeatedly in every run.
+    $baselineAliasPattern = '''([A-Za-z0-9]+)''\s*=\s*''([A-Za-z0-9]+)'''
+    $baselineAliasMap = @{}
+    [regex]::Matches($summaryBaselineContent, $baselineAliasPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+        ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
+    $newAliasMap = @{}
+    foreach ($alias in $roleAliases) {
+        $newAliasMap[$alias.Name] = $alias.CanonicalName
+    }
+    $renamedRoleChanges = [System.Collections.Generic.List[string]]::new()
+    foreach ($aliasName in ($newAliasMap.Keys | Sort-Object)) {
+        if (-not $baselineAliasMap.ContainsKey($aliasName)) {
+            $renamedRoleChanges.Add("- $aliasName → $($newAliasMap[$aliasName])")
+        } elseif ($baselineAliasMap[$aliasName] -ne $newAliasMap[$aliasName]) {
+            $renamedRoleChanges.Add("- ${aliasName}: $($baselineAliasMap[$aliasName]) → $($newAliasMap[$aliasName])")
+        }
+    }
+
+    if ($summaryAddedRoles) {
+        $summaryLines.Add("### Added roles ($(@($summaryAddedRoles).Count))")
+        $summaryAddedRoles | Sort-Object | ForEach-Object { $summaryLines.Add("- $_ ($($newRoleMap[$_]))") }
+        $summaryLines.Add('')
+    }
+
+    if ($deletedRoles) {
+        $summaryLines.Add("### Deleted roles ($(@($deletedRoles).Count))")
+        $deletedRoles | Sort-Object | ForEach-Object { $summaryLines.Add("- $_ ($($baselineRoleMap[$_]))") }
+        $summaryLines.Add('')
+    }
+
+    if ($renamedRoleChanges.Count -gt 0) {
+        $summaryLines.Add("### Renamed roles ($($renamedRoleChanges.Count))")
+        $renamedRoleChanges | ForEach-Object { $summaryLines.Add($_) }
+        $summaryLines.Add('')
+    }
+
+    # Compute privilege classification changes
+    $existingPrivMap = @{}
+    $privEntryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''[0-9a-f-]+'',\s*\$(true|false)\)'
+    [regex]::Matches($summaryBaselineContent, $privEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+        ForEach-Object { $existingPrivMap[$_.Groups[1].Value] = ($_.Groups[2].Value -eq 'true') }
+    $newPrivMap = @{}
+    foreach ($r in $roles) { $newPrivMap[$r.Name] = $r.IsPrivileged }
+    $privilegeChanges = [System.Collections.Generic.List[string]]::new()
+    foreach ($kv in $existingPrivMap.GetEnumerator()) {
+        if ($newPrivMap.ContainsKey($kv.Key) -and $newPrivMap[$kv.Key] -ne $kv.Value) {
+            $direction = if ($newPrivMap[$kv.Key]) { 'standard → privileged' } else { 'privileged → standard' }
+            $privilegeChanges.Add("- $($kv.Key): $direction")
+        }
+    }
+    if ($privilegeChanges.Count -gt 0) {
+        $summaryLines.Add("### Privilege classification changes ($($privilegeChanges.Count))")
+        $privilegeChanges | ForEach-Object { $summaryLines.Add($_) }
+        $summaryLines.Add('')
+    }
+
+    if ($summaryLines.Count -eq 0) {
+        $summaryLines.Add('_No role additions, deletions, renames, or privilege classification changes._')
+        $summaryLines.Add('')
+    }
+
+    $summaryLines.Add("**Total roles:** $($roles.Count) ($privilegedCount privileged, $($roles.Count - $privilegedCount) standard)")
+
+    $summary = $summaryLines -join "`n"
+    # Multi-line output via heredoc-style EOF delimiter (GitHub Actions requirement)
+    "diff_summary<<DIFF_EOF`n$summary`nDIFF_EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 }
 
 #endregion

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -338,11 +338,16 @@ function Get-RoleDiffSummaryMarkdown {
     )
 
     $summaryLines = [System.Collections.Generic.List[string]]::new()
-    $summaryGuidPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(?:true|false)\)'
+    $combinedRolePattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(true|false)\)'
 
     $baselineRoleMap = @{}
-    [regex]::Matches($BaselineContent, $summaryGuidPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $baselineRoleMap[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
+    $existingPrivMap = @{}
+    [regex]::Matches($BaselineContent, $combinedRolePattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+        ForEach-Object {
+            $name = $_.Groups[1].Value
+            $baselineRoleMap[$name] = $_.Groups[2].Value.ToLower()
+            $existingPrivMap[$name] = ($_.Groups[3].Value -eq 'true')
+        }
 
     $newRoleMap = @{}
     foreach ($role in $Roles) {
@@ -352,15 +357,14 @@ function Get-RoleDiffSummaryMarkdown {
     $newNames = @($newRoleMap.Keys)
     $baselineRoleNames = @($baselineRoleMap.Keys)
     $summaryAddedRoles = $newNames | Where-Object { $_ -notin $baselineRoleNames }
-    $aliasNames = $RoleAliases | ForEach-Object { $_.Name }
-    $deletedRoles = $baselineRoleNames | Where-Object { ($_ -notin $newNames) -and ($_ -notin $aliasNames) }
+    $deletedRoles = $baselineRoleNames | Where-Object { ($_ -notin $newNames) -and ($_ -notin $RoleAliases.Name) }
 
     # Compare alias mappings against baseline so unchanged compatibility aliases
     # are not reported repeatedly in every run.
     $baselineAliasPattern = '''([A-Za-z0-9]+)''\s*=\s*''([A-Za-z0-9]+)'''
     $baselineAliasMap = @{}
     [regex]::Matches($BaselineContent, $baselineAliasPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
+        ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
 
     $newAliasMap = @{}
     foreach ($alias in $RoleAliases) {
@@ -394,12 +398,7 @@ function Get-RoleDiffSummaryMarkdown {
         $summaryLines.Add('')
     }
 
-    # Compute privilege classification changes
-    $existingPrivMap = @{}
-    $privEntryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''[0-9a-f-]+'',\s*\$(true|false)\)'
-    [regex]::Matches($BaselineContent, $privEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $existingPrivMap[$_.Groups[1].Value] = ($_.Groups[2].Value -eq 'true') }
-
+    # Compute privilege classification changes ($existingPrivMap populated in combined role parse above)
     $newPrivMap = @{}
     foreach ($role in $Roles) {
         $newPrivMap[$role.Name] = $role.IsPrivileged
@@ -648,8 +647,10 @@ if ($addedRoles) {
 # Output diff summary for GitHub Actions PR body
 if ($env:GITHUB_OUTPUT) {
     $summary = Get-RoleDiffSummaryMarkdown -BaselineContent $summaryBaselineContent -Roles $roles -RoleAliases $roleAliases -PrivilegedCount $privilegedCount
-    # Multi-line output via heredoc-style EOF delimiter (GitHub Actions requirement)
-    "diff_summary<<DIFF_EOF`n$summary`nDIFF_EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    # Multi-line output via heredoc-style EOF delimiter (GitHub Actions requirement).
+    # Use a random delimiter to prevent injection if summary content ever contains the delimiter string.
+    $delimiter = "DIFF_$(New-Guid)"
+    "diff_summary<<$delimiter`n$summary`n$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 }
 
 #endregion

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -448,7 +448,7 @@ if ($env:GITHUB_OUTPUT) {
 
 # Safeguard: if more than 20% of existing roles would be new preservations, something may be wrong
 $existingNames = [regex]::Matches($roleInfoContent, "'([A-Za-z0-9]+)'\s*=") |
-    ForEach-Object { $_.Groups[1].Value }
+ForEach-Object { $_.Groups[1].Value }
 if ($existingNames.Count -gt 0 -and $preservedRoles.Count -gt ($existingNames.Count * 0.2)) {
     throw "Too many existing roles ($($preservedRoles.Count) of $($existingNames.Count)) not found in public docs. Possible parsing issue."
 }
@@ -457,7 +457,7 @@ if ($existingNames.Count -gt 0 -and $preservedRoles.Count -gt ($existingNames.Co
 $existingRoleGuids = @{}
 $guidEntryPattern = "'([A-Za-z0-9]+)'\s*=\s*\[MtRoleDefinition\]::new\('([0-9a-f-]+)'"
 [regex]::Matches($roleInfoContent, $guidEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-    ForEach-Object { $existingRoleGuids[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
+ForEach-Object { $existingRoleGuids[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
 $newRoleGuidMap = @{}
 foreach ($r in $roles) { $newRoleGuidMap[$r.Name] = $r.Id }
 $changedGuidCount = 0
@@ -538,7 +538,7 @@ if ($env:GITHUB_OUTPUT) {
     $summaryGuidPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''([0-9a-f-]+)'',\s*\$(?:true|false)\)'
     $baselineRoleMap = @{}
     [regex]::Matches($summaryBaselineContent, $summaryGuidPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-        ForEach-Object { $baselineRoleMap[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
+    ForEach-Object { $baselineRoleMap[$_.Groups[1].Value] = $_.Groups[2].Value.ToLower() }
     $baselineRoleNames = $baselineRoleMap.Keys
     $newRoleMap = @{}
     foreach ($role in $roles) {
@@ -553,7 +553,7 @@ if ($env:GITHUB_OUTPUT) {
     $baselineAliasPattern = '''([A-Za-z0-9]+)''\s*=\s*''([A-Za-z0-9]+)'''
     $baselineAliasMap = @{}
     [regex]::Matches($summaryBaselineContent, $baselineAliasPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-        ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
+    ForEach-Object { $baselineAliasMap[$_.Groups[1].Value] = $_.Groups[2].Value }
     $newAliasMap = @{}
     foreach ($alias in $roleAliases) {
         $newAliasMap[$alias.Name] = $alias.CanonicalName
@@ -589,7 +589,7 @@ if ($env:GITHUB_OUTPUT) {
     $existingPrivMap = @{}
     $privEntryPattern = '''([A-Za-z0-9]+)''\s*=\s*\[MtRoleDefinition\]::new\(''[0-9a-f-]+'',\s*\$(true|false)\)'
     [regex]::Matches($summaryBaselineContent, $privEntryPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
-        ForEach-Object { $existingPrivMap[$_.Groups[1].Value] = ($_.Groups[2].Value -eq 'true') }
+    ForEach-Object { $existingPrivMap[$_.Groups[1].Value] = ($_.Groups[2].Value -eq 'true') }
     $newPrivMap = @{}
     foreach ($r in $roles) { $newPrivMap[$r.Name] = $r.IsPrivileged }
     $privilegeChanges = [System.Collections.Generic.List[string]]::new()

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -331,6 +331,7 @@ function Get-RoleDiffSummaryMarkdown {
         [object[]] $Roles,
 
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [object[]] $RoleAliases,
 
         [Parameter(Mandatory)]

--- a/build/Update-MtRoleDefinitions.ps1
+++ b/build/Update-MtRoleDefinitions.ps1
@@ -540,18 +540,23 @@ if ($env:GITHUB_OUTPUT) {
     try {
         $repoRoot = (git -C $PSScriptRoot rev-parse --show-toplevel 2>$null)
         if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($repoRoot)) {
-            $resolvedRoleInfoPath = (Resolve-Path $RoleInfoPath).ProviderPath
-            Push-Location $repoRoot
-            try {
-                $relativeRoleInfoPath = Resolve-Path -LiteralPath $resolvedRoleInfoPath -Relative
-            } finally {
-                Pop-Location
-            }
+            $resolvedRepoRoot = (Resolve-Path -LiteralPath $repoRoot -ErrorAction Stop).ProviderPath
+            $resolvedRoleInfoPath = (Resolve-Path -LiteralPath $RoleInfoPath -ErrorAction Stop).ProviderPath
+            $relativeRoleInfoPath = [System.IO.Path]::GetRelativePath($resolvedRepoRoot, $resolvedRoleInfoPath)
 
-            $relativeRoleInfoPath = $relativeRoleInfoPath -replace '^[.][\\/]', '' -replace '\\', '/'
-            $headRoleInfo = (git -C $repoRoot show "HEAD:$relativeRoleInfoPath" 2>$null | Out-String)
-            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($headRoleInfo)) {
-                $summaryBaselineContent = $headRoleInfo
+            if (
+                -not [System.IO.Path]::IsPathRooted($relativeRoleInfoPath) -and
+                -not $relativeRoleInfoPath.StartsWith('..' + [System.IO.Path]::DirectorySeparatorChar) -and
+                -not $relativeRoleInfoPath.StartsWith('..' + [System.IO.Path]::AltDirectorySeparatorChar) -and
+                $relativeRoleInfoPath -ne '..'
+            ) {
+                $relativeRoleInfoPath = $relativeRoleInfoPath -replace '\\', '/'
+                $headRoleInfo = (git -C $resolvedRepoRoot show "HEAD:$relativeRoleInfoPath" 2>$null | Out-String)
+                if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($headRoleInfo)) {
+                    $summaryBaselineContent = $headRoleInfo
+                }
+            } else {
+                Write-Verbose "Unable to resolve HEAD baseline for summary output because '$resolvedRoleInfoPath' is outside repository root '$resolvedRepoRoot'. Falling back to current file content."
             }
         }
     } catch {

--- a/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
+++ b/powershell/tests/functions/Update-MtRoleDefinitions.Tests.ps1
@@ -372,3 +372,171 @@ Describe 'Get-MtRoleInfo type contract' {
         }
     }
 }
+
+Describe 'Get-RoleDiffSummaryMarkdown' {
+
+    Context 'Added role not present in baseline' {
+        It 'includes the new role under "Added roles"' {
+            $baseline = @"
+    'RoleA' = [MtRoleDefinition]::new('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', `$false)
+"@
+            $roles = @(
+                @{ Name = 'RoleA'; Id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; IsPrivileged = $false }
+                @{ Name = 'RoleB'; Id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'; IsPrivileged = $false }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases @() -PrivilegedCount 0
+
+            $result | Should -Match '### Added roles \(1\)'
+            $result | Should -Match 'RoleB'
+            $result | Should -Not -Match 'Deleted roles'
+        }
+    }
+
+    Context 'Deleted role no longer in the feed and not aliased' {
+        It 'includes the removed role under "Deleted roles"' {
+            $baseline = @"
+    'RoleA' = [MtRoleDefinition]::new('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', `$false)
+    'RoleB' = [MtRoleDefinition]::new('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', `$false)
+"@
+            $roles = @(
+                @{ Name = 'RoleA'; Id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; IsPrivileged = $false }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases @() -PrivilegedCount 0
+
+            $result | Should -Match '### Deleted roles \(1\)'
+            $result | Should -Match 'RoleB'
+            $result | Should -Not -Match 'Added roles'
+        }
+    }
+
+    Context 'Renamed role is not reported as deleted when it appears in RoleAliases' {
+        It 'omits the old name from the Deleted roles section' {
+            $baseline = @"
+    'OldName' = [MtRoleDefinition]::new('cccccccc-cccc-cccc-cccc-cccccccccccc', `$false)
+"@
+            $roles = @(
+                @{ Name = 'NewName'; Id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'; IsPrivileged = $false }
+            )
+            $aliases = @(
+                @{ Name = 'OldName'; CanonicalName = 'NewName' }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases $aliases -PrivilegedCount 0
+
+            $result | Should -Not -Match 'Deleted roles'
+        }
+    }
+
+    Context 'New alias not present in baseline' {
+        It 'lists the new alias under "Renamed roles"' {
+            # Baseline has the current role name but no alias entries yet.
+            $baseline = @"
+    'NewName' = [MtRoleDefinition]::new('cccccccc-cccc-cccc-cccc-cccccccccccc', `$false)
+"@
+            $roles = @(
+                @{ Name = 'NewName'; Id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'; IsPrivileged = $false }
+            )
+            $aliases = @(
+                @{ Name = 'OldName'; CanonicalName = 'NewName' }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases $aliases -PrivilegedCount 0
+
+            $result | Should -Match '### Renamed roles \(1\)'
+            $result | Should -Match 'OldName'
+            $result | Should -Not -Match 'Deleted roles'
+        }
+    }
+
+    Context 'Existing alias retargeted to a new canonical name' {
+        It 'shows both the old and new target name in "Renamed roles"' {
+            # Baseline: role 'PreviousName' plus an existing alias 'OldName' → 'PreviousName'.
+            $baseline = @"
+    'PreviousName' = [MtRoleDefinition]::new('cccccccc-cccc-cccc-cccc-cccccccccccc', `$false)
+    'OldName' = 'PreviousName'
+"@
+            # New data: role renamed again to 'NewName'; alias retargeted accordingly.
+            $roles = @(
+                @{ Name = 'NewName'; Id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'; IsPrivileged = $false }
+            )
+            $aliases = @(
+                @{ Name = 'OldName'; CanonicalName = 'NewName' }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases $aliases -PrivilegedCount 0
+
+            $result | Should -Match '### Renamed roles'
+            # Line format: "- OldName: PreviousName → NewName"
+            $result | Should -Match 'OldName.*PreviousName.*NewName'
+        }
+    }
+
+    Context 'Role reclassified from standard to privileged' {
+        It 'reports the change under "Privilege classification changes"' {
+            $baseline = @"
+    'RoleA' = [MtRoleDefinition]::new('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', `$false)
+"@
+            $roles = @(
+                @{ Name = 'RoleA'; Id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; IsPrivileged = $true }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases @() -PrivilegedCount 1
+
+            $result | Should -Match '### Privilege classification changes \(1\)'
+            $result | Should -Match 'standard → privileged'
+        }
+    }
+
+    Context 'Role reclassified from privileged to standard' {
+        It 'reports the change under "Privilege classification changes"' {
+            $baseline = @"
+    'RoleA' = [MtRoleDefinition]::new('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', `$true)
+"@
+            $roles = @(
+                @{ Name = 'RoleA'; Id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; IsPrivileged = $false }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases @() -PrivilegedCount 0
+
+            $result | Should -Match '### Privilege classification changes \(1\)'
+            $result | Should -Match 'privileged → standard'
+        }
+    }
+
+    Context 'No changes between baseline and new data' {
+        It 'returns the no-changes placeholder message' {
+            $baseline = @"
+    'RoleA' = [MtRoleDefinition]::new('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', `$false)
+"@
+            $roles = @(
+                @{ Name = 'RoleA'; Id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; IsPrivileged = $false }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases @() -PrivilegedCount 0
+
+            $result | Should -Match '_No role additions'
+            $result | Should -Not -Match 'Added roles'
+            $result | Should -Not -Match 'Deleted roles'
+            $result | Should -Not -Match 'Renamed roles'
+            $result | Should -Not -Match '### Privilege classification'
+        }
+    }
+
+    Context 'Summary footer' {
+        It 'always includes total role count and privileged/standard breakdown' {
+            $baseline = @"
+    'RoleA' = [MtRoleDefinition]::new('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', `$false)
+"@
+            $roles = @(
+                @{ Name = 'RoleA'; Id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; IsPrivileged = $false }
+                @{ Name = 'RoleB'; Id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'; IsPrivileged = $true }
+            )
+
+            $result = Get-RoleDiffSummaryMarkdown -BaselineContent $baseline -Roles $roles -RoleAliases @() -PrivilegedCount 1
+
+            $result | Should -Match '\*\*Total roles:\*\* 2 \(1 privileged, 1 standard\)'
+        }
+    }
+}


### PR DESCRIPTION

## 📑 Description

Your wish is my command @SamErde

#1718

Adding summary of diffrence to the PR description example of what the diff will show in the output is shown in below powershell snippet (only tested locally but markdown output looks correct.)

```powershell
$env:GITHUB_OUTPUT = [System.IO.Path]::GetTempFileName()
./build/Update-MtRoleDefinitions.ps1                    
Fetching role definitions from GitHub...
Parsing role definitions from Markdown...                                                                               
Found 132 role definitions.
Preserving 8 existing roles not in public docs: DeviceJoin, DeviceManagers, DeviceUsers, GuestUser, OnPremisesDirectorySyncAccount, RestrictedGuestUser, User, WorkplaceDeviceJoin
Adding 2 compatibility aliases for renamed roles: AzureADJoinedDeviceLocalAdministrator, Test
Generating hashtable entries...
Updating C:\Users\Morte\Desktop\github\maester\build/../powershell/internal/Get-MtRoleInfo.ps1...

Update complete!
  Total roles: 140
  Privileged:  32
  Standard:    108
  Preserved:   8 (system/implicit roles not in public docs)
  Aliases:     2 (renamed roles kept for compatibility)
  New roles:   ApplicationDeveloper, AttackSimulationAdministrator, AttributeAssignmentAdministrator, AttributeAssignmentReader, AttributeDefinitionAdministrator, AttributeDefinitionReader, AttributeLogAdministrator, AttributeLogReader, AttributeProvisioningAdministrator, AttributeProvisioningReader, AuthenticationAdministrator, AuthenticationExtensibilityAdministrator, AuthenticationExtensibilityPasswordAdministrator, AuthenticationPolicyAdministrator, AzureDevOpsAdministrator, AzureInformationProtectionAdministrator, B2CIEFKeysetAdministrator, B2CIEFPolicyAdministrator, BillingAdministrator, CloudApplicationAdministrator, CloudAppSecurityAdministrator, CloudDeviceAdministrator, ComplianceAdministrator, GlobalReader

Get-Content $env:GITHUB_OUTPUT                          
diff_summary<<DIFF_EOF
### Added roles (2)
- AIReader (1fe13547-53f6-408d-ac04-7f8eed167b38)
- CustomerDelegatedAdminRelationshipAdministrator (fc8ad4e2-40e4-4724-8317-bcda7503ecbf)

### Renamed roles (1)
- Test → ApplicationDeveloper

**Total roles:** 140 (32 privileged, 108 standard)
DIFF_EOF
```


Closes # No issue to my knowledge other than a comment on mentioned PR

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [ X] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [ X] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->

---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖
