### PR TITLE
fix: SPF lookups fail on null DNS server (CISA.MS.EXO.2.1/2.2)

### DIFF
--- a/powershell/public/cisa/exchange/Get-MailAuthenticationRecord.ps1
+++ b/powershell/public/cisa/exchange/Get-MailAuthenticationRecord.ps1
@@ -115,7 +115,11 @@
                         $recordSet.spfLookups = $mtDnsCache.spfLookups
                     } else {
                         Write-Verbose "SPF Lookups records not in cache, querying"
-                        $recordSet.spfLookups = Resolve-SPFRecord -Name $DomainName -Server $DnsServerIpAddress
+                        if ($DnsServerIpAddress) {
+                            $recordSet.spfLookups = Resolve-SPFRecord -Name $DomainName -Server $DnsServerIpAddress
+                        } else {
+                            $recordSet.spfLookups = Resolve-SPFRecord -Name $DomainName
+                        }
                         ($__MtSession.DnsCache | Where-Object { $_.domain -eq $DomainName }).spfLookups = $recordSet.spfLookups
                     }
                 }


### PR DESCRIPTION
## 📑 Description

`Test-MtCisaSpfDirective` (CISA.MS.EXO.2.2) and `Test-MtCisaSpfRestriction`
(CISA.MS.EXO.2.1) fail with:

    Cannot validate argument on parameter 'Server'. The argument is null or empty.

`Get-MailAuthenticationRecord` calls `Resolve-SPFRecord -Name $DomainName -Server
$DnsServerIpAddress` unconditionally. When the SPF tests run without a DNS server,
`$DnsServerIpAddress` is `$null`, binds to `-Server`, and the `[ValidateNotNullOrEmpty()]`
attribute on that parameter throws before the body's own `if ($Server)` guard runs.

Fix: only pass `-Server` when a DNS server was supplied, matching the pattern
`Resolve-SPFRecord` already uses for its own recursive calls (the redirect/include
branches guard with `if ($Server)` before passing `-Server`):

    if ($DnsServerIpAddress) {
        $recordSet.spfLookups = Resolve-SPFRecord -Name $DomainName -Server $DnsServerIpAddress
    } else {
        $recordSet.spfLookups = Resolve-SPFRecord -Name $DomainName
    }

This keeps the change at the one call site and does not alter the public contract of
`Resolve-SPFRecord` (an exported command), so other callers are unaffected.

Before: `Get-MailAuthenticationRecord -DomainName <domain> -Records SPF` throws the
validation error. After: it returns the SPF record and lookups as expected.

## ✅ Checks

- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mail authentication record retrieval to work more flexibly with different DNS configurations, enabling broader compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->