### PR TITLE
Add MT.1183: Temporary bypass for onPremisesObjectIdentifier updates should be disabled

### DIFF
--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -153,6 +153,7 @@
         'Test-MtEntitlementManagementDeletedGroups', 'Test-MtEntitlementManagementInactivePolicies',
         'Test-MtEntitlementManagementOrphanedResources', 'Test-MtEntitlementManagementValidApprovers',
         'Test-MtEntitlementManagementValidResourceRoles', 'Test-MtEntraDeviceJoinRestricted', 'Test-MtEntraIDConnectSsso',
+        'Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked',
         'Test-MtEntraIDConnectSyncSoftHardMatching', 'Test-MtKrbtgtAzureADNotSynced', 'Test-MtExoDelicensingResiliency',
         'Test-MtExoMailTip', 'Test-MtExoModernAuth', 'Test-MtExoMoeraMailActivity', 'Test-MtExoOutlookAddin',
         'Test-MtExoRejectDirectSend', 'Test-MtExoSetScl', 'Test-MtFeatureUpdatePolicy', 'Test-MtGroupCreationRestricted',

--- a/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.md
+++ b/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.md
@@ -12,12 +12,12 @@ To check and disable the temporary bypass using Graph PowerShell:
 
 1. Connect to Graph using **Connect-MgGraph -Scopes "OnPremDirectorySynchronization.ReadWrite.All"**.
 2. Run the following PowerShell command to review the current value:
-```
+```powershell
 $onPremSync = Get-MgDirectoryOnPremiseSynchronization
 $onPremSync.Features | fl
 ```
 3. If `AllowOnPremUpdateOfOnPremisesObjectIdentifierEnabled` is `$true` and remediation is complete, disable it:
-```
+```powershell
 $onPremSync = Get-MgDirectoryOnPremiseSynchronization
 $onPremSync.Features.AllowOnPremUpdateOfOnPremisesObjectIdentifierEnabled = $false
 Update-MgDirectoryOnPremiseSynchronization `

--- a/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.md
+++ b/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.md
@@ -1,0 +1,35 @@
+﻿Checks if the temporary bypass for onPremisesObjectIdentifier updates is disabled
+
+Starting July 1, 2026, Microsoft Entra ID adds extra protections for hard match operations during on-premises directory synchronization. These protections help prevent an on-premises Active Directory object from taking over the wrong cloud account when the target account is risky to reassociate. A hard match can be blocked when the target cloud account already has onPremisesObjectIdentifier set, is assigned a privileged Microsoft Entra role, or is eligible for a privileged Microsoft Entra role.
+
+If you can't remediate an affected object before enforcement, Microsoft Entra ID lets you enable the tenant-level feature flag `allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled` as a temporary bypass. This flag is disabled by default.
+
+Enabling this feature flag reduces the protection provided by hard match security enforcement for the entire tenant, not just the object you're remediating. It should only be used as a temporary bypass for a validated migration, recovery, or consolidation scenario, and disabled again as soon as remediation is complete. Leaving it enabled indefinitely re-opens the risk of an on-premises object taking over the wrong, potentially privileged, cloud account.
+
+#### Remediation action:
+
+To check and disable the temporary bypass using Graph PowerShell:
+
+1. Connect to Graph using **Connect-MgGraph -Scopes "OnPremDirectorySynchronization.ReadWrite.All"**.
+2. Run the following PowerShell command to review the current value:
+```
+$onPremSync = Get-MgDirectoryOnPremiseSynchronization
+$onPremSync.Features | fl
+```
+3. If `AllowOnPremUpdateOfOnPremisesObjectIdentifierEnabled` is `$true` and remediation is complete, disable it:
+```
+$onPremSync = Get-MgDirectoryOnPremiseSynchronization
+$onPremSync.Features.AllowOnPremUpdateOfOnPremisesObjectIdentifierEnabled = $false
+Update-MgDirectoryOnPremiseSynchronization `
+    -OnPremisesDirectorySynchronizationId $onPremSync.Id `
+    -Features $onPremSync.Features
+```
+
+#### Related links
+
+* [Configure Microsoft Entra Connect for an existing tenant - Temporarily allow onPremisesObjectIdentifier updates | Microsoft Learn](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-install-existing-tenant#temporarily-allow-onpremisesobjectidentifier-updates)
+* [Update-MgDirectoryOnPremiseSynchronization | Microsoft Learn - Graph PowerShell v1.0](https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.identity.directorymanagement/update-mgdirectoryonpremisesynchronization)
+
+<!--- Results --->
+%TestResult%
+

--- a/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.ps1
+++ b/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.ps1
@@ -64,4 +64,3 @@
         return $null
     }
 }
-

