### PR TITLE
ci: tighten dependency review policy

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -9,9 +9,12 @@ on:
       - "report/package.json"
       - "report/package-lock.json"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   dependency-review:
@@ -23,4 +26,5 @@ jobs:
       - name: Dependency review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
-          fail-on-severity: high
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development, unknown


### PR DESCRIPTION
## Summary

Tightens the dependency review workflow policy for better security coverage.

## Changes

- **Remove `pull-requests: write` permission** — not needed since PR comment summary is not enabled; least-privilege principle applied.
- **Lower `fail-on-severity` from `high` to `moderate`** — catches a broader set of vulnerabilities earlier.
- **Add `fail-on-scopes: runtime, development, unknown`** — ensures all dependency scopes are checked, not just production runtime.
- **Add `concurrency` group** — cancels redundant runs when a PR is updated, reducing CI resource waste.

## Policy rationale

| Setting | Before | After |
|---------|--------|-------|
| `fail-on-severity` | `high` | `moderate` |
| `fail-on-scopes` | _(default)_ | `runtime, development, unknown` |
| `pull-requests: write` | present | removed |
| Concurrency | none | workflow + PR number/ref, cancel-in-progress |

No functional changes outside `.github/workflows/dependency-review.yaml`.