### PR TITLE
docs: refresh stale ORCA generated test docs

### DIFF
--- a/website/docs/tests/orca/ORCA.100.md
+++ b/website/docs/tests/orca/ORCA.100.md
@@ -27,8 +27,8 @@ Set the Bulk Complaint Level threshold to be 6.
 
 #### Related Links
 
-* [Bulk Complaint Level values](https://aka.ms/orca-antispam-docs-1) 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Bulk Complaint Level values](https://aka.ms/orca-antispam-docs-1)
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.101.md
+++ b/website/docs/tests/orca/ORCA.101.md
@@ -27,7 +27,7 @@ Set the anti-spam policy to mark bulk mail as spam.
 
 #### Related Links
 
-* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6) 
+* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 * [Set-HostedContentFilterPolicy](https://aka.ms/orca-antispam-docs-9)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.102.md
+++ b/website/docs/tests/orca/ORCA.102.md
@@ -27,7 +27,7 @@ Turn off Advanced Spam filter (ASF) options in Anti-Spam filter policies.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.103.md
+++ b/website/docs/tests/orca/ORCA.103.md
@@ -27,7 +27,7 @@ Set RecipientLimitExternalPerHour to 500, RecipientLimitInternalPerHour to 1000,
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.104.md
+++ b/website/docs/tests/orca/ORCA.104.md
@@ -27,7 +27,7 @@ Change High Confidence Phish action to Quarantine message.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.105.md
+++ b/website/docs/tests/orca/ORCA.105.md
@@ -27,8 +27,8 @@ Enable Safe Links Synchronous URL detonation.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
-* [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
+* [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7)
 * [Set up Microsoft Defender for Office 365 Safe Links policies](https://aka.ms/orca-atpp-docs-10)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.106.md
+++ b/website/docs/tests/orca/ORCA.106.md
@@ -27,8 +27,8 @@ Configure the Quarantine retention period to 30 days.
 
 #### Related Links
 
-* [Manage quarantined messages and files as an administrator in Office 365](https://aka.ms/orca-antispam-docs-6) 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Manage quarantined messages and files as an administrator in Office 365](https://aka.ms/orca-antispam-docs-6)
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.107.md
+++ b/website/docs/tests/orca/ORCA.107.md
@@ -27,8 +27,8 @@ Enable End-user Spam notifications on a quarantine policy.
 
 #### Related Links
 
-* [Configure end-user spam notifications in Exchange Online](https://aka.ms/orca-antispam-docs-2) 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Configure end-user spam notifications in Exchange Online](https://aka.ms/orca-antispam-docs-2)
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.108.md
+++ b/website/docs/tests/orca/ORCA.108.md
@@ -27,7 +27,7 @@ Set up DKIM signing to sign your emails.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - DKIM](https://security.microsoft.com/authentication?viewid=DKIM) 
+* [Microsoft 365 Defender Portal - DKIM](https://security.microsoft.com/authentication?viewid=DKIM)
 * [Use DKIM to validate outbound email sent from your custom domain in Office 365](https://aka.ms/orca-dkim-docs-1)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.109.md
+++ b/website/docs/tests/orca/ORCA.109.md
@@ -27,8 +27,8 @@ Remove allow listing on senders.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
-* [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
+* [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 * [Use Anti-Spam Policy Sender/Domain Allow lists](https://aka.ms/orca-antispam-docs-4)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.110.md
+++ b/website/docs/tests/orca/ORCA.110.md
@@ -27,7 +27,7 @@ Disable notifying internal senders of malware detection.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-malware](https://security.microsoft.com/antimalwarev2) 
+* [Microsoft 365 Defender Portal - Anti-malware](https://security.microsoft.com/antimalwarev2)
 * [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.111.md
+++ b/website/docs/tests/orca/ORCA.111.md
@@ -27,8 +27,8 @@ Enable unauthenticated sender tagging in Anti-phishing policy.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
-* [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
+* [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 * [Unverified Sender](https://aka.ms/orca-atpp-docs-12)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.112.md
+++ b/website/docs/tests/orca/ORCA.112.md
@@ -27,8 +27,8 @@ Configure Anti-spoofing protection action to Move message to the recipients' Jun
 
 #### Related Links
 
-* [Configuring the anti-spoofing policy](https://aka.ms/orca-atpp-docs-5) 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Configuring the anti-spoofing policy](https://aka.ms/orca-atpp-docs-5)
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.113.md
+++ b/website/docs/tests/orca/ORCA.113.md
@@ -20,15 +20,15 @@ keywords:
 
 ## Overview
 
-Microsoft Defender for Office 365 Safe Links can help protect your organization by providing time-of-click verification of  web addresses (URLs) in email messages and Office documents. It is possible to allow users click through Safe Links to the original URL. It is recommended to configure Safe Links policies to not let users click through safe links. 
+Microsoft Defender for Office 365 Safe Links can help protect your organization by providing time-of-click verification of  web addresses (URLs) in email messages and Office documents. It is possible to allow users click through Safe Links to the original URL. It is recommended to configure Safe Links policies to not let users click through safe links.
 
 #### Remediation action
 Do not let users click through safe links to original URL.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
-* [Microsoft Defender for Office 365 Safe Links policies](https://aka.ms/orca-atpp-docs-11) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
+* [Microsoft Defender for Office 365 Safe Links policies](https://aka.ms/orca-atpp-docs-11)
 * [Recommended settings for EOP and Office 365 Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-8)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.114.md
+++ b/website/docs/tests/orca/ORCA.114.md
@@ -27,7 +27,7 @@ Remove IP addresses from IP allow list.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Use Anti-Spam Policy IP Allow lists](https://aka.ms/orca-antispam-docs-3)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.115.md
+++ b/website/docs/tests/orca/ORCA.115.md
@@ -27,8 +27,8 @@ Enable Mailbox intelligence based impersonation protection in anti-phishing poli
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
+* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7)
 * [Set up Microsoft Defender for Office 365 anti-phishing and anti-phishing policies](https://aka.ms/orca-atpp-docs-9)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.116.md
+++ b/website/docs/tests/orca/ORCA.116.md
@@ -27,8 +27,8 @@ Change Mailbox intelligence based impersonation protection action to move messag
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
+* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7)
 * [Set up Microsoft Defender for Office 365 anti-phishing and anti-phishing policies](https://aka.ms/orca-atpp-docs-9)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.118.1.md
+++ b/website/docs/tests/orca/ORCA.118.1.md
@@ -27,7 +27,7 @@ Remove allow listing on domains.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Use Anti-Spam Policy Sender/Domain Allow lists](https://aka.ms/orca-antispam-docs-4)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.118.2.md
+++ b/website/docs/tests/orca/ORCA.118.2.md
@@ -27,7 +27,7 @@ Remove allow listed domains.
 
 #### Related Links
 
-* [Exchange admin center in Exchange Online](https://outlook.office365.com/ecp/) 
+* [Exchange admin center in Exchange Online](https://outlook.office365.com/ecp/)
 * [Using Exchange Transport Rules (ETRs) to allow specific senders](https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/create-safe-sender-lists-in-office-365#using-exchange-transport-rules-etrs-to-allow-specific-senders-recommended)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.118.3.md
+++ b/website/docs/tests/orca/ORCA.118.3.md
@@ -27,7 +27,7 @@ Remove allow listing on domains belonging to your organisation.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Use Anti-Spam Policy Sender/Domain Allow lists](https://aka.ms/orca-antispam-docs-4)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.118.4.md
+++ b/website/docs/tests/orca/ORCA.118.4.md
@@ -27,7 +27,7 @@ Remove allow listing on domains belonging to your organisation.
 
 #### Related Links
 
-* [Exchange admin center in Exchange Online](https://outlook.office365.com/ecp/) 
+* [Exchange admin center in Exchange Online](https://outlook.office365.com/ecp/)
 * [Using Exchange Transport Rules (ETRs) to allow specific senders](https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/create-safe-sender-lists-in-office-365#using-exchange-transport-rules-etrs-to-allow-specific-senders-recommended)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.119.md
+++ b/website/docs/tests/orca/ORCA.119.md
@@ -27,7 +27,7 @@ Enable Similar Domains Safety Tips so that users can receive visible indication 
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.120.1.md
+++ b/website/docs/tests/orca/ORCA.120.1.md
@@ -27,8 +27,8 @@ Enable Zero Hour Autopurge.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
+* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 * [Zero-hour auto purge - protection against spam and malware](https://aka.ms/orca-zha-docs-2)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.120.2.md
+++ b/website/docs/tests/orca/ORCA.120.2.md
@@ -27,7 +27,7 @@ Enable Zero Hour Autopurge.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-malware](https://security.microsoft.com/antimalwarev2) 
+* [Microsoft 365 Defender Portal - Anti-malware](https://security.microsoft.com/antimalwarev2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.120.3.md
+++ b/website/docs/tests/orca/ORCA.120.3.md
@@ -27,8 +27,8 @@ Enable Zero Hour Autopurge.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
+* [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 * [Zero-hour auto purge - protection against spam and malware](https://aka.ms/orca-zha-docs-2)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.121.md
+++ b/website/docs/tests/orca/ORCA.121.md
@@ -27,7 +27,7 @@ Change filter policy action to support Zero Hour Auto Purge.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Zero-hour auto purge - protection against spam and malware](https://aka.ms/orca-zha-docs-2)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.123.md
+++ b/website/docs/tests/orca/ORCA.123.md
@@ -27,7 +27,7 @@ Enable Unusual Characters Safety Tips so that users can receive visible indicati
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.124.md
+++ b/website/docs/tests/orca/ORCA.124.md
@@ -27,7 +27,7 @@ Set Safe attachments unknown malware response to block messages.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2) 
+* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.139.md
+++ b/website/docs/tests/orca/ORCA.139.md
@@ -27,7 +27,7 @@ Change Spam action to move message to Junk Email Folder.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365 security](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.140.md
+++ b/website/docs/tests/orca/ORCA.140.md
@@ -27,7 +27,7 @@ Change High Confidence Spam action to Quarantine message.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.141.md
+++ b/website/docs/tests/orca/ORCA.141.md
@@ -27,7 +27,7 @@ Change bulk action to move messages to junk mail folder.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.142.md
+++ b/website/docs/tests/orca/ORCA.142.md
@@ -27,7 +27,7 @@ Change Phish action to Quarantine message.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.143.md
+++ b/website/docs/tests/orca/ORCA.143.md
@@ -27,7 +27,7 @@ Safety Tips should be enabled.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam settings](https://security.microsoft.com/antispam)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-antispam-docs-8)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.156.md
+++ b/website/docs/tests/orca/ORCA.156.md
@@ -27,7 +27,7 @@ Enable tracking of user clicks in Safe Links Policies.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.158.md
+++ b/website/docs/tests/orca/ORCA.158.md
@@ -27,7 +27,7 @@ Enable Safe Attachments for SharePoint and Teams.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2) 
+* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.179.md
+++ b/website/docs/tests/orca/ORCA.179.md
@@ -27,7 +27,7 @@ Enable Safe Links between internal users.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.180.md
+++ b/website/docs/tests/orca/ORCA.180.md
@@ -27,8 +27,8 @@ Enable anti-spoofing protection in Anti-phishing policy.
 
 #### Related Links
 
-* [Anti-spoofing protection in Office 365](https:/aka.ms/orca-atpp-docs-3) 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Anti-spoofing protection in Office 365](https:/aka.ms/orca-atpp-docs-3)
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.205.md
+++ b/website/docs/tests/orca/ORCA.205.md
@@ -27,8 +27,8 @@ Enable common attachment type filter.
 
 #### Related Links
 
-* [Configure anti-malware policies](https://aka.ms/orca-mfp-docs-1) 
-* [Microsoft 365 Defender Portal - Anti-malware](https://security.microsoft.com/antimalwarev2) 
+* [Configure anti-malware policies](https://aka.ms/orca-mfp-docs-1)
+* [Microsoft 365 Defender Portal - Anti-malware](https://security.microsoft.com/antimalwarev2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-6)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.220.md
+++ b/website/docs/tests/orca/ORCA.220.md
@@ -27,7 +27,7 @@ Set Advanced Phish filter Threshold to 3 or 4.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.221.md
+++ b/website/docs/tests/orca/ORCA.221.md
@@ -27,7 +27,7 @@ Enable mailbox intelligence in anti-phishing policies.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.222.md
+++ b/website/docs/tests/orca/ORCA.222.md
@@ -27,7 +27,7 @@ Configure domain impersonation action to Quarantine.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.223.md
+++ b/website/docs/tests/orca/ORCA.223.md
@@ -27,7 +27,7 @@ Configure user impersonation action to Quarantine.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.224.md
+++ b/website/docs/tests/orca/ORCA.224.md
@@ -27,7 +27,7 @@ Enable Similar Users Safety Tips so that users can receive visible indication on
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.225.md
+++ b/website/docs/tests/orca/ORCA.225.md
@@ -27,8 +27,8 @@ Enable Safe Documents for Office clients.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7) 
+* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2)
+* [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 * [Safe Documents in Microsoft 365 E5](https://aka.ms/orca-atpp-docs-1)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.226.md
+++ b/website/docs/tests/orca/ORCA.226.md
@@ -27,8 +27,8 @@ Apply a Safe Links policy to every domain.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
-* [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
+* [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.227.md
+++ b/website/docs/tests/orca/ORCA.227.md
@@ -27,8 +27,8 @@ Apply a Safe Attachments policy to every domain.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2) 
-* [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4) 
+* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2)
+* [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.228.md
+++ b/website/docs/tests/orca/ORCA.228.md
@@ -27,7 +27,7 @@ Remove allow listing on senders in Anti-phishing policy.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.229.md
+++ b/website/docs/tests/orca/ORCA.229.md
@@ -27,7 +27,7 @@ Remove allow listing on domains in Anti-phishing policy.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing) 
+* [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.230.md
+++ b/website/docs/tests/orca/ORCA.230.md
@@ -27,9 +27,9 @@ Check your anti-phishing policies for duplicate rules. Some policies and setting
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Antiphishing policies](https://security.microsoft.com/antiphishing) 
-* [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7) 
+* [Microsoft 365 Defender Portal - Antiphishing policies](https://security.microsoft.com/antiphishing)
+* [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4)
+* [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 * [Setting up antiphishing policies](https://aka.ms/orca-atpp-docs-2)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.231.md
+++ b/website/docs/tests/orca/ORCA.231.md
@@ -27,7 +27,7 @@ Check your anti-spam policies for duplicate rules. Some policies and settings ma
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-spam policies](https://security.microsoft.com/antispam) 
+* [Microsoft 365 Defender Portal - Anti-spam policies](https://security.microsoft.com/antispam)
 * [Order and precedence of email protection](https://aka.ms/orca-antispam-docs-5)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.232.md
+++ b/website/docs/tests/orca/ORCA.232.md
@@ -27,7 +27,7 @@ Check your malware filter policies for duplicate rules. Some policies and settin
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Anti-malware policies](https://security.microsoft.com/antimalwarev2) 
+* [Microsoft 365 Defender Portal - Anti-malware policies](https://security.microsoft.com/antimalwarev2)
 * [Order and precedence of email protection](https://aka.ms/orca-atpp-docs-4)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.233.1.md
+++ b/website/docs/tests/orca/ORCA.233.1.md
@@ -27,7 +27,7 @@ Configure enhanced filtering on connectors when email path is not direct to EOP.
 
 #### Related Links
 
-* [Enhanced Filtering for Connectors](https://aka.ms/orca-connectors-docs-1) 
+* [Enhanced Filtering for Connectors](https://aka.ms/orca-connectors-docs-1)
 * [Microsoft 365 Defender Portal - Enhanced Filtering](https://aka.ms/orca-connectors-action-skiplisting)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.233.md
+++ b/website/docs/tests/orca/ORCA.233.md
@@ -27,7 +27,7 @@ Send mail directly to EOP or configure enhanced filtering.
 
 #### Related Links
 
-* [Enhanced Filtering for Connectors](https://aka.ms/orca-connectors-docs-1) 
+* [Enhanced Filtering for Connectors](https://aka.ms/orca-connectors-docs-1)
 * [Microsoft 365 Defender Portal - Enhanced Filtering](https://aka.ms/orca-connectors-action-skiplisting)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.234.md
+++ b/website/docs/tests/orca/ORCA.234.md
@@ -27,8 +27,8 @@ Do not let usres click through Protected View if Safe Documents identified the f
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2) 
-* [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7) 
+* [Microsoft 365 Defender Portal - Safe attachments](https://security.microsoft.com/safeattachmentv2)
+* [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 * [Safe Documents in Microsoft 365 E5](https://aka.ms/orca-atpp-docs-1)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.236.md
+++ b/website/docs/tests/orca/ORCA.236.md
@@ -27,7 +27,7 @@ Enable Safe Links policy action for unknown potentially malicious URLs in emails
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.237.md
+++ b/website/docs/tests/orca/ORCA.237.md
@@ -27,7 +27,7 @@ Enable Safe Links policy action for unknown potentially malicious URLs in teams 
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.238.md
+++ b/website/docs/tests/orca/ORCA.238.md
@@ -27,7 +27,7 @@ Enable Safe Links policy action for unknown potentially malicious URLs in office
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.239.md
+++ b/website/docs/tests/orca/ORCA.239.md
@@ -27,7 +27,7 @@ Remove exclusions from the built-in protection policies.
 
 #### Related Links
 
-* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2) 
+* [Microsoft 365 Defender Portal - Safe links](https://security.microsoft.com/safelinksv2)
 * [Recommended settings for EOP and Microsoft Defender for Office 365](https://aka.ms/orca-atpp-docs-7)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.240.md
+++ b/website/docs/tests/orca/ORCA.240.md
@@ -27,7 +27,7 @@ Configure external tags to highlight emails which are sent from external.
 
 #### Related Links
 
-* [Native external in Outlook](https://techcommunity.microsoft.com/t5/exchange-team-blog/native-external-sender-callouts-on-email-in-outlook/ba-p/2250098) 
+* [Native external in Outlook](https://techcommunity.microsoft.com/t5/exchange-team-blog/native-external-sender-callouts-on-email-in-outlook/ba-p/2250098)
 * [Set External in Outlook (Set-ExternalInOutlook)](https://learn.microsoft.com/en-us/powershell/module/exchange/set-externalinoutlook?view=exchange-ps)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.241.md
+++ b/website/docs/tests/orca/ORCA.241.md
@@ -27,7 +27,7 @@ Enable first contact safety tips to highlight suspicious messages to users.
 
 #### Related Links
 
-* [First Contact Safety Tip](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-about?view=o365-worldwide#first-contact-safety-tip) 
+* [First Contact Safety Tip](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-about?view=o365-worldwide#first-contact-safety-tip)
 * [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.243.md
+++ b/website/docs/tests/orca/ORCA.243.md
@@ -27,7 +27,7 @@ Enable Authenticated Receive Chain (ARC) trusted sealers for domains not pointed
 
 #### Related Links
 
-* [Configuring trusted ARC sealers](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-arc-configure?view=o365-worldwide) 
+* [Configuring trusted ARC sealers](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-arc-configure?view=o365-worldwide)
 * [Improving 'Defense in Depth' with Trusted ARC Sealers for Microsoft Defender for Office 365](https://techcommunity.microsoft.com/t5/microsoft-defender-for-office/improving-defense-in-depth-with-trusted-arc-sealers-for/ba-p/3440707)
 
 ## Test Metadata

--- a/website/docs/tests/orca/ORCA.244.md
+++ b/website/docs/tests/orca/ORCA.244.md
@@ -20,14 +20,14 @@ keywords:
 
 ## Overview
 
-Domain-based Message Authentication, Reporting & Conformance (DMARC) is a standard that helps prevent spoofing by verifying the senders identity. If an email fails DMARC validation, it often means that the sender is not who they claim to be, and the email could be fraudulent. The owner of the sending domain controls the DMARC policy for their domain, and provides recommendations to receivers on what action should be performed when DMARC fails. When the Honor DMARC Policy setting is set to False, the organisations policy is not considered. It is recommended to honor this policy. 
+Domain-based Message Authentication, Reporting & Conformance (DMARC) is a standard that helps prevent spoofing by verifying the senders identity. If an email fails DMARC validation, it often means that the sender is not who they claim to be, and the email could be fraudulent. The owner of the sending domain controls the DMARC policy for their domain, and provides recommendations to receivers on what action should be performed when DMARC fails. When the Honor DMARC Policy setting is set to False, the organisations policy is not considered. It is recommended to honor this policy.
 
 #### Remediation action
 Configure anti-phish policy to honor sending domains DMARC configuration.
 
 #### Related Links
 
-* [Announcing New DMARC Policy Handling Defaults for Enhanced Email Security](https://techcommunity.microsoft.com/t5/exchange-team-blog/announcing-new-dmarc-policy-handling-defaults-for-enhanced-email/ba-p/3878883) 
+* [Announcing New DMARC Policy Handling Defaults for Enhanced Email Security](https://techcommunity.microsoft.com/t5/exchange-team-blog/announcing-new-dmarc-policy-handling-defaults-for-enhanced-email/ba-p/3878883)
 * [Microsoft 365 Defender Portal - Anti-phishing](https://security.microsoft.com/antiphishing)
 
 ## Test Metadata


### PR DESCRIPTION
Moves the stale generated ORCA documentation normalization out of #1763. The source Markdown already has no trailing whitespace; this refresh updates only the 62 generated ORCA pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized formatting across ORCA test documentation.
  * Removed trailing whitespace and normalized spacing and line breaks in Related Links sections.
  * Preserved all link text, destinations, and existing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->