### PR TITLE
ci: pin CodeQL workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,8 @@
 #
 name: "CodeQL Advanced"
 
+permissions: {}
+
 on:
   push:
     branches: [ "main" ]
@@ -57,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

Pins all mutable action tags in the CodeQL workflow to immutable commit SHAs to prevent supply chain attacks via tag mutation.

## Changes

- Add top-level `permissions: {}` to deny all token access by default (defense-in-depth; job-level permissions override as needed)
- Pin `actions/checkout` from `v6` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6)
- Pin `github/codeql-action/init` from `v4` → `e46ed2cbd01164d986452f91f178727624ae40d7` (v4)
- Pin `github/codeql-action/analyze` from `v4` → `e46ed2cbd01164d986452f91f178727624ae40d7` (v4)

Existing job-level permissions (`security-events: write`, `packages: read`, `actions: read`, `contents: read`) are preserved so CodeQL continues to function correctly.

## Security rationale

Mutable tags (e.g. `@v4`) can be silently updated to point to arbitrary code. Pinning to a full commit SHA ensures the exact version is used on every run, regardless of what the tag points to.