### PR TITLE
docs: add missing AuditLog.Read.All and EntitlementManagement.Read.Al…

### DIFF
--- a/website/docs/sections/permissions.md
+++ b/website/docs/sections/permissions.md
@@ -1,9 +1,11 @@
+- **AuditLog.Read.All**
 - **DeviceManagementConfiguration.Read.All**
 - **DeviceManagementManagedDevices.Read.All**
 - **DeviceManagementRBAC.Read.All**
 - **DeviceManagementServiceConfig.Read.All**
 - **Directory.Read.All**
 - **DirectoryRecommendations.Read.All**
+- **EntitlementManagement.Read.All**
 - **IdentityRiskEvent.Read.All**
 - **OnPremDirectorySynchronization.Read.All**
 - **OrgSettings-AppsAndServices.Read.All**


### PR DESCRIPTION
## 📑 Description
Adds two missing Microsoft Graph Application Permissions to the setup 
documentation that are required for several built-in Maester tests:

- **AuditLog.Read.All** – required for MT.1063 (App registration owners should have MFA registered)
- **EntitlementManagement.Read.All** – required for:
  - MT.1106 - Catalog resources must have valid roles
  - MT.1107 - Access packages and catalogs should not reference deleted groups
  - MT.1109 - Access package approval workflows must have valid approvers
  - MT.1110 - Catalogs should not contain resources without associated access packages

When following the documentation exactly as written, these tests fail with 
insufficient privileges errors. After adding both permissions and granting 
admin consent, all listed tests pass successfully.

Note: The permissions list in `Get-MtGraphScope.ps1` may also need to be 
updated separately.

Closes #1784 

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [x] My pull request adheres to the code style of this project.
- [x] My code requires changes to the documentation.
- [x] I have updated the documentation as required.
- [ ] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
