### PR TITLE
Add markdown summary report generation

### DIFF
--- a/powershell/internal/Get-MtMarkdownSummaryReport.ps1
+++ b/powershell/internal/Get-MtMarkdownSummaryReport.ps1
@@ -1,0 +1,43 @@
+﻿function Get-MtMarkdownSummaryReport {
+    <#
+    .Synopsis
+    Generates a compact markdown summary report with only result counters.
+
+    .Description
+    This markdown report is intended for quick sharing in pull requests, tickets,
+    and workflow summaries where only the top-level result counts are needed.
+    #>
+    [CmdletBinding()]
+    param(
+        # The Maester test results returned from Invoke-Maester -PassThru
+        [Parameter(Mandatory = $true, Position = 0)]
+        [psobject] $MaesterResults
+    )
+
+    $tenantDisplay = if (![string]::IsNullOrEmpty($MaesterResults.TenantName)) {
+        "$($MaesterResults.TenantName) ($($MaesterResults.TenantId))"
+    } else {
+        "Tenant ID: $($MaesterResults.TenantId)"
+    }
+
+    $executedAt = $MaesterResults.ExecutedAt
+
+    $lines = @(
+        '# Maester Test Results Summary'
+        ''
+        "**Tenant:** $tenantDisplay"
+        "**Date:** $executedAt"
+        ''
+        '| Metric | Count |'
+        '| - | -: |'
+        "| Passed ✅ | $($MaesterResults.PassedCount) |"
+        "| Failed ❌ | $($MaesterResults.FailedCount) |"
+        "| Investigate 🕵️ | $($MaesterResults.InvestigateCount) |"
+        "| Skipped ⏭️ | $($MaesterResults.SkippedCount) |"
+        "| Error ⚠️ | $($MaesterResults.ErrorCount) |"
+        "| Not Run 🛑 | $($MaesterResults.NotRunCount) |"
+        "| Total 📊 | $($MaesterResults.TotalCount) |"
+    )
+
+    return ($lines -join "`n")
+}

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -219,27 +219,6 @@
 
     function ValidateAndSetOutputFiles($out) {
         $result = $null
-        if (![string]::IsNullOrEmpty($out.OutputHtmlFile)) {
-            if ($out.OutputHtmlFile.EndsWith('.html') -eq $false) {
-                $result = 'The OutputHtmlFile parameter must have an .html extension.'
-            }
-        }
-        if (![string]::IsNullOrEmpty($out.OutputMarkdownFile)) {
-            if ($out.OutputMarkdownFile.EndsWith('.md') -eq $false) {
-                $result = 'The OutputMarkdownFile parameter must have an .md extension.'
-            }
-        }
-        if (![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)) {
-            if ($out.OutputMarkdownSummaryFile.EndsWith('.md') -eq $false) {
-                $result = 'The OutputMarkdownSummaryFile parameter must have an .md extension.'
-            }
-        }
-        if (![string]::IsNullOrEmpty($out.OutputJsonFile)) {
-            if ($out.OutputJsonFile.EndsWith('.json') -eq $false) {
-                $result = 'The OutputJsonFile parameter must have a .json extension.'
-            }
-        }
-
         $someOutputFileHasValue = ![string]::IsNullOrEmpty($out.OutputHtmlFile) -or `
             ![string]::IsNullOrEmpty($out.OutputMarkdownFile) -or ![string]::IsNullOrEmpty($out.OutputJsonFile) -or `
             ![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)
@@ -271,6 +250,28 @@
                 $out.OutputExcelFile = Join-Path $out.OutputFolder "$($out.OutputFolderFileName).xlsx"
             }
         }
+
+        if (![string]::IsNullOrEmpty($out.OutputHtmlFile)) {
+            if ($out.OutputHtmlFile.EndsWith('.html') -eq $false) {
+                $result = 'The OutputHtmlFile parameter must have an .html extension.'
+            }
+        }
+        if (![string]::IsNullOrEmpty($out.OutputMarkdownFile)) {
+            if ($out.OutputMarkdownFile.EndsWith('.md') -eq $false) {
+                $result = 'The OutputMarkdownFile parameter must have an .md extension.'
+            }
+        }
+        if (![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)) {
+            if ($out.OutputMarkdownSummaryFile.EndsWith('.md') -eq $false) {
+                $result = 'The OutputMarkdownSummaryFile parameter must have an .md extension.'
+            }
+        }
+        if (![string]::IsNullOrEmpty($out.OutputJsonFile)) {
+            if ($out.OutputJsonFile.EndsWith('.json') -eq $false) {
+                $result = 'The OutputJsonFile parameter must have a .json extension.'
+            }
+        }
+
         return $result
     }
 
@@ -347,14 +348,14 @@
     }
 
     $out = [PSCustomObject]@{
-        OutputFolder         = $OutputFolder
-        OutputFolderFileName = $OutputFolderFileName
-        OutputHtmlFile       = $OutputHtmlFile
-        OutputMarkdownFile   = $OutputMarkdownFile
+        OutputFolder              = $OutputFolder
+        OutputFolderFileName      = $OutputFolderFileName
+        OutputHtmlFile            = $OutputHtmlFile
+        OutputMarkdownFile        = $OutputMarkdownFile
         OutputMarkdownSummaryFile = $OutputMarkdownSummaryFile
-        OutputJsonFile       = $OutputJsonFile
-        OutputCsvFile        = $null
-        OutputExcelFile      = $null
+        OutputJsonFile            = $OutputJsonFile
+        OutputCsvFile             = $null
+        OutputExcelFile           = $null
     }
 
     $result = ValidateAndSetOutputFiles $out

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -127,11 +127,14 @@
         # The path to the file to save the test results in markdown format. The filename should include a .md extension.
         [string] $OutputMarkdownFile,
 
+        # The path to the file to save a compact markdown summary with only result counters. The filename should include a .md extension.
+        [string] $OutputMarkdownSummaryFile,
+
         # The path to the file to save the test results in json format. The filename should include a .json extension.
         [string] $OutputJsonFile,
 
         # The folder to save the test results in. If no -Output* is set, defaults to ./test-results.
-        # If set, other -Output* parameters are ignored and all formats will be generated (markdown, html, json) with a timestamp and saved in the folder.
+        # If set, other -Output* parameters are ignored and all formats will be generated (markdown, markdown summary, html, json) with a timestamp and saved in the folder.
         [string] $OutputFolder,
 
         # The filename prefix to use for all the files in the output folder. e.g. 'TestResults' will generate TestResults.html, TestResults.md, TestResults.json.
@@ -226,6 +229,11 @@
                 $result = 'The OutputMarkdownFile parameter must have an .md extension.'
             }
         }