--- a/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.ps1
+++ b/powershell/public/maester/entra/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked.ps1
@@ -1,0 +1,67 @@
+﻿function Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked {
+    <#
+    .SYNOPSIS
+    Checks if the temporary bypass for onPremisesObjectIdentifier updates is disabled
+
+    .DESCRIPTION
+    Microsoft Entra ID added hard match security protections that can block a hard match when the target cloud
+    account already has onPremisesObjectIdentifier set, is assigned a privileged Microsoft Entra role, or is
+    eligible for a privileged Microsoft Entra role.
+
+    The allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled tenant feature flag temporarily bypasses these
+    protections. It's disabled by default and should stay disabled unless a validated migration, recovery, or
+    consolidation scenario requires a temporary bypass.
+
+    .EXAMPLE
+    Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked
+
+    Returns true if the temporary bypass for onPremisesObjectIdentifier updates is disabled
+
+    .LINK
+    https://maester.dev/docs/commands/Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (-not (Test-MtConnection Graph)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
+        return $null
+    }
+
+    Write-Verbose "Checking if the temporary bypass for onPremisesObjectIdentifier updates is disabled..."
+    try {
+        $organizationConfig = Invoke-MtGraphRequest -RelativeUri "organization"
+    } catch {
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        return $null
+    }
+    if ($organizationConfig.onPremisesSyncEnabled -ne $true) {
+        Add-MtTestResultDetail -SkippedBecause 'Custom' -SkippedCustomReason 'OnPremisesSynchronization is not configured'
+        return $null
+    }
+
+    try {
+        $onPremisesSynchronizationConfig = Invoke-MtGraphRequest -RelativeUri "directory/onPremisesSynchronization" -ApiVersion beta
+
+        $bypassEnabled = $onPremisesSynchronizationConfig.features.allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled -eq $true
+
+        if ($bypassEnabled) {
+            $testResult = "The temporary bypass **allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled** is currently *enabled* for this tenant.`n`n" `
+                + "This reduces the hard match security protections that block an on-premises object from taking over a cloud account that already has onPremisesObjectIdentifier set, or that's assigned or eligible for a privileged Microsoft Entra role.`n`n" `
+                + "Disable this flag as soon as your migration, recovery, or consolidation work is complete."
+        } else {
+            $testResult = "Well done. The temporary bypass for onPremisesObjectIdentifier updates isn't enabled, so hard match security protections remain in effect."
+        }
+        Add-MtTestResultDetail -Result $testResult
+        return -not $bypassEnabled
+    } catch {
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 403) {
+            Add-MtTestResultDetail -SkippedBecause NotAuthorized
+        } else {
+            Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        }
+        return $null
+    }
+}
+

--- a/tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1
+++ b/tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1
@@ -6,4 +6,8 @@ Describe 'Maester/Entra' -Tag 'Entra', 'Graph', 'Hybrid', 'Maester' {
     It 'MT.1147: Do not sync krbtgt_AzureAD to Entra ID. See https://maester.dev/docs/tests/MT.1147' -Tag 'MT.1147' {
         Test-MtKrbtgtAzureADNotSynced | Should -Be $true -Because 'krbtgt_AzureAD should exist only in Entra ID and should not be synchronized from on-premises Active Directory'
     }
+
+    It 'MT.1183: Temporary bypass for onPremisesObjectIdentifier updates should be disabled. See https://maester.dev/docs/tests/MT.1183' -Tag 'MT.1183' {
+        Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked | Should -Be $true -Because 'the temporary bypass for onPremisesObjectIdentifier updates should be disabled'
+    }
 }

--- a/tests/maester-config.json
+++ b/tests/maester-config.json
@@ -1554,6 +1554,11 @@
       "Title": "Conditional Access policy is present that blocks high agent risk signins"
     },
     {
+      "Id": "MT.1183",
+      "Severity": "Medium",
+      "Title": "Temporary bypass for onPremisesObjectIdentifier updates should be disabled"
+    },
+    {
       "Id": "ORCA.100",
       "Severity": "Medium",
       "Title": "Bulk Complaint Level threshold is between 4 and 6."


### PR DESCRIPTION
## Summary
- Adds `Test-MtEntraIDConnectSyncOnPremisesObjectIdentifierUpdatesBlocked`, which checks that the tenant-level feature flag `allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled` on `directory/onPremisesSynchronization` is disabled.
- This flag temporarily bypasses Microsoft Entra ID's hard match security protections (rolling out from July 1, 2026) that block an on-premises object from taking over a cloud account that already has `onPremisesObjectIdentifier` set, or that's assigned/eligible for a privileged Microsoft Entra role. It should only be enabled briefly during a validated migration, recovery, or consolidation scenario, then disabled again.
- Registered as **MT.1183** (reserved on #697), Severity: Medium, alongside the closely related MT.1073 (soft/hard-match blocking) test in `tests/Maester/Entra/Test-MtOnPremisesSynchronization.Tests.ps1`.

Reference: [Configure Microsoft Entra Connect for an existing tenant – Temporarily allow onPremisesObjectIdentifier updates](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-install-existing-tenant#temporarily-allow-onpremisesobjectidentifier-updates)

## Test plan
- [x] `Invoke-ScriptAnalyzer` on the new file — no findings
- [x] `./build/Build-LocalMaester.ps1` — builds and imports cleanly, new function exported
- [x] `./powershell/tests/pester.ps1` — all 6293 QA tests pass
- [ ] Maintainer review of Severity (Medium) and function naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tenant health check cmdlet to verify the temporary bypass for on-premises object identifier updates is disabled.
  * Included guidance for reviewing and remediating the relevant Microsoft Graph feature flag.

* **Tests**
  * Added coverage to assert the check reports the bypass as disabled.
  * Registered the new medium-severity test in the test configuration.

* **Documentation**
  * Added public documentation describing expected behavior and remediation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->