### PR TITLE
ci: tighten scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,8 +14,8 @@ on:
   push:
     branches: ["main"]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Deny all permissions by default; grant only what each job needs.
+permissions: {}
 
 jobs:
   analysis:
@@ -24,13 +24,12 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
+      # Needed to checkout code and perform repository analysis.
+      contents: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
## Summary

The current workflow-level `permissions: read-all` grants every token scope to every job, violating the principle of least privilege. Ironically, this also causes Scorecard's own **Token-Permissions** check to flag the workflow.

## Changes

- Replace workflow-level `permissions: read-all` with deny-by-default `permissions: {}`
- Add explicit job-level grants in the `analysis` job with only what is required:
  - `contents: read` — checkout and repository analysis
  - `security-events: write` — upload SARIF results to the code-scanning dashboard
  - `id-token: write` — publish results and display the Scorecard badge
- Remove the now-unnecessary commented-out permission hints (private-repo guidance)
- Retain `persist-credentials: false` on the checkout step

## Security impact

Every job that runs in this workflow now starts with zero implicit token permissions. Least-privilege is enforced at the workflow level and permissions are granted explicitly at the job level.