+        if (![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)) {
+            if ($out.OutputMarkdownSummaryFile.EndsWith('.md') -eq $false) {
+                $result = 'The OutputMarkdownSummaryFile parameter must have an .md extension.'
+            }
+        }
         if (![string]::IsNullOrEmpty($out.OutputJsonFile)) {
             if ($out.OutputJsonFile.EndsWith('.json') -eq $false) {
                 $result = 'The OutputJsonFile parameter must have a .json extension.'
@@ -233,7 +241,8 @@
         }
 
         $someOutputFileHasValue = ![string]::IsNullOrEmpty($out.OutputHtmlFile) -or `
-            ![string]::IsNullOrEmpty($out.OutputMarkdownFile) -or ![string]::IsNullOrEmpty($out.OutputJsonFile)
+            ![string]::IsNullOrEmpty($out.OutputMarkdownFile) -or ![string]::IsNullOrEmpty($out.OutputJsonFile) -or `
+            ![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)
 
         if ([string]::IsNullOrEmpty($out.OutputFolder) -and !$someOutputFileHasValue) {
             # No outputs specified. Set default folder.
@@ -252,6 +261,7 @@
 
             $out.OutputHtmlFile = Join-Path $out.OutputFolder "$($out.OutputFolderFileName).html"
             $out.OutputMarkdownFile = Join-Path $out.OutputFolder "$($out.OutputFolderFileName).md"
+            $out.OutputMarkdownSummaryFile = Join-Path $out.OutputFolder "$($out.OutputFolderFileName)-summary.md"
             $out.OutputJsonFile = Join-Path $out.OutputFolder "$($out.OutputFolderFileName).json"
 
             if ($ExportCsv.IsPresent) {
@@ -341,6 +351,7 @@
         OutputFolderFileName = $OutputFolderFileName
         OutputHtmlFile       = $OutputHtmlFile
         OutputMarkdownFile   = $OutputMarkdownFile
+        OutputMarkdownSummaryFile = $OutputMarkdownSummaryFile
         OutputJsonFile       = $OutputJsonFile
         OutputCsvFile        = $null
         OutputExcelFile      = $null
@@ -484,6 +495,12 @@
             Write-MtProgress -Activity 'Creating markdown report'
             $output = Get-MtMarkdownReport -MaesterResults $maesterResults
             $output | Out-File -FilePath $out.OutputMarkdownFile -Encoding UTF8
+        }
+
+        if (![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)) {
+            Write-MtProgress -Activity 'Creating markdown summary report'
+            $output = Get-MtMarkdownSummaryReport -MaesterResults $maesterResults
+            $output | Out-File -FilePath $out.OutputMarkdownSummaryFile -Encoding UTF8
         }
 
         if (![string]::IsNullOrEmpty($out.OutputCsvFile)) {

--- a/powershell/tests/functions/Invoke-Maester.Tests.ps1
+++ b/powershell/tests/functions/Invoke-Maester.Tests.ps1
@@ -82,8 +82,8 @@
 
         $summaryContent = Get-Content -Path $summaryPath -Raw
         $summaryContent | Should -BeLike '*| Metric | Count |*'
-        $summaryContent | Should -BeLike '*| Passed |*'
-        $summaryContent | Should -BeLike '*| Failed |*'
-        $summaryContent | Should -BeLike '*| Total |*'
+        $summaryContent | Should -Match '\|\s*Passed\b[^|]*\|'
+        $summaryContent | Should -Match '\|\s*Failed\b[^|]*\|'
+        $summaryContent | Should -Match '\|\s*Total\b[^|]*\|'
     }
 }

--- a/powershell/tests/functions/Invoke-Maester.Tests.ps1
+++ b/powershell/tests/functions/Invoke-Maester.Tests.ps1
@@ -52,4 +52,38 @@
         $Result.SkippedCount | Should -BeExactly $expectedSkippedCount -Because 'counting Skipped'
         $Result.NotRunCount | Should -BeExactly $expectedNotRunCount -Because 'counting Notrun'
     }
+
+    It 'Generates a markdown summary file with counters table' {
+        if (Get-MgContext) { Disconnect-Graph } # Ensure we are disconnected
+
+        $outputRoot = Join-Path -Path $PSScriptRoot -ChildPath '../test-results'
+        $summaryPath = Join-Path -Path ([System.IO.Path]::GetFullPath($outputRoot)) -ChildPath 'TestResults-summary.md'
+
+        if (Test-Path $summaryPath) {
+            Remove-Item -Path $summaryPath -Force
+        }
+
+        $maesterParams = @{
+            Path                      = [System.IO.Path]::GetFullPath((Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'smoketests'))
+            OutputFolder              = [System.IO.Path]::GetFullPath($outputRoot)
+            PassThru                  = $true
+            SkipGraphConnect          = $true
+            NonInteractive            = $true
+            OutputFolderFileName      = 'TestResults'
+            ExcludeTag                = 'testtag'
+            NoLogo                    = $true
+            OutputMarkdownSummaryFile = $summaryPath
+        }
+
+        $result = Invoke-Maester @maesterParams
+        $result | Should -Not -BeNullOrEmpty -Because 'there should be a result'
+
+        Test-Path $summaryPath | Should -BeTrue -Because 'the markdown summary file should be created'
+
+        $summaryContent = Get-Content -Path $summaryPath -Raw
+        $summaryContent | Should -BeLike '*| Metric | Count |*'
+        $summaryContent | Should -BeLike '*| Passed |*'
+        $summaryContent | Should -BeLike '*| Failed |*'
+        $summaryContent | Should -BeLike '*| Total |*'
+    }
 }

