### PR TITLE
Add Discord codebase digest workflow

### DIFF
--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -7,6 +7,7 @@ const DEFAULT_BRANCH = process.env.DIGEST_BRANCH || "main";
 const TIME_ZONE = "Australia/Melbourne";
 const DISCORD_LIMIT = 1800;
 const DISCORD_SUPPRESS_EMBEDS = 1 << 2;
+const MAX_COMMIT_PAGES = 100;
 
 const token = process.env.GITHUB_TOKEN;
 const dryRun = parseBoolean(process.env.DIGEST_DRY_RUN ?? process.env.DRY_RUN, false);
@@ -196,7 +197,7 @@ async function buildDigest({ owner, repo, commits }) {
 async function fetchCommits({ owner, repo, branch, since, until }) {
   const all = [];
 
-  for (let page = 1; page <= 10; page++) {
+  for (let page = 1; page <= MAX_COMMIT_PAGES; page++) {
     const pageItems = await githubJson(githubCommitsPath({
       owner,
       repo,
@@ -210,6 +211,10 @@ async function fetchCommits({ owner, repo, branch, since, until }) {
     if (pageItems.length < 100) {
       break;
     }
+
+    if (page === MAX_COMMIT_PAGES) {
+      fail(`Commit pagination exceeded ${MAX_COMMIT_PAGES * 100} commits; narrow the digest window.`);
+    }
   }
 
   return all;
@@ -219,8 +224,12 @@ async function fetchPullRequest({ owner, repo, number }) {
   try {
     return await githubJson(githubPullRequestPath({ owner, repo, number }));
   } catch (error) {
-    console.warn(`Warning: could not fetch PR #${number}: ${error.message}`);
-    return null;
+    if (error.status === 404) {
+      console.warn(`Warning: PR #${number} was not found; treating commit as a direct commit.`);
+      return null;
+    }
+
+    throw error;
   }
 }
 
@@ -235,7 +244,7 @@ async function githubJson(path) {
   });
 
   if (!response.ok) {
-    throw new Error(`GitHub API ${path} failed (${response.status}): ${response.body}`);
+    throw githubApiError(path, response);
   }
 
   return JSON.parse(response.body);
@@ -653,6 +662,12 @@ function parseJson(value, fallback) {
   }
 }
 
+function githubApiError(path, response) {
+  const error = new Error(`GitHub API ${path} failed (${response.status}): ${response.body}`);
+  error.status = response.status;
+  return error;
+}
+
 function parseMonthKey(value, name) {
   const match = String(value).match(/^(\d{4})-(\d{2})$/);
   if (!match) {
@@ -690,13 +705,20 @@ function enumerateMonths(start, end) {
 }
 
 function monthStart(month) {
-  return new Date(Date.UTC(month.year, month.month - 1, 1, 0, 0, 0));
+  return melbourneLocalTimeToUtc({
+    year: month.year,
+    month: month.month,
+    day: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  });
 }
 
 function nextMonthStart(month) {
   return month.month === 12
-    ? new Date(Date.UTC(month.year + 1, 0, 1, 0, 0, 0))
-    : new Date(Date.UTC(month.year, month.month, 1, 0, 0, 0));
+    ? monthStart({ year: month.year + 1, month: 1 })
+    : monthStart({ year: month.year, month: month.month + 1 });
 }
 
 function currentMonthKey(date) {
@@ -709,6 +731,60 @@ function currentMonthKey(date) {
   const year = parts.find((part) => part.type === "year")?.value;
   const month = parts.find((part) => part.type === "month")?.value;
   return `${year}-${month}`;
+}
+
+function melbourneLocalTimeToUtc(target) {
+  let utc = new Date(Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute,
+    target.second,
+  ));
+  const targetUtc = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute,
+    target.second,
+  );
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const parts = melbourneParts(utc);
+    const actualUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+    const diff = actualUtc - targetUtc;
+    if (diff === 0) {
+      return utc;
+    }
+
+    utc = new Date(utc.getTime() - diff);
+  }
+
+  return utc;
+}
+
+function melbourneParts(date) {
+  const parts = new Intl.DateTimeFormat("en-AU", {
+    timeZone: TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+
+  return {
+    year: Number(parts.find((part) => part.type === "year")?.value),
+    month: Number(parts.find((part) => part.type === "month")?.value),
+    day: Number(parts.find((part) => part.type === "day")?.value),
+    hour: Number(parts.find((part) => part.type === "hour")?.value),
+    minute: Number(parts.find((part) => part.type === "minute")?.value),
+    second: Number(parts.find((part) => part.type === "second")?.value),
+  };
 }
 
 function melbourneHour(date) {

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -87,6 +87,7 @@ async function buildDigest({ owner, repo, commits }) {
             url: pr.html_url,
             commitSha: commit.sha,
             commitUrl: commit.html_url,
+            contributor: contributorFromPullRequest(pr),
           });
         }
         continue;
@@ -97,6 +98,7 @@ async function buildDigest({ owner, repo, commits }) {
       title: sanitizeTitle(title),
       sha: commit.sha,
       url: commit.html_url,
+      contributor: contributorFromCommit(commit),
     });
   }
 
@@ -204,7 +206,7 @@ function buildDiscordChunks(digest, { since, until }) {
     entries.push({ text: "**Merged PRs**", section: "Merged PRs", heading: true });
     for (const pr of digest.mergedPrs) {
       entries.push({
-        text: `- [\`${shortSha(pr.commitSha)}\`](${pr.commitUrl}) ${truncate(pr.title)} ([#${pr.number}](${pr.url}))`,
+        text: `- [\`${shortSha(pr.commitSha)}\`](${pr.commitUrl}) ${truncate(pr.title)} by ${formatContributor(pr.contributor)} ([#${pr.number}](${pr.url}))`,
         section: "Merged PRs",
       });
     }
@@ -215,7 +217,7 @@ function buildDiscordChunks(digest, { since, until }) {
     entries.push({ text: "**Direct commits**", section: "Direct commits", heading: true });
     for (const commit of digest.directCommits) {
       entries.push({
-        text: `- [\`${shortSha(commit.sha)}\`](${commit.url}) ${truncate(commit.title)}`,
+        text: `- [\`${shortSha(commit.sha)}\`](${commit.url}) ${truncate(commit.title)} by ${formatContributor(commit.contributor)}`,
         section: "Direct commits",
       });
     }
@@ -331,6 +333,43 @@ function isDependencyUpdate(title) {
     || /\bbump\b.+\bfrom\b.+\bto\b/i.test(title);
 }
 
+function contributorFromPullRequest(pr) {
+  if (pr.user?.login) {
+    return {
+      name: pr.user.login,
+      url: pr.user.html_url || `https://github.com/${pr.user.login}`,
+    };
+  }
+
+  return { name: "unknown" };
+}
+
+function contributorFromCommit(commit) {
+  if (commit.author?.login) {
+    return {
+      name: commit.author.login,
+      url: commit.author.html_url || `https://github.com/${commit.author.login}`,
+    };
+  }
+
+  return {
+    name: sanitizeTitle(commit.commit?.author?.name || "unknown"),
+  };
+}
+
+function formatContributor(contributor) {
+  if (!contributor?.name) {
+    return "unknown";
+  }
+
+  const name = escapeMarkdown(contributor.name);
+  if (contributor.url) {
+    return `[${name}](${contributor.url})`;
+  }
+
+  return name;
+}
+
 function commitTitle(commit) {
   return sanitizeTitle(commit.commit?.message?.split("\n")[0] || commit.sha);
 }
@@ -340,6 +379,10 @@ function sanitizeTitle(value) {
     .replace(/[\r\n]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function escapeMarkdown(value) {
+  return String(value).replace(/([\\`*_{}[\]()#+.!|-])/g, "\\$1");
 }
 
 function truncate(value, maxLength = 240) {

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+
+const API_ROOT = process.env.GITHUB_API_URL || "https://api.github.com";
+const REPOSITORY = process.env.GITHUB_REPOSITORY || "maester365/maester";
+const DEFAULT_BRANCH = process.env.DIGEST_BRANCH || "main";
+const TIME_ZONE = "Australia/Melbourne";
+const DISCORD_LIMIT = 1800;
+const DEFAULT_AVATAR_URL = "https://maester.dev/img/maester.png";
+
+const token = process.env.GITHUB_TOKEN;
+const dryRun = parseBoolean(process.env.DIGEST_DRY_RUN ?? process.env.DRY_RUN, false);
+const forcePost = parseBoolean(process.env.DIGEST_FORCE_POST ?? process.env.FORCE_POST, false);
+const sinceHours = parseSinceHours(process.env.DIGEST_SINCE_HOURS ?? process.env.SINCE_HOURS ?? "24");
+const webhookUrl = process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL;
+const avatarUrl = process.env.DISCORD_AVATAR_URL || DEFAULT_AVATAR_URL;
+const now = new Date(process.env.DIGEST_NOW || Date.now());
+
+if (!token) {
+  fail("GITHUB_TOKEN is required.");
+}
+
+if (!dryRun && !forcePost && melbourneHour(now) !== 9) {
+  console.log(`Skipping: local time in ${TIME_ZONE} is ${formatMelbourne(now)}, not 9am.`);
+  process.exit(0);
+}
+
+const until = now;
+const since = new Date(until.getTime() - sinceHours * 60 * 60 * 1000);
+const [owner, repo] = REPOSITORY.split("/");
+
+if (!owner || !repo) {
+  fail(`GITHUB_REPOSITORY must be owner/repo. Received: ${REPOSITORY}`);
+}
+
+console.log(`Building digest for ${REPOSITORY}@${DEFAULT_BRANCH}`);
+console.log(`Window: ${since.toISOString()} to ${until.toISOString()} (${TIME_ZONE})`);
+console.log(`Mode: ${dryRun ? "dry run" : "post"}${forcePost ? " (forced)" : ""}`);
+
+const commits = await fetchCommits({ owner, repo, branch: DEFAULT_BRANCH, since, until });
+const digest = await buildDigest({ owner, repo, commits });
+
+if (digest.total === 0) {
+  console.log("No qualifying human codebase updates found. Nothing to post.");
+  process.exit(0);
+}
+
+const chunks = buildDiscordChunks(digest, { since, until });
+
+if (dryRun) {
+  console.log(`Dry run generated ${chunks.length} Discord post(s).`);
+  for (const [index, chunk] of chunks.entries()) {
+    console.log(`\n--- Discord post ${index + 1}/${chunks.length} (${chunk.length} chars) ---\n${chunk}`);
+  }
+  process.exit(0);
+}
+
+if (!webhookUrl) {
+  fail("DISCORD_CODEBASE_WEBHOOK_URL is required when not running in dry-run mode.");
+}
+
+for (const [index, chunk] of chunks.entries()) {
+  await postDiscord(chunk);
+  console.log(`Posted Discord digest chunk ${index + 1}/${chunks.length}.`);
+}
+
+async function buildDigest({ owner, repo, commits }) {
+  const mergedPrs = [];
+  const directCommits = [];
+  const seenPrs = new Set();
+
+  for (const commit of commits) {
+    const title = commitTitle(commit);
+    const prNumber = extractPullRequestNumber(title);
+
+    if (isExcludedCommit(commit, title)) {
+      continue;
+    }
+
+    if (prNumber) {
+      const pr = await fetchPullRequest({ owner, repo, number: prNumber });
+      if (pr && isMergedToBranch(pr, DEFAULT_BRANCH) && !isExcludedPullRequest(pr)) {
+        if (!seenPrs.has(pr.number)) {
+          seenPrs.add(pr.number);
+          mergedPrs.push({
+            number: pr.number,
+            title: sanitizeTitle(pr.title),
+            url: pr.html_url,
+            commitSha: commit.sha,
+            commitUrl: commit.html_url,
+          });
+        }
+        continue;
+      }
+    }
+
+    directCommits.push({
+      title: sanitizeTitle(title),
+      sha: commit.sha,
+      url: commit.html_url,
+    });
+  }
+
+  return {
+    mergedPrs,
+    directCommits,
+    total: mergedPrs.length + directCommits.length,
+  };
+}
+
+async function fetchCommits({ owner, repo, branch, since, until }) {
+  const all = [];
+
+  for (let page = 1; page <= 10; page++) {
+    const params = new URLSearchParams({
+      sha: branch,
+      since: since.toISOString(),
+      until: until.toISOString(),
+      per_page: "100",
+      page: String(page),
+    });
+
+    const pageItems = await githubJson(`/repos/${owner}/${repo}/commits?${params}`);
+    all.push(...pageItems);
+
+    if (pageItems.length < 100) {
+      break;
+    }
+  }
+
+  return all;
+}
+
+async function fetchPullRequest({ owner, repo, number }) {
+  try {
+    return await githubJson(`/repos/${owner}/${repo}/pulls/${number}`);
+  } catch (error) {
+    console.warn(`Warning: could not fetch PR #${number}: ${error.message}`);
+    return null;
+  }
+}
+
+async function githubJson(path) {
+  const response = await fetch(`${API_ROOT}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "maester-discord-codebase-digest",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${path} failed (${response.status}): ${body}`);
+  }
+
+  return response.json();
+}
+
+async function postDiscord(content) {
+  const payload = {
+    username: "Maester bot",
+    avatar_url: avatarUrl,
+    content,
+    allowed_mentions: { parse: [] },
+  };
+
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 429) {
+      const rateLimit = await response.json().catch(() => ({ retry_after: 1 }));
+      const delayMs = Math.ceil((rateLimit.retry_after ?? 1) * 1000);
+      await sleep(delayMs);
+      continue;
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Discord webhook failed (${response.status}): ${body}`);
+    }
+
+    return;
+  }
+
+  throw new Error("Discord webhook failed after retrying rate limits.");
+}
+
+function buildDiscordChunks(digest, { since, until }) {
+  const entries = [];
+
+  entries.push({ text: `_${formatMelbourne(since)} - ${formatMelbourne(until)}_` });
+  entries.push({ text: "" });
+
+  if (digest.mergedPrs.length > 0) {
+    entries.push({ text: "**Merged PRs**", section: "Merged PRs", heading: true });
+    for (const pr of digest.mergedPrs) {
+      entries.push({
+        text: `- [\`${shortSha(pr.commitSha)}\`](${pr.commitUrl}) ${truncate(pr.title)} ([#${pr.number}](${pr.url}))`,
+        section: "Merged PRs",
+      });
+    }
+    entries.push({ text: "" });
+  }
+
+  if (digest.directCommits.length > 0) {
+    entries.push({ text: "**Direct commits**", section: "Direct commits", heading: true });
+    for (const commit of digest.directCommits) {
+      entries.push({
+        text: `- [\`${shortSha(commit.sha)}\`](${commit.url}) ${truncate(commit.title)}`,
+        section: "Direct commits",
+      });
+    }
+  }
+
+  return splitPosts(entries);
+}
+
+function splitPosts(entries) {
+  let chunks = splitWithHeader(entries, (page, total) => header(page, total));
+  let previousCount = 0;
+
+  while (chunks.length !== previousCount) {
+    previousCount = chunks.length;
+    chunks = splitWithHeader(entries, (page) => header(page, previousCount));
+  }
+
+  return chunks;
+}
+
+function splitWithHeader(entries, makeHeader) {
+  const chunks = [];
+  let page = 1;
+  let current = makeHeader(page, 1);
+  let currentSection = null;
+
+  for (const entry of entries) {
+    const line = entry.text.length > DISCORD_LIMIT / 2 ? truncate(entry.text, 900) : entry.text;
+    const candidate = `${current}\n${line}`;
+
+    if (candidate.length > DISCORD_LIMIT && current !== makeHeader(page, 1)) {
+      chunks.push(current.trimEnd());
+      page += 1;
+      current = makeHeader(page, 1);
+      if (entry.section && !entry.heading && entry.section === currentSection) {
+        current = `${current}\n**${entry.section} continued**`;
+      }
+      current = `${current}\n${line}`;
+    } else {
+      current = candidate;
+    }
+
+    if (entry.section) {
+      currentSection = entry.section;
+    }
+  }
+
+  chunks.push(current.trimEnd());
+  return chunks;
+}
+
+function header(page, total) {
+  if (total > 1) {
+    return `**Maester codebase update (${page}/${total})**`;
+  }
+
+  return "**Maester codebase update**";
+}
+
+function extractPullRequestNumber(title) {
+  const squashMatch = title.match(/\(#(\d+)\)\s*$/);
+  if (squashMatch) {
+    return Number(squashMatch[1]);
+  }
+
+  const mergeMatch = title.match(/^Merge pull request #(\d+)\b/);
+  if (mergeMatch) {
+    return Number(mergeMatch[1]);
+  }
+
+  return null;
+}
+
+function isMergedToBranch(pr, branch) {
+  return pr.merged_at && pr.base?.ref === branch;
+}
+
+function isExcludedCommit(commit, title) {
+  return isBotLogin(commit.author?.login)
+    || isBotLogin(commit.committer?.login)
+    || isBotName(commit.commit?.author?.name)
+    || isBotName(commit.commit?.committer?.name)
+    || isDependencyUpdate(title);
+}
+
+function isExcludedPullRequest(pr) {
+  return isBotLogin(pr.user?.login) || isDependencyUpdate(pr.title);
+}
+
+function isBotLogin(login) {
+  if (!login) {
+    return false;
+  }
+
+  return login.endsWith("[bot]")
+    || login === "dependabot"
+    || login === "dependabot-preview"
+    || login === "github-actions";
+}
+
+function isBotName(name) {
+  if (!name) {
+    return false;
+  }
+
+  return /\[bot\]/i.test(name) || /dependabot/i.test(name) || /github-actions/i.test(name);
+}
+
+function isDependencyUpdate(title) {
+  return /^chore\(deps\):\s*bump\b/i.test(title)
+    || /^build\(deps\):\s*bump\b/i.test(title)
+    || /^deps:\s*bump\b/i.test(title)
+    || /\bbump\b.+\bfrom\b.+\bto\b/i.test(title);
+}
+
+function commitTitle(commit) {
+  return sanitizeTitle(commit.commit?.message?.split("\n")[0] || commit.sha);
+}
+
+function sanitizeTitle(value) {
+  return String(value)
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncate(value, maxLength = 240) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+function shortSha(sha) {
+  return sha.slice(0, 7);
+}
+
+function parseBoolean(value, defaultValue) {
+  if (value === undefined || value === null || value === "") {
+    return defaultValue;
+  }
+
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function parseSinceHours(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    fail(`since_hours must be a positive number. Received: ${value}`);
+  }
+
+  return parsed;
+}
+
+function melbourneHour(date) {
+  const parts = new Intl.DateTimeFormat("en-AU", {
+    timeZone: TIME_ZONE,
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+
+  return Number(parts.find((part) => part.type === "hour")?.value);
+}
+
+function formatMelbourne(date) {
+  return new Intl.DateTimeFormat("en-AU", {
+    timeZone: TIME_ZONE,
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -5,14 +5,13 @@ const REPOSITORY = process.env.GITHUB_REPOSITORY || "maester365/maester";
 const DEFAULT_BRANCH = process.env.DIGEST_BRANCH || "main";
 const TIME_ZONE = "Australia/Melbourne";
 const DISCORD_LIMIT = 1800;
-const DEFAULT_AVATAR_URL = "https://maester.dev/img/maester.png";
 
 const token = process.env.GITHUB_TOKEN;
 const dryRun = parseBoolean(process.env.DIGEST_DRY_RUN ?? process.env.DRY_RUN, false);
 const forcePost = parseBoolean(process.env.DIGEST_FORCE_POST ?? process.env.FORCE_POST, false);
 const sinceHours = parseSinceHours(process.env.DIGEST_SINCE_HOURS ?? process.env.SINCE_HOURS ?? "24");
 const webhookUrl = process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL;
-const avatarUrl = process.env.DISCORD_AVATAR_URL || DEFAULT_AVATAR_URL;
+const avatarUrl = process.env.DISCORD_AVATAR_URL;
 const now = new Date(process.env.DIGEST_NOW || Date.now());
 
 if (!token) {
@@ -160,10 +159,13 @@ async function githubJson(path) {
 async function postDiscord(content) {
   const payload = {
     username: "Maester bot",
-    avatar_url: avatarUrl,
     content,
     allowed_mentions: { parse: [] },
   };
+
+  if (avatarUrl) {
+    payload.avatar_url = avatarUrl;
+  }
 
   for (let attempt = 1; attempt <= 5; attempt++) {
     const response = await fetch(webhookUrl, {

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const API_ROOT = process.env.GITHUB_API_URL || "https://api.github.com";
+const GITHUB_API_ORIGIN = "https://api.github.com";
 const REPOSITORY = process.env.GITHUB_REPOSITORY || "maester365/maester";
 const DEFAULT_BRANCH = process.env.DIGEST_BRANCH || "main";
 const TIME_ZONE = "Australia/Melbourne";
@@ -11,7 +11,7 @@ const token = process.env.GITHUB_TOKEN;
 const dryRun = parseBoolean(process.env.DIGEST_DRY_RUN ?? process.env.DRY_RUN, false);
 const forcePost = parseBoolean(process.env.DIGEST_FORCE_POST ?? process.env.FORCE_POST, false);
 const sinceHours = parseSinceHours(process.env.DIGEST_SINCE_HOURS ?? process.env.SINCE_HOURS ?? "24");
-const webhookUrl = process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL;
+const webhookUrl = parseDiscordWebhookUrl(process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL);
 const avatarUrl = process.env.DISCORD_AVATAR_URL;
 const now = new Date(process.env.DIGEST_NOW || Date.now());
 const mode = process.env.DIGEST_MODE || "daily";
@@ -20,11 +20,7 @@ if (!token) {
   fail("GITHUB_TOKEN is required.");
 }
 
-const [owner, repo] = REPOSITORY.split("/");
-
-if (!owner || !repo) {
-  fail(`GITHUB_REPOSITORY must be owner/repo. Received: ${REPOSITORY}`);
-}
+const [owner, repo] = parseRepository(REPOSITORY);
 
 if (mode === "monthly-backfill") {
   await runMonthlyBackfill({ owner, repo });
@@ -229,7 +225,7 @@ async function fetchPullRequest({ owner, repo, number }) {
 }
 
 async function githubJson(path) {
-  const response = await fetch(`${API_ROOT}${path}`, {
+  const response = await fetch(githubApiUrl(path), {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
@@ -503,6 +499,52 @@ function parseSinceHours(value) {
   }
 
   return parsed;
+}
+
+function parseRepository(value) {
+  const normalized = String(value);
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(normalized)) {
+    fail(`GITHUB_REPOSITORY must be owner/repo. Received: ${value}`);
+  }
+
+  return normalized.split("/");
+}
+
+function githubApiUrl(path) {
+  if (typeof path !== "string" || !path.startsWith("/")) {
+    fail(`GitHub API path must start with /. Received: ${path}`);
+  }
+
+  const url = new URL(path, GITHUB_API_ORIGIN);
+  if (url.origin !== GITHUB_API_ORIGIN) {
+    fail(`Refusing to call non-GitHub API URL: ${url.origin}`);
+  }
+
+  return url;
+}
+
+function parseDiscordWebhookUrl(value) {
+  if (!value) {
+    return null;
+  }
+
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail("Discord webhook URL is not a valid URL.");
+  }
+
+  const allowedHosts = new Set(["discord.com", "discordapp.com"]);
+  if (url.protocol !== "https:" || !allowedHosts.has(url.hostname.toLowerCase())) {
+    fail("Discord webhook URL must use https://discord.com or https://discordapp.com.");
+  }
+
+  if (!url.pathname.startsWith("/api/webhooks/") || url.username || url.password || url.search || url.hash) {
+    fail("Discord webhook URL must be a Discord /api/webhooks/ URL without credentials, query, or fragment.");
+  }
+
+  return url;
 }
 
 function parseMonthKey(value, name) {

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-const GITHUB_API_ORIGIN = "https://api.github.com";
+import { request } from "node:https";
+
 const REPOSITORY = process.env.GITHUB_REPOSITORY || "maester365/maester";
 const DEFAULT_BRANCH = process.env.DIGEST_BRANCH || "main";
 const TIME_ZONE = "Australia/Melbourne";
@@ -11,7 +12,7 @@ const token = process.env.GITHUB_TOKEN;
 const dryRun = parseBoolean(process.env.DIGEST_DRY_RUN ?? process.env.DRY_RUN, false);
 const forcePost = parseBoolean(process.env.DIGEST_FORCE_POST ?? process.env.FORCE_POST, false);
 const sinceHours = parseSinceHours(process.env.DIGEST_SINCE_HOURS ?? process.env.SINCE_HOURS ?? "24");
-const webhookUrl = parseDiscordWebhookUrl(process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL);
+const discordWebhook = parseDiscordWebhookUrl(process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL);
 const avatarUrl = process.env.DISCORD_AVATAR_URL;
 const now = new Date(process.env.DIGEST_NOW || Date.now());
 const mode = process.env.DIGEST_MODE || "daily";
@@ -74,7 +75,7 @@ async function runMonthlyBackfill({ owner, repo }) {
     fail("Set DIGEST_BACKFILL_CONFIRM='POST HISTORICAL BACKFILL' to post the monthly historical backfill.");
   }
 
-  if (!dryRun && !webhookUrl) {
+  if (!dryRun && !discordWebhook) {
     fail("DISCORD_CODEBASE_WEBHOOK_URL is required when not running in dry-run mode.");
   }
 
@@ -136,7 +137,7 @@ async function outputDiscordChunks(chunks) {
     return;
   }
 
-  if (!webhookUrl) {
+  if (!discordWebhook) {
     fail("DISCORD_CODEBASE_WEBHOOK_URL is required when not running in dry-run mode.");
   }
 
@@ -196,15 +197,14 @@ async function fetchCommits({ owner, repo, branch, since, until }) {
   const all = [];
 
   for (let page = 1; page <= 10; page++) {
-    const params = new URLSearchParams({
-      sha: branch,
-      since: since.toISOString(),
-      until: until.toISOString(),
-      per_page: "100",
-      page: String(page),
-    });
-
-    const pageItems = await githubJson(`/repos/${owner}/${repo}/commits?${params}`);
+    const pageItems = await githubJson(githubCommitsPath({
+      owner,
+      repo,
+      branch,
+      since,
+      until,
+      page,
+    }));
     all.push(...pageItems);
 
     if (pageItems.length < 100) {
@@ -217,7 +217,7 @@ async function fetchCommits({ owner, repo, branch, since, until }) {
 
 async function fetchPullRequest({ owner, repo, number }) {
   try {
-    return await githubJson(`/repos/${owner}/${repo}/pulls/${number}`);
+    return await githubJson(githubPullRequestPath({ owner, repo, number }));
   } catch (error) {
     console.warn(`Warning: could not fetch PR #${number}: ${error.message}`);
     return null;
@@ -225,7 +225,7 @@ async function fetchPullRequest({ owner, repo, number }) {
 }
 
 async function githubJson(path) {
-  const response = await fetch(githubApiUrl(path), {
+  const response = await githubRequest(path, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
@@ -235,11 +235,10 @@ async function githubJson(path) {
   });
 
   if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`GitHub API ${path} failed (${response.status}): ${body}`);
+    throw new Error(`GitHub API ${path} failed (${response.status}): ${response.body}`);
   }
 
-  return response.json();
+  return JSON.parse(response.body);
 }
 
 async function postDiscord(content) {
@@ -255,22 +254,20 @@ async function postDiscord(content) {
   }
 
   for (let attempt = 1; attempt <= 5; attempt++) {
-    const response = await fetch(webhookUrl, {
-      method: "POST",
+    const response = await discordWebhookRequest(discordWebhook.path, {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
 
     if (response.status === 429) {
-      const rateLimit = await response.json().catch(() => ({ retry_after: 1 }));
+      const rateLimit = parseJson(response.body, { retry_after: 1 });
       const delayMs = Math.ceil((rateLimit.retry_after ?? 1) * 1000);
       await sleep(delayMs);
       continue;
     }
 
     if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Discord webhook failed (${response.status}): ${body}`);
+      throw new Error(`Discord webhook failed (${response.status}): ${response.body}`);
     }
 
     return;
@@ -510,17 +507,110 @@ function parseRepository(value) {
   return normalized.split("/");
 }
 
-function githubApiUrl(path) {
-  if (typeof path !== "string" || !path.startsWith("/")) {
-    fail(`GitHub API path must start with /. Received: ${path}`);
+function githubCommitsPath({ owner, repo, branch, since, until, page }) {
+  const params = new URLSearchParams({
+    sha: branch,
+    since: since.toISOString(),
+    until: until.toISOString(),
+    per_page: "100",
+    page: String(page),
+  });
+
+  return `/repos/${pathSegment(owner)}/${pathSegment(repo)}/commits?${params}`;
+}
+
+function githubPullRequestPath({ owner, repo, number }) {
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    fail(`Pull request number must be a positive integer. Received: ${number}`);
   }
 
-  const url = new URL(path, GITHUB_API_ORIGIN);
-  if (url.origin !== GITHUB_API_ORIGIN) {
-    fail(`Refusing to call non-GitHub API URL: ${url.origin}`);
+  return `/repos/${pathSegment(owner)}/${pathSegment(repo)}/pulls/${number}`;
+}
+
+function pathSegment(value) {
+  return encodeURIComponent(value);
+}
+
+function isGithubApiPath(path) {
+  return typeof path === "string"
+    && path.startsWith("/repos/")
+    && !path.startsWith("//")
+    && !path.includes("\\")
+    && !/[\r\n]/.test(path);
+}
+
+function githubRequest(path, { headers }) {
+  if (!isGithubApiPath(path)) {
+    fail(`Refusing to call invalid GitHub API path: ${path}`);
   }
 
-  return url;
+  return new Promise((resolve, reject) => {
+    const req = request({
+      protocol: "https:",
+      hostname: "api.github.com",
+      method: "GET",
+      path,
+      headers,
+    }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        resolve({
+          ok: res.statusCode >= 200 && res.statusCode < 300,
+          status: res.statusCode,
+          body,
+        });
+      });
+    });
+
+    req.setTimeout(30000, () => {
+      req.destroy(new Error("GitHub API request timed out."));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function discordWebhookRequest(path, { headers, body }) {
+  if (!isDiscordWebhookPath(path)) {
+    fail("Refusing to call invalid Discord webhook path.");
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request({
+      protocol: "https:",
+      hostname: "discord.com",
+      method: "POST",
+      path,
+      headers: {
+        ...headers,
+        "Content-Length": Buffer.byteLength(body),
+      },
+    }, (res) => {
+      let responseBody = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        responseBody += chunk;
+      });
+      res.on("end", () => {
+        resolve({
+          ok: res.statusCode >= 200 && res.statusCode < 300,
+          status: res.statusCode,
+          body: responseBody,
+        });
+      });
+    });
+
+    req.setTimeout(30000, () => {
+      req.destroy(new Error("Discord webhook request timed out."));
+    });
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
 }
 
 function parseDiscordWebhookUrl(value) {
@@ -544,7 +634,23 @@ function parseDiscordWebhookUrl(value) {
     fail("Discord webhook URL must be a Discord /api/webhooks/ URL without credentials, query, or fragment.");
   }
 
-  return url;
+  return { path: url.pathname };
+}
+
+function isDiscordWebhookPath(path) {
+  return typeof path === "string"
+    && path.startsWith("/api/webhooks/")
+    && !path.startsWith("//")
+    && !path.includes("\\")
+    && !/[\r\n]/.test(path);
+}
+
+function parseJson(value, fallback) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
 }
 
 function parseMonthKey(value, name) {

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -14,53 +14,140 @@ const sinceHours = parseSinceHours(process.env.DIGEST_SINCE_HOURS ?? process.env
 const webhookUrl = process.env.DISCORD_CODEBASE_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL;
 const avatarUrl = process.env.DISCORD_AVATAR_URL;
 const now = new Date(process.env.DIGEST_NOW || Date.now());
+const mode = process.env.DIGEST_MODE || "daily";
 
 if (!token) {
   fail("GITHUB_TOKEN is required.");
 }
 
-if (!dryRun && !forcePost && melbourneHour(now) !== 9) {
-  console.log(`Skipping: local time in ${TIME_ZONE} is ${formatMelbourne(now)}, not 9am.`);
-  process.exit(0);
-}
-
-const until = now;
-const since = new Date(until.getTime() - sinceHours * 60 * 60 * 1000);
 const [owner, repo] = REPOSITORY.split("/");
 
 if (!owner || !repo) {
   fail(`GITHUB_REPOSITORY must be owner/repo. Received: ${REPOSITORY}`);
 }
 
-console.log(`Building digest for ${REPOSITORY}@${DEFAULT_BRANCH}`);
-console.log(`Window: ${since.toISOString()} to ${until.toISOString()} (${TIME_ZONE})`);
-console.log(`Mode: ${dryRun ? "dry run" : "post"}${forcePost ? " (forced)" : ""}`);
-
-const commits = await fetchCommits({ owner, repo, branch: DEFAULT_BRANCH, since, until });
-const digest = await buildDigest({ owner, repo, commits });
-
-if (digest.total === 0) {
-  console.log("No qualifying human codebase updates found. Nothing to post.");
-  process.exit(0);
+if (mode === "monthly-backfill") {
+  await runMonthlyBackfill({ owner, repo });
+} else if (mode === "daily") {
+  await runDailyDigest({ owner, repo });
+} else {
+  fail(`Unsupported DIGEST_MODE: ${mode}`);
 }
 
-const chunks = buildDiscordChunks(digest, { since, until });
-
-if (dryRun) {
-  console.log(`Dry run generated ${chunks.length} Discord post(s).`);
-  for (const [index, chunk] of chunks.entries()) {
-    console.log(`\n--- Discord post ${index + 1}/${chunks.length} (${chunk.length} chars) ---\n${chunk}`);
+async function runDailyDigest({ owner, repo }) {
+  if (!dryRun && !forcePost && melbourneHour(now) !== 9) {
+    console.log(`Skipping: local time in ${TIME_ZONE} is ${formatMelbourne(now)}, not 9am.`);
+    process.exit(0);
   }
-  process.exit(0);
+
+  const until = now;
+  const since = new Date(until.getTime() - sinceHours * 60 * 60 * 1000);
+
+  console.log(`Building digest for ${REPOSITORY}@${DEFAULT_BRANCH}`);
+  console.log(`Window: ${since.toISOString()} to ${until.toISOString()} (${TIME_ZONE})`);
+  console.log(`Mode: ${dryRun ? "dry run" : "post"}${forcePost ? " (forced)" : ""}`);
+
+  const commits = await fetchCommits({ owner, repo, branch: DEFAULT_BRANCH, since, until });
+  const digest = await buildDigest({ owner, repo, commits });
+
+  if (digest.total === 0) {
+    console.log("No qualifying human codebase updates found. Nothing to post.");
+    process.exit(0);
+  }
+
+  const chunks = buildDiscordChunks(digest, {
+    title: "Maester codebase update",
+    label: formatMelbourneDate(until),
+  });
+
+  await outputDiscordChunks(chunks);
 }
 
-if (!webhookUrl) {
-  fail("DISCORD_CODEBASE_WEBHOOK_URL is required when not running in dry-run mode.");
+async function runMonthlyBackfill({ owner, repo }) {
+  const startMonth = parseMonthKey(process.env.DIGEST_BACKFILL_START_MONTH || "2023-11", "DIGEST_BACKFILL_START_MONTH");
+  const endMonthValue = process.env.DIGEST_BACKFILL_END_MONTH || currentMonthKey(now);
+  const endMonth = parseMonthKey(endMonthValue, "DIGEST_BACKFILL_END_MONTH");
+  const months = enumerateMonths(startMonth, endMonth);
+  const shouldPrintChunks = parseBoolean(process.env.DIGEST_PRINT_CHUNKS, months.length <= 2);
+
+  if (months.length === 0) {
+    fail(`Backfill start month must be before or equal to end month. Received ${startMonth.key} to ${endMonth.key}.`);
+  }
+
+  if (!dryRun && process.env.DIGEST_BACKFILL_CONFIRM !== "POST HISTORICAL BACKFILL") {
+    fail("Set DIGEST_BACKFILL_CONFIRM='POST HISTORICAL BACKFILL' to post the monthly historical backfill.");
+  }
+
+  if (!dryRun && !webhookUrl) {
+    fail("DISCORD_CODEBASE_WEBHOOK_URL is required when not running in dry-run mode.");
+  }
+
+  console.log(`Building monthly backfill for ${REPOSITORY}@${DEFAULT_BRANCH}`);
+  console.log(`Months: ${startMonth.key} to ${endMonth.key}`);
+  console.log(`Mode: ${dryRun ? "dry run" : "post"}`);
+
+  let totalUpdates = 0;
+  let totalPosts = 0;
+  let monthsWithUpdates = 0;
+
+  for (const month of months) {
+    const since = monthStart(month);
+    const until = nextMonthStart(month);
+    const commits = await fetchCommits({ owner, repo, branch: DEFAULT_BRANCH, since, until });
+    const digest = await buildDigest({ owner, repo, commits: [...commits].reverse() });
+
+    if (digest.total === 0) {
+      console.log(`${month.key}: no qualifying human updates.`);
+      continue;
+    }
+
+    const chunks = buildDiscordChunks(digest, {
+      title: "Maester historical codebase update",
+      label: formatMonthLabel(since),
+    });
+
+    totalUpdates += digest.total;
+    totalPosts += chunks.length;
+    monthsWithUpdates += 1;
+
+    console.log(`${month.key}: ${digest.total} update(s), ${chunks.length} Discord post(s).`);
+
+    if (dryRun) {
+      if (shouldPrintChunks) {
+        for (const [index, chunk] of chunks.entries()) {
+          console.log(`\n--- ${month.key} Discord post ${index + 1}/${chunks.length} (${chunk.length} chars) ---\n${chunk}`);
+        }
+      }
+      continue;
+    }
+
+    for (const [index, chunk] of chunks.entries()) {
+      await postDiscord(chunk);
+      console.log(`${month.key}: posted Discord backfill chunk ${index + 1}/${chunks.length}.`);
+      await sleep(750);
+    }
+  }
+
+  console.log(`Backfill complete: ${totalUpdates} update(s) across ${monthsWithUpdates} month(s), ${totalPosts} Discord post(s).`);
 }
 
-for (const [index, chunk] of chunks.entries()) {
-  await postDiscord(chunk);
-  console.log(`Posted Discord digest chunk ${index + 1}/${chunks.length}.`);
+async function outputDiscordChunks(chunks) {
+  if (dryRun) {
+    console.log(`Dry run generated ${chunks.length} Discord post(s).`);
+    for (const [index, chunk] of chunks.entries()) {
+      console.log(`\n--- Discord post ${index + 1}/${chunks.length} (${chunk.length} chars) ---\n${chunk}`);
+    }
+    return;
+  }
+
+  if (!webhookUrl) {
+    fail("DISCORD_CODEBASE_WEBHOOK_URL is required when not running in dry-run mode.");
+  }
+
+  for (const [index, chunk] of chunks.entries()) {
+    await postDiscord(chunk);
+    console.log(`Posted Discord digest chunk ${index + 1}/${chunks.length}.`);
+  }
 }
 
 async function buildDigest({ owner, repo, commits }) {
@@ -196,10 +283,10 @@ async function postDiscord(content) {
   throw new Error("Discord webhook failed after retrying rate limits.");
 }
 
-function buildDiscordChunks(digest, { since, until }) {
+function buildDiscordChunks(digest, { title, label }) {
   const entries = [];
 
-  entries.push({ text: `_${formatMelbourneDate(until)}_` });
+  entries.push({ text: `_${label}_` });
   entries.push({ text: "" });
 
   if (digest.mergedPrs.length > 0) {
@@ -223,16 +310,16 @@ function buildDiscordChunks(digest, { since, until }) {
     }
   }
 
-  return splitPosts(entries);
+  return splitPosts(entries, title);
 }
 
-function splitPosts(entries) {
-  let chunks = splitWithHeader(entries, (page, total) => header(page, total));
+function splitPosts(entries, title) {
+  let chunks = splitWithHeader(entries, (page, total) => header(title, page, total));
   let previousCount = 0;
 
   while (chunks.length !== previousCount) {
     previousCount = chunks.length;
-    chunks = splitWithHeader(entries, (page) => header(page, previousCount));
+    chunks = splitWithHeader(entries, (page) => header(title, page, previousCount));
   }
 
   return chunks;
@@ -269,12 +356,12 @@ function splitWithHeader(entries, makeHeader) {
   return chunks;
 }
 
-function header(page, total) {
+function header(title, page, total) {
   if (total > 1) {
-    return `**Maester codebase update (${page}/${total})**`;
+    return `**${title} (${page}/${total})**`;
   }
 
-  return "**Maester codebase update**";
+  return `**${title}**`;
 }
 
 function extractPullRequestNumber(title) {
@@ -296,15 +383,19 @@ function isMergedToBranch(pr, branch) {
 }
 
 function isExcludedCommit(commit, title) {
-  return isBotLogin(commit.author?.login)
-    || isBotLogin(commit.committer?.login)
+  return isBotAccount(commit.author)
+    || isBotAccount(commit.committer)
     || isBotName(commit.commit?.author?.name)
     || isBotName(commit.commit?.committer?.name)
     || isDependencyUpdate(title);
 }
 
 function isExcludedPullRequest(pr) {
-  return isBotLogin(pr.user?.login) || isDependencyUpdate(pr.title);
+  return isBotAccount(pr.user) || isDependencyUpdate(pr.title);
+}
+
+function isBotAccount(account) {
+  return isBotLogin(account?.login) || account?.type === "Bot";
 }
 
 function isBotLogin(login) {
@@ -414,6 +505,64 @@ function parseSinceHours(value) {
   return parsed;
 }
 
+function parseMonthKey(value, name) {
+  const match = String(value).match(/^(\d{4})-(\d{2})$/);
+  if (!match) {
+    fail(`${name} must use YYYY-MM format. Received: ${value}`);
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) {
+    fail(`${name} month must be between 01 and 12. Received: ${value}`);
+  }
+
+  return {
+    year,
+    month,
+    key: `${match[1]}-${match[2]}`,
+  };
+}
+
+function enumerateMonths(start, end) {
+  const months = [];
+  let year = start.year;
+  let month = start.month;
+
+  while (year < end.year || (year === end.year && month <= end.month)) {
+    months.push({ year, month, key: `${year}-${String(month).padStart(2, "0")}` });
+    month += 1;
+    if (month > 12) {
+      year += 1;
+      month = 1;
+    }
+  }
+
+  return months;
+}
+
+function monthStart(month) {
+  return new Date(Date.UTC(month.year, month.month - 1, 1, 0, 0, 0));
+}
+
+function nextMonthStart(month) {
+  return month.month === 12
+    ? new Date(Date.UTC(month.year + 1, 0, 1, 0, 0, 0))
+    : new Date(Date.UTC(month.year, month.month, 1, 0, 0, 0));
+}
+
+function currentMonthKey(date) {
+  const parts = new Intl.DateTimeFormat("en-AU", {
+    timeZone: TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(date);
+
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  return `${year}-${month}`;
+}
+
 function melbourneHour(date) {
   const parts = new Intl.DateTimeFormat("en-AU", {
     timeZone: TIME_ZONE,
@@ -436,6 +585,14 @@ function formatMelbourneDate(date) {
   return new Intl.DateTimeFormat("en-AU", {
     timeZone: TIME_ZONE,
     dateStyle: "medium",
+  }).format(date);
+}
+
+function formatMonthLabel(date) {
+  return new Intl.DateTimeFormat("en-AU", {
+    timeZone: TIME_ZONE,
+    month: "long",
+    year: "numeric",
   }).format(date);
 }
 

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -199,7 +199,7 @@ async function postDiscord(content) {
 function buildDiscordChunks(digest, { since, until }) {
   const entries = [];
 
-  entries.push({ text: `_${formatMelbourne(since)} - ${formatMelbourne(until)}_` });
+  entries.push({ text: `_${formatMelbourneDate(until)}_` });
   entries.push({ text: "" });
 
   if (digest.mergedPrs.length > 0) {
@@ -429,6 +429,13 @@ function formatMelbourne(date) {
     timeZone: TIME_ZONE,
     dateStyle: "medium",
     timeStyle: "short",
+  }).format(date);
+}
+
+function formatMelbourneDate(date) {
+  return new Intl.DateTimeFormat("en-AU", {
+    timeZone: TIME_ZONE,
+    dateStyle: "medium",
   }).format(date);
 }
 

--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -5,6 +5,7 @@ const REPOSITORY = process.env.GITHUB_REPOSITORY || "maester365/maester";
 const DEFAULT_BRANCH = process.env.DIGEST_BRANCH || "main";
 const TIME_ZONE = "Australia/Melbourne";
 const DISCORD_LIMIT = 1800;
+const DISCORD_SUPPRESS_EMBEDS = 1 << 2;
 
 const token = process.env.GITHUB_TOKEN;
 const dryRun = parseBoolean(process.env.DIGEST_DRY_RUN ?? process.env.DRY_RUN, false);
@@ -161,6 +162,7 @@ async function postDiscord(content) {
     username: "Maester bot",
     content,
     allowed_mentions: { parse: [] },
+    flags: DISCORD_SUPPRESS_EMBEDS,
   };
 
   if (avatarUrl) {

--- a/.github/workflows/discord-codebase-digest.yml
+++ b/.github/workflows/discord-codebase-digest.yml
@@ -48,7 +48,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DISCORD_CODEBASE_WEBHOOK_URL: ${{ secrets.DISCORD_CODEBASE_WEBHOOK_URL }}
-          DISCORD_AVATAR_URL: "https://maester.dev/img/maester.png"
           DIGEST_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           DIGEST_FORCE_POST: ${{ github.event_name == 'workflow_dispatch' && inputs.force_post || false }}
           DIGEST_SINCE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.since_hours || '24' }}

--- a/.github/workflows/discord-codebase-digest.yml
+++ b/.github/workflows/discord-codebase-digest.yml
@@ -1,0 +1,55 @@
+name: Daily Discord codebase digest
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and log the Discord payload without posting."
+        required: false
+        default: true
+        type: boolean
+      force_post:
+        description: "Post even when it is not 9am in Australia/Melbourne."
+        required: false
+        default: false
+        type: boolean
+      since_hours:
+        description: "How many hours of main branch activity to include."
+        required: false
+        default: "24"
+        type: string
+  schedule:
+    - cron: "0 22 * * *"
+    - cron: "0 23 * * *"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: daily-discord-codebase-digest
+  cancel-in-progress: false
+
+jobs:
+  post-digest:
+    name: Post daily Discord digest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.x"
+
+      - name: Build and post digest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DISCORD_CODEBASE_WEBHOOK_URL: ${{ secrets.DISCORD_CODEBASE_WEBHOOK_URL }}
+          DISCORD_AVATAR_URL: "https://maester.dev/img/maester.png"
+          DIGEST_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          DIGEST_FORCE_POST: ${{ github.event_name == 'workflow_dispatch' && inputs.force_post || false }}
+          DIGEST_SINCE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.since_hours || '24' }}
+        run: node .github/scripts/discord-codebase-digest.mjs

--- a/.github/workflows/discord-codebase-digest.yml
+++ b/.github/workflows/discord-codebase-digest.yml
@@ -34,10 +34,13 @@ jobs:
   post-digest:
     name: Post daily Discord digest
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary

Adds a daily Discord codebase digest for the Maester repo.

- posts a daily 9am Australia/Melbourne digest through a Discord webhook
- uses `GITHUB_TOKEN` with read-only contents/pull-request permissions
- excludes bot/dependency update noise
- formats clickable commit and PR links as Discord Markdown
- splits long digests into multiple safe-size Discord posts

## Discord setup

The `#codebase-updates` Discord channel and `Maester bot` webhook have been created, and `DISCORD_CODEBASE_WEBHOOK_URL` has been saved as a GitHub Actions secret for `maester365/maester`.

## Validation

- `node --check .github/scripts/discord-codebase-digest.mjs`
- local dry run with `DIGEST_DRY_RUN=true DIGEST_SINCE_HOURS=72`
- local no-op check with a near-empty window
- scheduled-time guard check outside 9am Melbourne
- forced live post to `#codebase-updates` verified the webhook posts as `Maester bot` with no user or role mentions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Discord “codebase digest” summarizing recent main-branch activity.
  * Runs daily on a schedule and supports manual runs with dry-run, force post, and configurable lookback; also includes a monthly historical backfill mode.
  * Organizes updates into Discord-ready sections for merged pull requests and direct commits, with safe truncation and chunked delivery.
* **Reliability**
  * Improved posting robustness by retrying on Discord rate limits and handling empty-update cases gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->