### PR TITLE
fix: relax line ending attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,25 +1,3 @@
-# Normalize line endings: text files are stored with LF in the repository.
-* text=auto
-
-# Files that must always use LF, both in the repository and in the working tree.
-*.yml text eol=lf
-*.yaml text eol=lf
-*.sh text eol=lf
-*.js text eol=lf
-*.mjs text eol=lf
-*.ts text eol=lf
-*.tsx text eol=lf
-*.json text eol=lf
-*.md text eol=lf
-*.svg text eol=lf
-
-# PowerShell files: stored with LF in the repository; working tree EOL follows each user's Git settings
-# (e.g., core.autocrlf) so Windows contributors can keep a native experience.
-*.ps1 text
-*.psm1 text
-*.psd1 text
-*.ps1xml text
-
 # Binary files.
 *.png binary
 *.jpg binary


### PR DESCRIPTION
## Summary

Relaxes `.gitattributes` so the repository no longer forces text line-ending normalization while existing committed files still contain a mix of CRLF, LF, and mixed endings.

## Why

The previous `.gitattributes` rules asked Git to normalize text files, including YAML, Markdown, and PowerShell files. Because many existing committed files were not renormalized at the same time, contributors could see large phantom local diffs after pulling or switching branches.

## Impact

This keeps the binary file protections in `.gitattributes`, but removes the text normalization rules that caused Git to report line-ending-only changes. The PR now avoids the large 27-file normalization diff.

## Validation

- `git status -sb` showed only `.gitattributes` changed before commit.
- The pushed PR branch contains a single `.gitattributes` commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository file-handling settings by removing line-ending and binary-file normalization rules. This should not affect end-user features directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->