### PR TITLE
Skip build-validation-report when report files are unchanged

### DIFF
--- a/.github/workflows/build-validation-report.yaml
+++ b/.github/workflows/build-validation-report.yaml
@@ -12,7 +12,6 @@ jobs:
       contents: read
       actions: read
       pull-requests: read
-      checks: write
     runs-on: ubuntu-latest
     steps:
       - name: Detect report-related file changes
@@ -51,25 +50,11 @@ jobs:
 
             core.setOutput('should-run-reporter', hasRelevantChanges ? 'true' : 'false');
 
-      - name: Mark report as skipped when not relevant
+      - name: Skip report parsing when not relevant
         if: steps.changed-files.outputs.should-run-reporter != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Maester Test Results',
-              head_sha: context.payload.workflow_run.head_sha,
-              status: 'completed',
-              conclusion: 'success',
-              output: {
-                title: 'Maester Test Results (skipped)',
-                summary: 'No build/report-related files were modified in this pull request, so report parsing was skipped.',
-              },
-            });
-
-            core.info('Skipped test report parsing because no report-related files were modified.');
+        run: |
+          echo "No build/report-related files were modified in this pull request."
+          echo "Skipping test report parsing."
 
       # fail-on-error is set to false so that PRs which don't touch the path-filtered
       # files (build/**, powershell/**, report/**, tests/**) — and bot-created PRs where

--- a/.github/workflows/build-validation-report.yaml
+++ b/.github/workflows/build-validation-report.yaml
@@ -11,49 +11,38 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
-      - name: Detect report-related file changes
-        id: changed-files
+      - name: Detect test results artifact
+        id: test-results
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const pullRequests = context.payload.workflow_run.pull_requests ?? [];
-            if (pullRequests.length === 0) {
-              core.info('No pull request context on workflow_run; skipping report generation.');
-              core.setOutput('should-run-reporter', 'false');
-              return;
-            }
-
-            const includeMatchers = [
-              /^build\//,
-              /^powershell\//,
-              /^report\//,
-              /^tests\//,
-              /^\.github\/workflows\/build-validation\.yaml$/,
-            ];
-
-            const changedFiles = await github.paginate(
-              github.rest.pulls.listFiles,
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
               {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: pullRequests[0].number,
+                run_id: context.payload.workflow_run.id,
                 per_page: 100,
               },
             );
 
