### PR TITLE
Updated CIS test 8.4.1 to correctly reflect what CIS demands

### DIFF
--- a/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
+++ b/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
@@ -40,7 +40,7 @@
         # CIS test 8.4.1 is "On or less permissive" for Microsoft Apps, so all Microsoft Apps states pass. The checks are retained for display purposes but do not affect the overall result.
         if (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and (-not $appPermPolicy.DefaultCatalogApps)) {
             # Microsoft apps
-            $result += "| Microsoft apps | Allow al l apps | $passResult |`n"
+            $result += "| Microsoft apps | Allow all apps | $passResult |`n"
         } elseif (($appPermPolicy.DefaultCatalogAppsType -eq 'AllowedAppList') -and ($appPermPolicy.DefaultCatalogApps)) {
             $result += "| Microsoft apps | Allow specific apps and block all others | $passResult |`n"
         } elseif (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and ($appPermPolicy.DefaultCatalogApps)) {

--- a/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
+++ b/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
@@ -37,7 +37,7 @@
         $result = "| Policy | Value | Status |`n"
         $result += "| --- | --- | --- |`n"
 
-        # Currently the CIS test 8.4.1 is On or less permissive meaning anything basicly goes for Microsoft Apps i will leave the checks as is but changed all to pass since the CIS test is not concerned with Microsoft Apps
+        # CIS test 8.4.1 is "On or less permissive" for Microsoft Apps, so all Microsoft Apps states pass. The checks are retained for display purposes but do not affect the overall result.
         if (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and (-not $appPermPolicy.DefaultCatalogApps)) {
             # Microsoft apps
             $result += "| Microsoft apps | Allow all apps | $passResult |`n"

--- a/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
+++ b/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
@@ -37,17 +37,16 @@
         $result = "| Policy | Value | Status |`n"
         $result += "| --- | --- | --- |`n"
 
+        # Currently the CIS test 8.4.1 is On or less permissive meaning anything basicly goes for Microsoft Apps i will leave the checks as is but changed all to pass since the CIS test is not concerned with Microsoft Apps
         if (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and (-not $appPermPolicy.DefaultCatalogApps)) {
             # Microsoft apps
             $result += "| Microsoft apps | Allow all apps | $passResult |`n"
         } elseif (($appPermPolicy.DefaultCatalogAppsType -eq 'AllowedAppList') -and ($appPermPolicy.DefaultCatalogApps)) {
             $result += "| Microsoft apps | Allow specific apps and block all others | $passResult |`n"
-            $return = $false
         } elseif (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and ($appPermPolicy.DefaultCatalogApps)) {
-            $result += "| Microsoft apps | Block specific apps and allow all others | $failResult |`n"
+            $result += "| Microsoft apps | Block specific apps and allow all others | $passResult |`n"
         } else {
-            $result += "| Microsoft apps | Block all apps | $failResult |`n"
-            $return = $false
+            $result += "| Microsoft apps | Block all apps | $passResult |`n"
         }
 
         if (($appPermPolicy.GlobalCatalogAppsType -eq 'BlockedAppList') -and (-not $appPermPolicy.GlobalCatalogApps)) {

--- a/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
+++ b/powershell/public/cis/Test-MtCisThirdPartyAndCustomApps.ps1
@@ -40,7 +40,7 @@
         # CIS test 8.4.1 is "On or less permissive" for Microsoft Apps, so all Microsoft Apps states pass. The checks are retained for display purposes but do not affect the overall result.
         if (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and (-not $appPermPolicy.DefaultCatalogApps)) {
             # Microsoft apps
-            $result += "| Microsoft apps | Allow all apps | $passResult |`n"
+            $result += "| Microsoft apps | Allow al l apps | $passResult |`n"
         } elseif (($appPermPolicy.DefaultCatalogAppsType -eq 'AllowedAppList') -and ($appPermPolicy.DefaultCatalogApps)) {
             $result += "| Microsoft apps | Allow specific apps and block all others | $passResult |`n"
         } elseif (($appPermPolicy.DefaultCatalogAppsType -eq 'BlockedAppList') -and ($appPermPolicy.DefaultCatalogApps)) {


### PR DESCRIPTION
## 📑 Description

This pr corrects the cis test for microsoft apps.
The CIS tests calls for Microsoft apps to be on or less permissive which is a everything goes kinda thing.
I left the checks in so it still shows what the setting is set to as CIS mentions this one but in reality it could be excluded

Closes #1888

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->

---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Microsoft apps compliance evaluation so the test no longer reports a failure when the configured policy matches the CIS requirement.
  * Kept existing pass/fail behavior unchanged for third-party and custom applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->