### PR TITLE
fix(MT.1066): ignore 'None' sentinel value for workload identity poli…

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaReferencedObjectsExist.ps1
+++ b/powershell/public/maester/entra/Test-MtCaReferencedObjectsExist.ps1
@@ -33,7 +33,7 @@ function Test-MtCaReferencedObjectsExist {
         $policies = Get-MtConditionalAccessPolicy
 
         # Collect all referenced objects
-        $allUsers = $policies.conditions.users.includeUsers + $policies.conditions.users.excludeUsers | Where-Object { $_ -ne 'All' -and $_ -ne 'GuestsOrExternalUsers' -and $_ -ne $null -and $_ -ne '' } | Select-Object -Unique
+        $allUsers = $policies.conditions.users.includeUsers + $policies.conditions.users.excludeUsers | Where-Object { $_ -ne 'All' -and $_ -ne 'GuestsOrExternalUsers' -and $_ -ne 'None' -and $_ -ne $null -and $_ -ne '' } | Select-Object -Unique
         $allGroups = $policies.conditions.users.includeGroups + $policies.conditions.users.excludeGroups | Where-Object { $_ -ne $null -and $_ -ne '' } | Select-Object -Unique
         $allRoles = $policies.conditions.users.includeRoles + $policies.conditions.users.excludeRoles | Where-Object { $_ -ne $null -and $_ -ne '' } | Select-Object -Unique
 


### PR DESCRIPTION
…cies

<!-- 
Thank you; we really appreciate your contributions! 🤗 We will try to review your pull request as soon as possible. Please make sure that the pull request is limited to one type of change (docs, feature, fix, etc.) and keep it as focused as possible. You can always create multiple focused PRs instead of opening a huge one.
-->

## 📑 Description
Fixes a false positive in test MT.1066 where Conditional Access policies 
scoped exclusively to workload identities were incorrectly flagged as 
referencing non-existent users.

When a policy targets workload identities only, the Microsoft Graph API 
returns `"None"` as a sentinel value in the `includeUsers` array. The test 
was attempting to look up a user with the ID `"None"`, which naturally 
returns a 404 and triggers a false positive.

The fix adds `"None"` to the list of known sentinel values that are already 
being filtered (alongside `"All"` and `"GuestsOrExternalUsers"`).

Closes #1778 

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information

The `"None"` sentinel value is used by the Graph API specifically for 
policies targeting workload identities, where no users, groups, or roles 
are assigned by design.

Verified fix locally against a tenant with a workload identity-scoped 
Conditional Access policy, test now passes correctly.

Before fix:
<img width="1160" height="621" alt="mt1066_before-fix" src="https://github.com/user-attachments/assets/20a99d05-10b7-4de8-90a6-fb61282ba8ab" />

After fix:
<img width="1065" height="298" alt="mt1066_after-fix" src="https://github.com/user-attachments/assets/1552871a-553d-4b31-923e-554403f5ca47" />

---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖
