### PR TITLE
fix: correct Add-MtTestResultDetail catch-block calls in CA tests

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.ps1
@@ -61,7 +61,7 @@
 
         return $result
     } catch {
-        Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $false
     }
 }

--- a/powershell/public/maester/entra/Test-MtCaMfaForGuest.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForGuest.ps1
@@ -69,7 +69,7 @@
         Add-MtTestResultDetail -Result $testResult -GraphObjects $policiesResult -GraphObjectType ConditionalAccess
         return $result
     } catch {
-        Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $false
     }
 }

--- a/powershell/public/maester/entra/Test-MtCaMisconfiguredIDProtection.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMisconfiguredIDProtection.ps1
@@ -59,7 +59,7 @@
         Add-MtTestResultDetail -Result $testResult -GraphObjects $policiesResult -GraphObjectType ConditionalAccess
         return $result
     } catch {
-        Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $false
     }
 }

--- a/powershell/public/maester/entra/Test-MtCaReferencedGroupsExist.ps1
+++ b/powershell/public/maester/entra/Test-MtCaReferencedGroupsExist.ps1
@@ -79,7 +79,7 @@
     return $result
 
   } catch {
-    Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+    Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
     return $null
   }
 }

--- a/powershell/public/maester/entra/Test-MtCaRequirePasswordChangeForHighUserRisk.ps1
+++ b/powershell/public/maester/entra/Test-MtCaRequirePasswordChangeForHighUserRisk.ps1
@@ -56,7 +56,7 @@
 
         return $result
     } catch {
-        Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $false
     }
 }

--- a/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.ps1
+++ b/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.ps1
@@ -57,7 +57,7 @@
 
         return $result
     } catch {
-        Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         return $false
     }
 }

--- a/powershell/public/maester/entra/Test-MtCaWIFBlockLegacyAuthentication.ps1
+++ b/powershell/public/maester/entra/Test-MtCaWIFBlockLegacyAuthentication.ps1
@@ -42,7 +42,7 @@
         Write-Verbose "Checking if the user $UserId is blocked from using legacy authentication"
         return $Result
     } catch {
-        Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
         Write-Verbose "An error occurred while checking if the user $UserId is blocked from using legacy authentication"
         return $false
     }


### PR DESCRIPTION
## Summary
- 7 Conditional Access tests call `Add-MtTestResultDetail -Error $_ -GraphObjectType ConditionalAccess` in their catch blocks, but `Add-MtTestResultDetail` has no `-Error` parameter (only `-SkippedError`).
- Since `-Error` does not prefix-match `-SkippedError`, PowerShell's parameter binder falls back to the common parameters `-ErrorAction`/`-ErrorVariable`, and throws `Parameter cannot be processed because the parameter name 'Error' is ambiguous.`
- Net effect: whenever one of these tests actually hits its catch block (a real Graph API error), instead of gracefully recording a skipped/error test result, it throws an unhandled parameter-binding exception.
- Fixed by replacing the call with `Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_`, the working pattern already used elsewhere in the repo (e.g. the CIS tests).

Affected files:
- `Test-MtCaMfaForAllUsers.ps1`
- `Test-MtCaMfaForGuest.ps1`
- `Test-MtCaMisconfiguredIDProtection.ps1`
- `Test-MtCaReferencedGroupsExist.ps1`
- `Test-MtCaRequirePasswordChangeForHighUserRisk.ps1`
- `Test-MtCaSecureSecurityInfoRegistration.ps1`
- `Test-MtCaWIFBlockLegacyAuthentication.ps1`

## Test plan
- [x] Reproduced the exact binder ambiguity error locally against a function matching `Add-MtTestResultDetail`'s signature (`[CmdletBinding()]` + `-SkippedError`/`-SkippedBecause` params), confirmed `-SkippedBecause Error -SkippedError $_` binds cleanly instead.
- [x] `Invoke-ScriptAnalyzer` (full rule set via the repo's `PSScriptAnalyzer.Tests.ps1`) — 82/82 checks pass on the 7 changed files.
- [x] `./powershell/tests/pester.ps1` — full suite, 6280/6280 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting across Conditional Access security checks.
  - Tests that cannot complete because of an error are now clearly marked as skipped, with the underlying error retained for troubleshooting.
  - Existing policy evaluation, success results, and failure behavior remain unchanged.
  - Provides more accurate test outcomes when required information or services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->