### PR TITLE
Set Pester to static version 5.7.1

### DIFF
--- a/.github/actions/publish-maester-module/action.yml
+++ b/.github/actions/publish-maester-module/action.yml
@@ -26,7 +26,7 @@ runs:
       # (Microsoft.Graph.Authentication 2.27.0) and the Pester baseline used in
       # build-validation.yaml (5.7.1).
       run: |
-        Install-Module Pester -MinimumVersion 5.7.1 -Force -Scope CurrentUser -AllowClobber
+        Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Force -Scope CurrentUser -AllowClobber
         Install-Module Microsoft.Graph.Authentication -MinimumVersion 2.27.0 -Force -Scope CurrentUser -AllowClobber
 
     - name: Validate built module

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -51,7 +51,7 @@ jobs:
           # -SkipPublisherCheck is required only for Pester: Windows images ship an inbox
           # Pester 3.4.0 signed by a different publisher, and installing a newer version
           # over it fails the Authenticode publisher match without the switch.
-          Install-Module Pester -MinimumVersion 5.7.1 -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
+          Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Force -SkipPublisherCheck -Scope CurrentUser -AllowClobber
           Install-Module PSFramework -Force -Scope CurrentUser -AllowClobber
           Install-Module PSModuleDevelopment -Force -Scope CurrentUser -AllowClobber
           Install-Module Microsoft.Graph.Authentication -MinimumVersion 2.27.0 -Force -Scope CurrentUser -AllowClobber

--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -3,9 +3,9 @@ name: 🏷️ Update Tag Documentation
 on:
   push:
     paths:
-      - "tests/**"
-      - "build/Update-TagsDocumentation.ps1"
-      - ".github/workflows/update-tags.yml"
+      - 'tests/**'
+      - 'build/Update-TagsDocumentation.ps1'
+      - '.github/workflows/update-tags.yml'
 
 permissions: {}
 

--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -3,9 +3,9 @@ name: 🏷️ Update Tag Documentation
 on:
   push:
     paths:
-      - 'tests/**'
-      - 'build/Update-TagsDocumentation.ps1'
-      - '.github/workflows/update-tags.yml'
+      - "tests/**"
+      - "build/Update-TagsDocumentation.ps1"
+      - ".github/workflows/update-tags.yml"
 
 permissions: {}
 
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set up PowerShell modules
         run: |
-          pwsh -NoLogo -NoProfile -Command "Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck"
+          pwsh -NoLogo -NoProfile -Command "Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck"
 
       - name: Generate tags document
         run: pwsh -NoLogo -NoProfile -File build/Update-TagsDocumentation.ps1

--- a/build/Update-CommandReference.ps1
+++ b/build/Update-CommandReference.ps1
@@ -4,7 +4,7 @@
 
 if (-not (Get-Module Alt3.Docusaurus.Powershell -ListAvailable)) { Install-Module Alt3.Docusaurus.Powershell -Scope CurrentUser -Force -SkipPublisherCheck }
 if (-not (Get-Module PlatyPS -ListAvailable)) { Install-Module PlatyPS -Scope CurrentUser -Force -SkipPublisherCheck }
-if (-not (Get-Module Pester -ListAvailable)) { Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck }
+if (-not (Get-Module Pester -ListAvailable)) { Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck }
 
 Import-Module Alt3.Docusaurus.Powershell
 Import-Module PlatyPS

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -17,7 +17,7 @@ If you see the following error when installing Maester, it means that you have a
 
 **A Microsoft-signed module named 'Pester' with version '3.4.0' that was previously installed conflicts with the new module 'Pester'**
 
-Run the following command to install the latest version of Pester and then retry installing Maester.
+Run the following command to install version 5.7.1 of Pester and then retry installing Maester.
 
 ```powershell
 Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -SkipPublisherCheck -Force

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -20,7 +20,7 @@ If you see the following error when installing Maester, it means that you have a
 Run the following command to install the latest version of Pester and then retry installing Maester.
 
 ```powershell
-Install-Module Pester -Scope CurrentUser -SkipPublisherCheck -Force
+Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -SkipPublisherCheck -Force
 ```
 
 To learn more or if you run into Pester installation issues see [Pester Installation and Update](https://pester.dev/docs/introduction/installation)

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -5,7 +5,7 @@ title: Installation guide
 - Install the **Maester** PowerShell module, Pester, and the out-of-the-box tests.
 
 ```powershell
-Install-Module Pester -SkipPublisherCheck -Force -Scope CurrentUser
+Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -SkipPublisherCheck -Force -Scope CurrentUser
 Install-Module Maester -Scope CurrentUser
 
 md maester-tests

--- a/website/versioned_docs/version-2.1.0/faq.md
+++ b/website/versioned_docs/version-2.1.0/faq.md
@@ -17,7 +17,7 @@ If you see the following error when installing Maester, it means that you have a
 
 **A Microsoft-signed module named 'Pester' with version '3.4.0' that was previously installed conflicts with the new module 'Pester'**
 
-Run the following command to install the latest version of Pester and then retry installing Maester.
+Run the following command to install version 5.7.1 of Pester and then retry installing Maester.
 
 ```powershell
 Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -SkipPublisherCheck -Force

--- a/website/versioned_docs/version-2.1.0/faq.md
+++ b/website/versioned_docs/version-2.1.0/faq.md
@@ -20,7 +20,7 @@ If you see the following error when installing Maester, it means that you have a
 Run the following command to install the latest version of Pester and then retry installing Maester.
 
 ```powershell
-Install-Module Pester -Scope CurrentUser -SkipPublisherCheck -Force
+Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -SkipPublisherCheck -Force
 ```
 
 To learn more or if you run into Pester installation issues see [Pester Installation and Update](https://pester.dev/docs/introduction/installation)

--- a/website/versioned_docs/version-2.1.0/installation.md
+++ b/website/versioned_docs/version-2.1.0/installation.md
@@ -5,7 +5,7 @@ title: Installation guide
 - Install the **Maester** PowerShell module, Pester, and the out-of-the-box tests.
 
 ```powershell
-Install-Module Pester -SkipPublisherCheck -Force -Scope CurrentUser
+Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -SkipPublisherCheck -Force -Scope CurrentUser
 Install-Module Maester -Scope CurrentUser
 
 md maester-tests


### PR DESCRIPTION
## 📑 Description

I did a couple PR's today and can see that the build validation times out after 6 hour execution time. 
I tested by updating to version 6.0.0 of pester and trying to run `./powershell/tests/pester.ps1` times out same place.
Downgraded to v 5.7.1 and it ran as expected so for now so other PR's gets tested on build validation aswell as scheduled actions and also updated docs to set the static version as v 6.0.0 has not been tested for test execution (yet)

This should be re-evaluated in the future and Maester should at some point get updated to be able to run on new version of Pester.

Closes # I did not create an issue for this

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [x] My pull request adheres to the code style of this project.
- [x] My code requires changes to the documentation.
- [x] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->

---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation and FAQ troubleshooting instructions to force-install **Pester 5.7.1** when resolving module version conflicts.

* **CI / Automation**
  * Pinned **Pester to exactly 5.7.1** during build/test runs to ensure consistent dependency behavior across workflow executions and setup scripts.
  * Updated automated tag documentation publishing to use the same pinned Pester version.

* **Chores**
  * Reformatted a workflow configuration block without changing its effective behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->