### PR TITLE
fix: preserve PowerShell scope in published module

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ For PowerShell coding conventions and rationale, please also review the [PowerSh
 
 ## Build Process
 
-Maester source code lives in `./powershell` (module functions) and `./tests` (bundled test suites). The publishable module is produced by running `./build/Build-MaesterModule.ps1`, which writes a consolidated build artifact to `./module`. The `./module` directory is generated output: it is ignored by git and must never be edited or committed. See the [Maester Contributing Guide](https://maester.dev/docs/contributing) for the full build and development workflow.
+Maester source code lives in `./powershell` (module functions) and `./tests` (bundled test suites). `./build/Build-MaesterModule.ps1` writes a consolidated optimization artifact to `./module`, while `./build/Build-MaesterPackage.ps1` creates the scope-safe source-layout package under `./publish/Maester` that is released to users. Both directories are generated output: they are ignored by git and must never be edited or committed. See the [Maester Contributing Guide](https://maester.dev/docs/contributing) for the full build and development workflow.
 
 ## Recommended PowerShell Practices
 

--- a/.github/actions/publish-maester-module/action.yml
+++ b/.github/actions/publish-maester-module/action.yml
@@ -1,9 +1,8 @@
 name: Build and publish Maester module
 description: >-
-  Builds the Maester module with Build-MaesterModule.ps1, validates the build
-  output, publishes it to the PowerShell Gallery, and zips it for the GitHub
-  release. The ./module directory is a build artifact produced by the build
-  script; it is ignored by git and must never be committed to source control.
+  Validates the consolidated Maester build, creates a scope-safe source-layout
+  package, publishes it to the PowerShell Gallery, and zips it for the GitHub
+  release. Generated module and publish directories are ignored by git.
 
 inputs:
   expected-version:
@@ -35,15 +34,21 @@ runs:
         EXPECTED_VERSION: ${{ inputs.expected-version }}
       run: ./build/Test-MaesterModuleOutput.ps1 -ModulePath ./module -ExpectedVersion $env:EXPECTED_VERSION
 
+    - name: Build scope-safe publish package
+      shell: pwsh
+      run: ./build/Build-MaesterPackage.ps1 -OutputRoot ./publish/Maester
+
+    - name: Validate publish package
+      shell: pwsh
+      env:
+        EXPECTED_VERSION: ${{ inputs.expected-version }}
+      run: ./build/Test-MaesterPackageOutput.ps1 -ModulePath ./publish/Maester -ExpectedVersion $env:EXPECTED_VERSION
+
     - name: Publish module to the PowerShell Gallery
       shell: pwsh
       env:
         GALLERY_API_KEY: ${{ inputs.gallery-api-key }}
       run: |
-        # Publish-Module requires the module folder name to match the module name,
-        # so stage the built ./module output in a folder named Maester first.
-        New-Item -ItemType Directory -Path ./publish -Force | Out-Null
-        Copy-Item ./module -Recurse -Destination ./publish/Maester -Force
         Publish-Module -Path ./publish/Maester -NuGetApiKey $env:GALLERY_API_KEY
 
     - name: Build PowerShell module zip for GitHub release

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -87,13 +87,15 @@ jobs:
           # Run Pester tests on Windows PowerShell
           ./powershell/tests/pester.ps1
 
-      - name: Build module and validate output
+      - name: Build module and validate outputs
         if: steps.filter.outputs.pwshmodule == 'true'
         shell: pwsh
         run: |
           # ./module/ is a build artifact and is never committed to source control.
           ./build/Build-MaesterModule.ps1
           ./build/Test-MaesterModuleOutput.ps1
+          ./build/Build-MaesterPackage.ps1 -OutputRoot ./publish/Maester
+          ./build/Test-MaesterPackageOutput.ps1 -ModulePath ./publish/Maester
 
       - name: Publish coverage summary
         # Only the Linux leg produces a JaCoCo coverage report (see PESTER_COVERAGE above).

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           name: maester-module
           path: |
-            ${{ github.workspace }}/module
+            ${{ github.workspace }}/publish/Maester
 
       - name: Create release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0

--- a/README.md
+++ b/README.md
@@ -99,14 +99,21 @@ The GitHub Action is moved to a new [repository](https://github.com/maester365/m
 
 ## Building from source
 
-Maester's source code lives in the `powershell/` and `tests/` folders. To produce the publishable module locally, run the build script from the repository root:
+Maester's source code lives in the `powershell/` and `tests/` folders. To build and validate the consolidated optimization artifact locally, run:
 
 ```powershell
 ./build/Build-MaesterModule.ps1
 Import-Module ./module/Maester.psd1 -Force
 ```
 
-The `module/` folder is a build artifact — it is ignored by git and never committed to source control. Built modules are attached to each [GitHub Release](https://github.com/maester365/maester/releases) and published to the PowerShell Gallery from CI. See the [contributing guide](https://maester.dev/docs/contributing) for full details.
+Release packages preserve the source-file layout and its PowerShell scope boundaries. To create the same package used by CI, run:
+
+```powershell
+./build/Build-MaesterPackage.ps1
+Import-Module ./publish/Maester/Maester.psd1 -Force
+```
+
+The `module/` and `publish/` folders are generated artifacts — they are ignored by git and never committed to source control. Packages under `publish/Maester` are attached to each [GitHub Release](https://github.com/maester365/maester/releases) and published to the PowerShell Gallery from CI. See the [contributing guide](https://maester.dev/docs/contributing) for full details.
 
 ## Contributing
 

--- a/build/Build-MaesterModule.md
+++ b/build/Build-MaesterModule.md
@@ -1,7 +1,10 @@
 # Build-MaesterModule
 
-Builds the Maester PowerShell module into a consolidated, publishable artifact
+Builds the Maester PowerShell module into a consolidated optimization artifact
 under `./module/`. The source tree (`powershell/`, `tests/`) is never modified.
+
+The released module is created separately by `Build-MaesterPackage.ps1`, which
+preserves individual source files and their PowerShell scope boundaries.
 
 ## Usage
 

--- a/build/Build-MaesterModule.ps1
+++ b/build/Build-MaesterModule.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-    Builds the Maester PowerShell module into a consolidated, publishable artifact.
+    Builds the Maester PowerShell module into a consolidated optimization artifact.
 
 .DESCRIPTION
     Consolidates all source files from powershell/internal/ and powershell/public/ into

--- a/build/Build-MaesterPackage.md
+++ b/build/Build-MaesterPackage.md
@@ -1,0 +1,29 @@
+# Build-MaesterPackage
+
+Builds the scope-safe Maester release package under `./publish/Maester/`.
+Unlike the consolidated optimization artifact, this package preserves individual
+PowerShell source files and their script-scope boundaries.
+
+## Usage
+
+```powershell
+./build/Build-MaesterPackage.ps1
+./build/Test-MaesterPackageOutput.ps1
+Import-Module ./publish/Maester/Maester.psd1 -Force
+```
+
+## Package contents
+
+The script copies the reviewed module source from `./powershell` and adds the
+security test suites from `./tests` under `maester-tests/`. It excludes local
+generated output and operating-system metadata such as `.DS_Store`.
+
+Both source trees remain unchanged. The output directory is cleaned and recreated
+on each run, and paths outside the repository are rejected as a deletion safeguard.
+
+## Validation
+
+`Test-MaesterPackageOutput.ps1` checks the package layout, manifest version,
+exported command count, and comment-based help. It also runs an empty DLP result
+through `Invoke-Maester` and fails if PowerShell function definitions appear in
+the report detail.

--- a/build/Build-MaesterPackage.ps1
+++ b/build/Build-MaesterPackage.ps1
@@ -1,0 +1,80 @@
+﻿<#
+.SYNOPSIS
+    Builds the scope-safe Maester package that is published to users.
+
+.DESCRIPTION
+    Copies the PowerShell module source tree without consolidating function files, then
+    adds the bundled Maester test suites under maester-tests. Preserving the individual
+    function files also preserves their PowerShell script-scope boundaries.
+
+    The source trees are never modified. The output directory is cleaned and recreated
+    on every run.
+
+.PARAMETER SourceRoot
+    Path to the PowerShell module source directory. Defaults to ../powershell relative
+    to this script.
+
+.PARAMETER TestsRoot
+    Path to the bundled test suites. Defaults to ../tests relative to this script.
+
+.PARAMETER OutputRoot
+    Path to the package directory. Defaults to ../publish/Maester relative to this script.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'CI packaging script that reports progress to the workflow log.')]
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string] $SourceRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../powershell").Path,
+
+    [Parameter()]
+    [string] $TestsRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/../tests").Path,
+
+    [Parameter()]
+    [string] $OutputRoot = "$PSScriptRoot/../publish/Maester"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$SourceRoot = (Resolve-Path -LiteralPath $SourceRoot).Path
+$TestsRoot = (Resolve-Path -LiteralPath $TestsRoot).Path
+
+$RepoRoot = (Resolve-Path -LiteralPath "$PSScriptRoot/..").Path
+$ResolvedOutput = [System.IO.Path]::GetFullPath($OutputRoot).TrimEnd('\', '/')
+$DriveRoot = [System.IO.Path]::GetPathRoot($ResolvedOutput).TrimEnd('\', '/')
+$ProtectedPaths = @($DriveRoot, $RepoRoot, $SourceRoot, $TestsRoot) |
+    ForEach-Object { $_.TrimEnd('\', '/') }
+
+if ($ResolvedOutput -in $ProtectedPaths) {
+    throw "Refusing to use protected path '$ResolvedOutput' as OutputRoot."
+}
+
+$RepoPath = $RepoRoot.TrimEnd('\', '/')
+if (-not $ResolvedOutput.StartsWith($RepoPath + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to use OutputRoot '$OutputRoot' because it is outside the repository root '$RepoRoot'."
+}
+
+Write-Host '── Preparing scope-safe Maester package' -ForegroundColor Cyan
+
+if (Test-Path -LiteralPath $ResolvedOutput) {
+    Remove-Item -LiteralPath $ResolvedOutput -Recurse -Force
+}
+$null = New-Item -Path $ResolvedOutput -ItemType Directory -Force
+
+$ExcludedSourceItems = @('.DS_Store', 'maester-tests', 'test-results')
+$SourceItems = Get-ChildItem -LiteralPath $SourceRoot -Force |
+    Where-Object { $_.Name -notin $ExcludedSourceItems }
+
+foreach ($Item in $SourceItems) {
+    Copy-Item -LiteralPath $Item.FullName -Destination $ResolvedOutput -Recurse -Force
+}
+
+$BundledTestsPath = Join-Path $ResolvedOutput 'maester-tests'
+$null = New-Item -Path $BundledTestsPath -ItemType Directory -Force
+Get-ChildItem -LiteralPath $TestsRoot -Force |
+    Where-Object { $_.Name -ne '.DS_Store' } |
+    Copy-Item -Destination $BundledTestsPath -Recurse -Force
+
+Write-Host "   Module source: $($SourceItems.Count) top-level items"
+Write-Host "   Bundled tests: $BundledTestsPath"
+Write-Host "── Package complete: $ResolvedOutput" -ForegroundColor Green

--- a/build/Test-MaesterPackageOutput.ps1
+++ b/build/Test-MaesterPackageOutput.ps1
@@ -1,0 +1,137 @@
+﻿<#
+.SYNOPSIS
+    Validates the scope-safe Maester package that is published to users.
+
+.DESCRIPTION
+    Confirms the source-layout package is complete, imports correctly, exposes command
+    help, and does not leak PowerShell function definitions into test result details.
+
+.PARAMETER ModulePath
+    Path to the packaged Maester module. Defaults to ../publish/Maester relative to this script.
+
+.PARAMETER ExpectedVersion
+    Optional version the package manifest must declare. A prerelease suffix is ignored
+    when comparing against ModuleVersion.
+
+.PARAMETER MinimumCommandCount
+    Minimum number of commands the package must export. Defaults to 200.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'CI validation script that reports progress to the workflow log.')]
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string] $ModulePath = "$PSScriptRoot/../publish/Maester",
+
+    [Parameter()]
+    [string] $ExpectedVersion,
+
+    [Parameter()]
+    [ValidateRange(1, [int]::MaxValue)]
+    [int] $MinimumCommandCount = 200
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ModulePath = (Resolve-Path -LiteralPath $ModulePath).Path
+Write-Host "── Validating packaged module at $ModulePath" -ForegroundColor Cyan
+
+$ExpectedItems = @(
+    'Maester.psd1'
+    'Maester.psm1'
+    'Maester.Format.ps1xml'
+    'assets'
+    'internal'
+    'public'
+    'maester-tests'
+    'maester-tests/Custom'
+)
+
+foreach ($Item in $ExpectedItems) {
+    if (-not (Test-Path -LiteralPath (Join-Path $ModulePath $Item))) {
+        throw "Package output is missing expected item: $Item"
+    }
+}
+Write-Host "   Verified: $($ExpectedItems.Count) expected files and directories present"
+
+$ManifestPath = Join-Path $ModulePath 'Maester.psd1'
+$Manifest = Import-PowerShellDataFile -Path $ManifestPath
+
+if ($ExpectedVersion) {
+    $ExpectedBaseVersion = ($ExpectedVersion -split '-')[0]
+    if ($Manifest.ModuleVersion -ne $ExpectedBaseVersion) {
+        throw "Manifest ModuleVersion '$($Manifest.ModuleVersion)' does not match expected version '$ExpectedBaseVersion' (from '$ExpectedVersion')."
+    }
+    Write-Host "   Verified: ModuleVersion $($Manifest.ModuleVersion) matches expected version"
+}
+
+Remove-Module Maester -Force -ErrorAction SilentlyContinue
+$ImportedModules = @(Import-Module $ManifestPath -Force -PassThru -ErrorAction Stop)
+$ImportedModule = $ImportedModules | Where-Object { $_.Name -eq 'Maester' } | Select-Object -First 1
+if (-not $ImportedModule) {
+    throw 'Import-Module did not return the Maester module object.'
+}
+
+$CommandCount = $ImportedModule.ExportedCommands.Count
+if ($CommandCount -lt $MinimumCommandCount) {
+    throw "Packaged module exports $CommandCount commands; expected at least $MinimumCommandCount."
+}
+Write-Host "   Verified: module imports and exports $CommandCount commands"
+
+$SampleFunctions = @('Invoke-Maester', 'Connect-Maester', 'Get-MtRole', 'Add-MtTestResultDetail')
+foreach ($FunctionName in $SampleFunctions) {
+    $Help = Get-Help -Name $FunctionName -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($Help.Synopsis) -or $Help.Synopsis.TrimStart().StartsWith($FunctionName)) {
+        throw "Comment-based help is missing or broken for $FunctionName (synopsis: '$($Help.Synopsis)')."
+    }
+}
+Write-Host "   Verified: comment-based help intact for $($SampleFunctions.Count) sample functions"
+
+$ReproRoot = Join-Path ([System.IO.Path]::GetTempPath()) "maester-package-validation-$([guid]::NewGuid())"
+$ReproTests = Join-Path $ReproRoot 'tests'
+$ReproOutput = Join-Path $ReproRoot 'output'
+$null = New-Item -Path $ReproTests -ItemType Directory -Force
+
+$ReproTestContent = @'
+Describe 'Packaged Maester result details' {
+    BeforeAll {
+        Mock -ModuleName Maester Test-MtConnection { return $true }
+        Mock -ModuleName Maester Get-MtLicenseInformation { return 'Plan' }
+        Mock -ModuleName Maester Get-MtExo { return @() }
+    }
+
+    It 'CISA.MS.EXO.8.2: keeps an empty DLP result free of function definitions' {
+        Test-MtCisaDlpPii | Should -BeFalse
+    }
+}
+'@
+
+$ReproTestPath = Join-Path $ReproTests 'PackageResultDetails.Tests.ps1'
+$Utf8Bom = [System.Text.UTF8Encoding]::new($true)
+[System.IO.File]::WriteAllText($ReproTestPath, $ReproTestContent, $Utf8Bom)
+
+try {
+    $MaesterResult = Invoke-Maester `
+        -Path $ReproTests `
+        -OutputFolder $ReproOutput `
+        -OutputFolderFileName 'PackageResultDetails' `
+        -SkipGraphConnect `
+        -SkipVersionCheck `
+        -NonInteractive `
+        -NoLogo `
+        -PassThru
+
+    $ResultDetail = [string] $MaesterResult.Tests[0].ResultDetail.TestResult
+    if ($ResultDetail -match 'Add-MtTestResultDetail\s+-Description' -or $ResultDetail -match '\.SYNOPSIS') {
+        throw 'Packaged module leaked a PowerShell function definition into TestResult.'
+    }
+    if ($ResultDetail -notmatch 'Your tenant does not have.*Data Loss Prevention Policies') {
+        throw "Packaged module returned an unexpected DLP result detail: '$ResultDetail'"
+    }
+    Write-Host '   Verified: report result details do not contain PowerShell function definitions'
+} finally {
+    Remove-Item -LiteralPath $ReproRoot -Recurse -Force -ErrorAction SilentlyContinue
+    $ImportedModules | Remove-Module -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host '── Packaged module validation passed' -ForegroundColor Green

--- a/build/maester-optimization-plan.md
+++ b/build/maester-optimization-plan.md
@@ -5,6 +5,12 @@ This document describes a set of targeted build-time and structural optimization
 installed function-file count while preserving Pester test behavior, user-facing behavior,
 and bundled tests.
 
+> **Current release packaging:** The consolidated `./module` artifact is retained for
+> optimization validation only. Releases are built with `Build-MaesterPackage.ps1` into
+> `./publish/Maester` so individual script files preserve their PowerShell scope boundaries.
+> References below to publishing `./module` describe the original rollout plan and are
+> superseded by the scope-safe package build.
+
 All changes are **build-time transformations only**. The source tree stays as individual files
 for developer ergonomics. The published artifact changes.
 

--- a/powershell/tests/general/Build-MaesterPackage.Tests.ps1
+++ b/powershell/tests/general/Build-MaesterPackage.Tests.ps1
@@ -1,0 +1,64 @@
+﻿BeforeAll {
+    $script:PackageScriptPath = Resolve-Path "$PSScriptRoot/../../../build/Build-MaesterPackage.ps1"
+    $script:RepoRoot = (Resolve-Path "$PSScriptRoot/../../..").Path
+
+    function Write-PackageTestFile {
+        param (
+            [Parameter(Mandatory)]
+            [string] $Path,
+
+            [Parameter(Mandatory)]
+            [string] $Content
+        )
+
+        $Utf8Bom = [System.Text.UTF8Encoding]::new($true)
+        [System.IO.File]::WriteAllText($Path, $Content, $Utf8Bom)
+    }
+}
+
+AfterAll {
+    Get-ChildItem -Path $script:RepoRoot -Directory -Filter '.tmp-maester-package-tests-*' |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Build-MaesterPackage' {
+    It 'preserves source files, bundles test suites, and excludes local metadata' {
+        $FixtureRoot = Join-Path $script:RepoRoot ".tmp-maester-package-tests-$([guid]::NewGuid())"
+        $SourceRoot = Join-Path $FixtureRoot 'powershell'
+        $TestsRoot = Join-Path $FixtureRoot 'tests'
+        $OutputRoot = Join-Path $FixtureRoot 'publish/Maester'
+
+        try {
+            $null = New-Item -Path (Join-Path $SourceRoot 'public') -ItemType Directory -Force
+            $null = New-Item -Path (Join-Path $SourceRoot 'internal') -ItemType Directory -Force
+            $null = New-Item -Path (Join-Path $SourceRoot 'assets') -ItemType Directory -Force
+            $null = New-Item -Path (Join-Path $TestsRoot 'Custom') -ItemType Directory -Force
+
+            Write-PackageTestFile -Path (Join-Path $SourceRoot 'Maester.psm1') -Content 'function Get-TestThing { return $true }'
+            Write-PackageTestFile -Path (Join-Path $SourceRoot 'Maester.psd1') -Content '@{ RootModule = ''Maester.psm1''; ModuleVersion = ''0.0.1'' }'
+            Write-PackageTestFile -Path (Join-Path $SourceRoot 'public/Get-TestThing.ps1') -Content 'function Get-TestThing { return $true }'
+            Write-PackageTestFile -Path (Join-Path $SourceRoot '.DS_Store') -Content 'local metadata'
+            Write-PackageTestFile -Path (Join-Path $TestsRoot 'Custom/Sample.Tests.ps1') -Content 'Describe ''Sample'' { It ''passes'' { $true | Should -BeTrue } }'
+
+            & $script:PackageScriptPath `
+                -SourceRoot $SourceRoot `
+                -TestsRoot $TestsRoot `
+                -OutputRoot $OutputRoot *> $null
+
+            (Join-Path $OutputRoot 'Maester.psm1') | Should -Exist
+            (Join-Path $OutputRoot 'public/Get-TestThing.ps1') | Should -Exist
+            (Join-Path $OutputRoot 'maester-tests/Custom/Sample.Tests.ps1') | Should -Exist
+            (Join-Path $OutputRoot '.DS_Store') | Should -Not -Exist
+        } finally {
+            Remove-Item -LiteralPath $FixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'rejects an output directory outside the repository' {
+        $OutsidePath = Join-Path ([System.IO.Path]::GetTempPath()) "maester-package-tests-$([guid]::NewGuid())"
+
+        {
+            & $script:PackageScriptPath -OutputRoot $OutsidePath *> $null
+        } | Should -Throw -ExpectedMessage '*outside the repository root*'
+    }
+}

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -32,13 +32,14 @@ Follow the guide below to set up Maester for development on your local machine, 
 
 ### Building the module
 
-The publishable Maester module is produced by a build script that consolidates the source files into an optimized module for faster import:
+Maester has two generated module outputs:
 
-- Run `./build/Build-MaesterModule.ps1` to produce the publishable module in `./module`.
-- Test your changes against the built output by importing it: `Import-Module ./module/Maester.psd1 -Force`.
-- `./module` is a build artifact: it is ignored by git and never committed to source control. Built modules are attached to GitHub Releases and published to the PowerShell Gallery from CI.
-- The `FunctionsToExport` list in the built `Maester.psd1` is auto-generated at build time from the public source files. Do not edit the built manifest manually.
-- The bundled test files in `./module/maester-tests` are copied at build time from `./tests`. Do not edit build output manually.
+- Run `./build/Build-MaesterModule.ps1` to produce the consolidated optimization artifact in `./module`, then import it with `Import-Module ./module/Maester.psd1 -Force`.
+- Run `./build/Build-MaesterPackage.ps1` to produce the scope-safe source-layout release package in `./publish/Maester`, then import it with `Import-Module ./publish/Maester/Maester.psd1 -Force`.
+- CI validates both outputs. The package under `./publish/Maester` is attached to GitHub Releases and published to the PowerShell Gallery.
+- `./module` and `./publish` are ignored by git and never committed to source control. Do not edit generated output manually.
+- The consolidated manifest's `FunctionsToExport` list is generated from the public source files. The release package preserves the reviewed source manifest and individual function files.
+- Bundled test files are copied from `./tests` into `maester-tests` in both generated outputs.
 
 ### Code style
 


### PR DESCRIPTION
## Summary

- keep the consolidated module as a validated optimization artifact
- publish a source-layout package that preserves PowerShell script-scope boundaries
- add a packaged-report regression for the empty DLP result reported in Discord
- update release artifacts and contributor documentation

Fixes #1924.

## Root cause

Starting with 2.1.66, the release workflow published the consolidated `Maester.psm1`. Consolidation removes the script-scope boundaries that individual function files normally provide. A conditionally initialized `$result` could therefore resolve to Pester/mock state and insert the `Add-MtTestResultDetail` function definition into `%TestResult%`.

## Validation

- all 3,134 general Pester tests passed
- package regression passed with Pester 5.7.1 and 6.0.0
- consolidated and source-layout build validators passed
- negative control reproduced and detected the leak in the consolidated artifact
- PSScriptAnalyzer, YAML parsing, and `git diff --check` passed