-            const hasRelevantChanges = changedFiles.some((file) =>
-              includeMatchers.some((matcher) => matcher.test(file.filename)),
+            const hasTestResults = artifacts.some((artifact) =>
+              artifact.name === 'test-results-Windows' && !artifact.expired,
             );
 
-            core.setOutput('should-run-reporter', hasRelevantChanges ? 'true' : 'false');
+            core.info(hasTestResults
+              ? 'Found test-results-Windows artifact; running test report parsing.'
+              : 'No test-results-Windows artifact was uploaded; skipping test report parsing.');
+            core.setOutput('found', hasTestResults ? 'true' : 'false');
 
-      - name: Skip report parsing when not relevant
-        if: steps.changed-files.outputs.should-run-reporter != 'true'
+      - name: Skip report parsing when no results were uploaded
+        if: steps.test-results.outputs.found != 'true'
         run: |
-          echo "No build/report-related files were modified in this pull request."
+          echo "No test-results-Windows artifact was uploaded by build-validation."
+          echo "This usually means the pull request did not modify build/report/test-related files."
           echo "Skipping test report parsing."
 
       # fail-on-error is set to false so that PRs which don't touch the path-filtered
@@ -62,7 +51,7 @@ jobs:
       # that will never be uploaded. Trade-off: if tests *should* have run but the upload
       # step failed silently, this check will report neutral instead of failing.
       - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: steps.changed-files.outputs.should-run-reporter == 'true'
+        if: steps.test-results.outputs.found == 'true'
         with:
           artifact: test-results-Windows
           name: Maester Test Results

--- a/.github/workflows/build-validation-report.yaml
+++ b/.github/workflows/build-validation-report.yaml
@@ -45,11 +45,9 @@ jobs:
           echo "This usually means the pull request did not modify build/report/test-related files."
           echo "Skipping test report parsing."
 
-      # fail-on-error is set to false so that PRs which don't touch the path-filtered
-      # files (build/**, powershell/**, report/**, tests/**) — and bot-created PRs where
-      # GITHUB_TOKEN suppresses workflow triggers — don't get stuck waiting for an artifact
-      # that will never be uploaded. Trade-off: if tests *should* have run but the upload
-      # step failed silently, this check will report neutral instead of failing.
+      # The reporter is gated on artifact detection, so PRs without path-filtered file
+      # changes skip this step entirely. fail-on-error is set to false so parsing
+      # problems in an existing artifact report neutral instead of failing the job.
       - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: steps.test-results.outputs.found == 'true'
         with:

--- a/.github/workflows/build-validation-report.yaml
+++ b/.github/workflows/build-validation-report.yaml
@@ -11,16 +11,73 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: read
       checks: write
     runs-on: ubuntu-latest
     steps:
+      - name: Detect report-related file changes
+        id: changed-files
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const pullRequests = context.payload.workflow_run.pull_requests ?? [];
+            if (pullRequests.length === 0) {
+              core.info('No pull request context on workflow_run; skipping report generation.');
+              core.setOutput('should-run-reporter', 'false');
+              return;
+            }
+
+            const includeMatchers = [
+              /^build\//,
+              /^powershell\//,
+              /^report\//,
+              /^tests\//,
+              /^\.github\/workflows\/build-validation\.yaml$/,
+            ];
+
+            const changedFiles = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullRequests[0].number,
+                per_page: 100,
+              },
+            );
+
+            const hasRelevantChanges = changedFiles.some((file) =>
+              includeMatchers.some((matcher) => matcher.test(file.filename)),
+            );
+
+            core.setOutput('should-run-reporter', hasRelevantChanges ? 'true' : 'false');
+
+      - name: Mark report as skipped when not relevant
+        if: steps.changed-files.outputs.should-run-reporter != 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Maester Test Results',
+              head_sha: context.payload.workflow_run.head_sha,
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: 'Maester Test Results (skipped)',
+                summary: 'No build/report-related files were modified in this pull request, so report parsing was skipped.',
+              },
+            });
+
+            core.info('Skipped test report parsing because no report-related files were modified.');
+
       # fail-on-error is set to false so that PRs which don't touch the path-filtered
-      # files (powershell/**, report/**, tests/**) — and bot-created PRs where GITHUB_TOKEN
-      # suppresses workflow triggers — don't get stuck waiting for an artifact that will
-      # never be uploaded. Trade-off: if tests *should* have run but the upload step failed
-      # silently, this check will report neutral instead of failing. Consider moving to a
-      # fan-in required-status-check pattern (Option 3) for a more robust long-term solution.
+      # files (build/**, powershell/**, report/**, tests/**) — and bot-created PRs where
+      # GITHUB_TOKEN suppresses workflow triggers — don't get stuck waiting for an artifact
+      # that will never be uploaded. Trade-off: if tests *should* have run but the upload
+      # step failed silently, this check will report neutral instead of failing.
       - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: steps.changed-files.outputs.should-run-reporter == 'true'
         with:
           artifact: test-results-Windows
           name: Maester Test Results


### PR DESCRIPTION
## 📑 Description

This change fixes noisy failures in `build-validation-report` for PRs that do not modify build/report/test-related files. Previously the workflow always attempted to parse test artifacts and failed with "no test report files were found" on unrelated PRs.

The workflow now checks whether the triggering `build-validation` run actually uploaded a `test-results-Windows` artifact and only runs `dorny/test-reporter` when it exists. When no artifact was uploaded (i.e., the PR did not touch path-filtered files, so tests never ran), the job logs a clear skip message and ends successfully.

Artifact presence is used as the gate (rather than inspecting PR file lists) because it is the ground truth for whether results exist, and it works for fork PRs where `workflow_run.pull_requests` is empty.

Closes # N/A

## ✅ Checks

- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [ ] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information

- The job itself always runs and succeeds on skips, so this remains compatible with required PR check configurations.
- Both actions are SHA-pinned, and job permissions follow least privilege (`contents: read`, `actions: read`, `checks: write` — the latter required by `dorny/test-reporter` to publish check runs).
- `fail-on-error: false` now only governs parsing problems within an artifact that was found; the skip path is handled by the artifact gate.

---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