### PR TITLE
Fix incorrect default in Microsoft 365 Group creation test (Test-MtGroupCreationRestricted.ps1)

### DIFF
--- a/powershell/public/maester/entra/Test-MtGroupCreationRestricted.ps1
+++ b/powershell/public/maester/entra/Test-MtGroupCreationRestricted.ps1
@@ -25,13 +25,14 @@
     try {
         $settings = Invoke-MtGraphRequest -RelativeUri 'settings' -ApiVersion 'beta'
 
+        # Default tenant behavior: if the setting is absent, group creation is NOT restricted.
         $groupCreationRestricted = $false
 
         $enableGroupCreation = $settings.values | Where-Object { $_.name -eq 'EnableGroupCreation' }
-
         if ($null -ne $enableGroupCreation) {
-            # If the setting is not found, it means that group creation is not restricted.
-            $groupCreationRestricted = ($enableGroupCreation.value -eq 'false')
+            # EnableGroupCreation = 'False' -> restricted to approved users
+            # EnableGroupCreation = 'True'  -> any user can create groups
+            $groupCreationRestricted = ($enableGroupCreation.value -eq 'False')
         }
 
         if ($groupCreationRestricted) {


### PR DESCRIPTION
## 📑 Description
Corrects the comparison casing in the group creation restriction test. Graph returns `EnableGroupCreation` as 'True'/'False', but the check compared against lowercase 'false'. Aligned the comparison to the actual casing returned by the API to make the logic correct and robust against case-sensitive comparison.

I've tested on a few tenant, but please verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group creation restriction logic to ensure consistent handling of configuration settings and provide predictable default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->