### PR TITLE
docs(build): remove stale Pester test-suite consolidation references

### DIFF
--- a/build/Build-MaesterModule.md
+++ b/build/Build-MaesterModule.md
@@ -136,8 +136,10 @@ All other manifest fields (version, GUID, `RequiredModules`,
 ### Phase G — Copy test suites
 
 Copies the `tests/` directory to `maester-tests/` in the output. Tests are
-copied as-is and not consolidated. Future per-suite consolidation is tracked
-in [issue #1559](https://github.com/maester365/maester/issues/1559).
+copied as-is and not consolidated. This intentionally preserves each authored
+Pester file as a separate discovery container because per-suite consolidation
+can change `BeforeDiscovery`, `BeforeAll`, and dynamic test-generation
+semantics.
 
 ### Phase H — Build profiling (optional)
 

--- a/build/Build-MaesterModule.ps1
+++ b/build/Build-MaesterModule.ps1
@@ -656,7 +656,7 @@ Write-Host "   FunctionsToExport: $($ExportFunctionList.Count) functions"
 Write-Host '   ScriptsToProcess:  OrcaClasses.ps1'
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Phase G — Copy tests as-is (issue #1559 tracks future per-suite consolidation)
+# Phase G — Copy tests as-is and preserve Pester file boundaries
 # ──────────────────────────────────────────────────────────────────────────────
 
 Write-Host '── Phase G: Copying test suites' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

Removes stale references to future Pester test-suite consolidation from two build files.

### Background

PR #1657 explored consolidating Pester test suites into single files per suite for faster module loading. After investigation, this approach was rejected because merging Pester discovery containers changes BeforeDiscovery, BeforeAll, and dynamic test-generation semantics — causing tests to be silently dropped (the Maester suite dropped from 167 to 76 discovered tests in testing).

### Changes

- **uild/Build-MaesterModule.ps1**: Updated Phase G comment from \issue #1559 tracks future per-suite consolidation\ to explain why Pester file boundaries are intentionally preserved.
- **uild/Build-MaesterModule.md**: Replaced the sentence \Future per-suite consolidation is tracked in issue #1559\ with an explanation that individual Pester files are kept separate because per-suite consolidation changes \BeforeDiscovery\, \BeforeAll\, and dynamic test-generation semantics.

### Related

- Closes: N/A (doc-only cleanup)
- References: #1559, #1657