### PR TITLE
[DO NOT MERGE] Pester 6.0.0 release candidate update

### DIFF
--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -41,9 +41,9 @@ jobs:
         if: steps.filter.outputs.pwshmodule == 'true'
         shell: pwsh
         run: |
-          # Pester 6.0.0-rc1 is installed explicitly because prereleases are not selected by -MinimumVersion.
+          # Pester 6.0.0-rc4 is installed explicitly because prereleases are not selected by -MinimumVersion.
           # Installed on every leg so behavior stays consistent across the matrix.
-          Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
+          Install-Module Pester -RequiredVersion 6.0.0-rc4 -AllowPrerelease -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module PSFramework -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module PSModuleDevelopment -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module Microsoft.Graph.Authentication -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -41,9 +41,9 @@ jobs:
         if: steps.filter.outputs.pwshmodule == 'true'
         shell: pwsh
         run: |
-          # Pester 5.7.1+ is required for the coverage configuration used in pester.ps1.
+          # Pester 6.0.0-rc1 is installed explicitly because prereleases are not selected by -MinimumVersion.
           # Installed on every leg so behavior stays consistent across the matrix.
-          Install-Module Pester -MinimumVersion 5.7.1 -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
+          Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module PSFramework -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module PSModuleDevelopment -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module Microsoft.Graph.Authentication -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber

--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set up PowerShell modules
         run: |
-          pwsh -NoLogo -NoProfile -Command "Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck"
+          pwsh -NoLogo -NoProfile -Command "Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck"
 
       - name: Generate tags document
         run: pwsh -NoLogo -NoProfile -File build/Update-TagsDocumentation.ps1

--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set up PowerShell modules
         run: |
-          pwsh -NoLogo -NoProfile -Command "Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck"
+          pwsh -NoLogo -NoProfile -Command "Install-Module Pester -RequiredVersion 6.0.0-rc4 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck"
 
       - name: Generate tags document
         run: pwsh -NoLogo -NoProfile -File build/Update-TagsDocumentation.ps1

--- a/build/Test-PSModule.ps1
+++ b/build/Test-PSModule.ps1
@@ -33,7 +33,7 @@ Import-Module "$PSScriptRoot\CommonFunctions.psm1" -Force -WarningAction Silentl
 ## Restore Module Dependencies
 &$PSScriptRoot\Restore-PSModuleDependencies.ps1 -ModuleManifestPath $ModuleManifestPath -PSModuleCacheDirectory $PSModuleCacheDirectoryInfo.FullName | Out-Null
 
-Import-Module Pester -MinimumVersion 5.0.0
+Import-Module Pester -RequiredVersion 6.0.0
 #$PSModule = Import-Module $ModulePath -PassThru -Force
 
 $PesterConfiguration = New-PesterConfiguration (Import-PowerShellDataFile $PesterConfigurationFileInfo.FullName)

--- a/build/Update-CommandReference.ps1
+++ b/build/Update-CommandReference.ps1
@@ -4,11 +4,11 @@
 
 if (-not (Get-Module Alt3.Docusaurus.Powershell -ListAvailable)) { Install-Module Alt3.Docusaurus.Powershell -Scope CurrentUser -Force -SkipPublisherCheck }
 if (-not (Get-Module PlatyPS -ListAvailable)) { Install-Module PlatyPS -Scope CurrentUser -Force -SkipPublisherCheck }
-if (-not (Get-Module Pester -ListAvailable)) { Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck }
+if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq '6.0.0' })) { Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck }
 
 Import-Module Alt3.Docusaurus.Powershell
 Import-Module PlatyPS
-Import-Module Pester
+Import-Module Pester -RequiredVersion 6.0.0
 Import-Module DnsClient
 
 # Generate the command reference markdown

--- a/build/Update-CommandReference.ps1
+++ b/build/Update-CommandReference.ps1
@@ -4,7 +4,7 @@
 
 if (-not (Get-Module Alt3.Docusaurus.Powershell -ListAvailable)) { Install-Module Alt3.Docusaurus.Powershell -Scope CurrentUser -Force -SkipPublisherCheck }
 if (-not (Get-Module PlatyPS -ListAvailable)) { Install-Module PlatyPS -Scope CurrentUser -Force -SkipPublisherCheck }
-if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq '6.0.0' })) { Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck }
+if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq '6.0.0' })) { Install-Module Pester -RequiredVersion 6.0.0-rc4 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck }
 
 Import-Module Alt3.Docusaurus.Powershell
 Import-Module PlatyPS

--- a/powershell/tests/pester.ps1
+++ b/powershell/tests/pester.ps1
@@ -26,7 +26,7 @@ Remove-Module Maester -ErrorAction Ignore
 Import-Module "$PSScriptRoot\..\Maester.psd1"
 
 Import-Module PSModuleDevelopment
-Import-Module Pester
+Import-Module Pester -RequiredVersion 6.0.0
 
 Write-PSFMessage -Level Important -Message "Creating test result folder"
 $null = New-Item -Path "$PSScriptRoot\..\.." -Name TestResults -ItemType Directory -Force


### PR DESCRIPTION
Hi — Pester 6.0.0 is almost ready, and before I release it I'm trying it out
against real-world Pester v5 test suites.

This PR updates Pester to the 6.0.0 release candidate and makes the changes
needed for your tests to run on it. I opened it to learn two things:

- whether migrating from v5 to v6 is straightforward, and
- where v6 breaks or behaves differently, so I can fix those things before the
  final release instead of after.

You don't need to merge this, and I'd suggest you don't — it's only meant to
show what a v6 update would involve and to give me feedback. Please leave it
open, though: if more release candidates come out I'll push those updates here
too, and I'll close it myself afterwards.

This PR was co-authored by GitHub Copilot. If you'd rather not receive
AI-assisted PRs, just close it and I won't open one for the next release.

Thanks for the CI time this run used, and for maintaining a suite I could test
against.

— Jakub & Copilot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell build and test stability by standardizing on Pester **6.0.0** across automation and scripts.
  * Reduced version-mismatch failures during validation, documentation generation, and test runs.
  * Updated prerelease installation behavior to ensure the required Pester version is available consistently.

* **Tests**
  * Adjusted the PowerShell test runner to import Pester with an explicit required version (no longer relying on default module resolution).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->