--- a/website/docs/commands/Invoke-Maester.mdx
+++ b/website/docs/commands/Invoke-Maester.mdx
@@ -16,7 +16,7 @@ This is the main Maester command that runs the tests and generates a report of t
 
 ```powershell
 Invoke-Maester [[-Path] <String>] [-Tag <String[]>] [-ExcludeTag <String[]>] [-IncludeLongRunning]
- [-IncludePreview] [-OutputHtmlFile <String>] [-OutputMarkdownFile <String>] [-OutputJsonFile <String>]
+ [-IncludePreview] [-OutputHtmlFile <String>] [-OutputMarkdownFile <String>] [-OutputMarkdownSummaryFile <String>] [-OutputJsonFile <String>]
  [-OutputFolder <String>] [-OutputFolderFileName <String>] [-PesterConfiguration <PesterConfiguration>]
  [-Verbosity <String>] [-NonInteractive] [-PassThru] [-MailRecipient <String[]>] [-MailTestResultsUri <String>]
  [-MailUserId <String>] [-TeamId <String>] [-TeamChannelId <String>] [-TeamChannelWebhookUri <String>]
@@ -264,6 +264,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutputMarkdownSummaryFile
+
+The path to the file to save a compact markdown summary with only result counters.
+The filename should include a .md extension.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutputJsonFile
 
 The path to the file to save the test results in json format.
@@ -285,7 +302,7 @@ Accept wildcard characters: False
 
 The folder to save the test results in.
 If no -Output* is set, defaults to ./test-results.
-If set, other -Output* parameters are ignored and all formats will be generated (markdown, html, json) with a timestamp and saved in the folder.
+If set, other -Output* parameters are ignored and all formats will be generated (markdown, markdown summary, html, json) with a timestamp and saved in the folder.
 
 ```yaml
 Type: String

--- a/website/docs/export-results.md
+++ b/website/docs/export-results.md
@@ -4,6 +4,16 @@ title: 📤 Exporting results
 
 Maester supports exporting test results to CSV and Excel files. This is useful for sharing test results with others or for further analysis in a spreadsheet program.
 
+## Exporting a markdown summary
+
+To export a compact markdown summary that contains only the counters table, use `Invoke-Maester` with `-OutputMarkdownSummaryFile`.
+
+```powershell
+Invoke-Maester -OutputMarkdownSummaryFile "C:\path\to\results-summary.md"
+```
+
+This summary is useful for quick updates in issues, pull requests, and chat messages.
+
 ## Exporting results to CSV
 
 To export test results to a CSV file, use the `Convert-MtResultsToFlatObject` command with the `-CsvFilePath` parameter. The following example exports test results to a CSV file:


### PR DESCRIPTION
## 📑 Description

Recently I've seen many errors in my GitHub action report like
> **Maester 🔥** $GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1026k.

And I already had [this idea](https://github.com/maester365/maester-action/issues/37), to integrate with GitHub actions artifacts.

This PR adds an extra report option (which is just an markdown summary).

Closes # <!-- Issue # here -->

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [x] My pull request adheres to the code style of this project.
- [x] My code requires changes to the documentation.
- [x] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information

<img width="977" height="518" alt="image" src="https://github.com/user-attachments/assets/8dddbe52-6124-4894-a932-74390256402f" />


---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖


@SamErde This is part one of integrating the github action with artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-OutputMarkdownSummaryFile` to generate a compact Markdown “results counters” table (Passed, Failed, Investigate, Skipped, Error, Not Run, Total).
  * When using `-OutputFolder`, the Markdown summary is auto-generated with a timestamped filename alongside other report formats.
* **Documentation**
  * Updated `Invoke-Maester` docs and the export-results guide with the new Markdown summary option, requirements, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->