### PR TITLE
fix: use GH_PAT in automated PR-creation workflows

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -26,4 +26,5 @@ jobs:
       - name: Create PR to update repo
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.GH_PAT }}
           title: Update maester.dev command reference

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -18,7 +18,16 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Update docs
         run: ./build/Update-CommandReference.ps1
         shell: pwsh
@@ -26,5 +35,5 @@ jobs:
       - name: Create PR to update repo
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           title: Update maester.dev command reference

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -14,8 +14,8 @@ concurrency:
 jobs:
   build:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-module-docs.yaml
+++ b/.github/workflows/update-module-docs.yaml
@@ -19,8 +19,8 @@ jobs:
   update-command-reference:
     runs-on: windows-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-module-docs.yaml
+++ b/.github/workflows/update-module-docs.yaml
@@ -23,7 +23,16 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Update maester.dev powershell docs
         run: ./build/Update-CommandReference.ps1
         shell: pwsh
@@ -31,5 +40,5 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           title: Update maester.dev powershell docs

--- a/.github/workflows/update-module-docs.yaml
+++ b/.github/workflows/update-module-docs.yaml
@@ -31,4 +31,5 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.GH_PAT }}
           title: Update maester.dev powershell docs

--- a/.github/workflows/update-role-definitions.yaml
+++ b/.github/workflows/update-role-definitions.yaml
@@ -15,8 +15,8 @@ jobs:
   update-role-definitions:
     runs-on: windows-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-role-definitions.yaml
+++ b/.github/workflows/update-role-definitions.yaml
@@ -30,6 +30,7 @@ jobs:
         if: success()
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.GH_PAT }}
           title: Update Entra ID role definitions
           body: |
             Automated update of Entra ID built-in role definitions from the

--- a/.github/workflows/update-role-definitions.yaml
+++ b/.github/workflows/update-role-definitions.yaml
@@ -19,7 +19,16 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Update Entra ID role definitions
         id: update
@@ -30,7 +39,7 @@ jobs:
         if: success()
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           title: Update Entra ID role definitions
           body: |
             Automated update of Entra ID built-in role definitions from the


### PR DESCRIPTION
Closes #1761

## Problem
Three automated workflows create PRs using `peter-evans/create-pull-request` with the default `GITHUB_TOKEN`. GitHub deliberately prevents `GITHUB_TOKEN`-created events from triggering downstream workflow runs, so required checks like `build-validation` and `CodeQL Advanced` are never queued on these auto-created PRs — leaving them permanently stuck in **"waiting for status to be reported"** until an admin force-merges.

## Fix
Added `token: ${{ secrets.GH_PAT }}` to the `create-pull-request` step in all three affected workflows. A PAT-authenticated PR creation is treated as a user action, so `pull_request`-triggered workflows fire normally.

## Affected workflows
- `.github/workflows/update-module-docs.yaml` — "Update maester.dev powershell docs"
- `.github/workflows/build-docs.yaml` — "Update maester.dev command reference"
- `.github/workflows/update-role-definitions.yaml` — "Update Entra ID role definitions"

## Required action before merging
A repo admin must create a **fine-grained PAT** (or classic PAT with `repo` scope) as a repository secret named **`GH_PAT`** with `Contents: write` and `Pull requests: write` permissions on this repository OR create a GitHub app and generate a token from it instead of a PAT that is tied to a specific user account. 