### PR TITLE
fix(report): remove deprecated baseUrl from tsconfig

### DIFF
--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -21,7 +21,6 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Summary

Fixes the `publish-module-preview` workflow failure caused by a TypeScript 6.0+ breaking change.

## Root Cause

The `build-maester-report-template` reusable workflow runs `npm run build` in the `report/` directory. The latest packages pulled in via `npm ci` (on Node.js 24.x) include TypeScript ≥6.0, which upgraded the `baseUrl` option from a deprecation **warning** to a hard **error** when `moduleResolution: "bundler"` is set:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
              Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

This caused `npm run build` to exit with code 1, blocking `create-preview-release` from running.

## Fix

Removed `"baseUrl": "."` from `report/tsconfig.json`.

This option is unnecessary because:
- **Vite** already handles the `@` path alias via `resolve.alias` in `vite.config.ts`
- TypeScript's `moduleResolution: "bundler"` supports `paths` without requiring `baseUrl`

## Files Changed

- `report/tsconfig.json` — removed the deprecated `baseUrl` compiler option

## Related

- Failing run: https://github.com/maester365/maester/actions/runs/25322687468