### PR TITLE
ci: add targeted concurrency controls to workflows

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: build-docs
+  cancel-in-progress: false
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -23,6 +23,10 @@ on:
       - "website/**"
       - ".github/workflows/build-website.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '28 13 * * 2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: publish-module-manualversionupdate
+  cancel-in-progress: false
+
 jobs:
   build-validation:
     uses: ./.github/workflows/build-validation.yaml

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: publish-module-preview
+  cancel-in-progress: false
+
 jobs:
   build-report:
     uses: ./.github/workflows/build-maester-report-template.yaml

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: publish-module
+  cancel-in-progress: false
+
 jobs:
   build-validation:
     uses: ./.github/workflows/build-validation.yaml

--- a/.github/workflows/publish-tests.yaml
+++ b/.github/workflows/publish-tests.yaml
@@ -4,6 +4,10 @@ name: publish-tests
 permissions:
   contents: read
 
+concurrency:
+  group: publish-tests
+  cancel-in-progress: false
+
 on:
   # Runs whenever a new Maester module is published
   release:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,10 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/update-module-docs.yaml
+++ b/.github/workflows/update-module-docs.yaml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: update-module-docs
+  cancel-in-progress: false
+
 jobs:
   update-command-reference:
     runs-on: windows-latest

--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: update-tag-documentation
+  cancel-in-progress: false
+
 jobs:
   update-tags:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds concurrency blocks to 11 GitHub Actions workflows to prevent duplicate and wasteful concurrent runs. Two workflows (publish-versioned-docs.yml, update-role-definitions.yaml) already had concurrency configured and are left unchanged.

## Concurrency policies applied

### PR/validation workflows -- cancel redundant PR runs
Runs are grouped by workflow name + PR number (or ref for non-PR triggers). Cancels in-progress runs only when triggered by a pull request, preserving manual/call-triggered runs.

| Workflow | Group | Cancel in progress |
|---|---|---|
| build-validation.yaml | github.workflow + github.event.pull_request.number or github.ref | true on pull_request |
| build-website.yaml | github.workflow + github.event.pull_request.number or github.ref | true on pull_request |

### Security/scanning workflows -- cancel stale runs, preserve scheduled
CodeQL cancels on PR (not scheduled). Scorecard cancels on push (preserving scheduled/branch-protection runs).

| Workflow | Group | Cancel in progress |
|---|---|---|
| codeql.yml | github.workflow + github.ref | true on pull_request |
| scorecard.yml | github.workflow + github.ref | true on push |

### Release/publish workflows -- never cancel
Each publish run represents a distinct release action. Cancellation would leave releases in a broken state.

| Workflow | Group | Cancel in progress |
|---|---|---|
| publish-module.yaml | publish-module | false |
| publish-module-preview.yaml | publish-module-preview | false |
| publish-module-manualversionupdate.yaml | publish-module-manualversionupdate | false |
| publish-tests.yaml | publish-tests | false |

### Documentation/update workflows -- never cancel
These workflows commit back to the repo. Cancellation mid-run could leave docs in an inconsistent state.

| Workflow | Group | Cancel in progress |
|---|---|---|
| build-docs.yaml | build-docs | false |
| update-module-docs.yaml | update-module-docs | false |
| update-tag-documentation.yml | update-tag-documentation | false |

## Workflows not changed

- publish-versioned-docs.yml -- already has concurrency group: docs-versioning-version, cancel-in-progress: false
- update-role-definitions.yaml -- already has concurrency group: update-role-definitions, cancel-in-progress: false
- build-validation-report.yaml -- left unconstrained; report runs are short-lived and triggered contextually
- dependency-review.yaml -- out of scope for this PR
