### PR TITLE
Add new permissions to the documentation

### DIFF
--- a/website/docs/sections/permissions.md
+++ b/website/docs/sections/permissions.md
@@ -6,6 +6,8 @@
 - **DirectoryRecommendations.Read.All**
 - **IdentityRiskEvent.Read.All**
 - **OnPremDirectorySynchronization.Read.All**
+- **OrgSettings-AppsAndServices.Read.All**
+- **OrgSettings-Forms.Read.All**
 - **Policy.Read.All**
 - **Policy.Read.ConditionalAccess**
 - **PrivilegedAccess.Read.AzureAD**


### PR DESCRIPTION
## 📑 Description
Just adds graph permissions that Maester prints as missing (`OrgSettings-AppsAndServices.Read.All` and `OrgSettings-Forms.Read.All`) to sections where they not defined.

## ✅ Checks
- [x ] My pull request adheres to the code style of this project.
- [x] My code requires changes to the documentation.
- [x] I have updated the documentation as required.
- [ ] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.
