### PR TITLE
Fix command reference builds after Alt3 2.0 release

### DIFF
--- a/build/Update-CommandReference.ps1
+++ b/build/Update-CommandReference.ps1
@@ -2,12 +2,16 @@
 # * This command needs to be run from the root of the project. e.g. ./build/Build-CommandReference.ps1
 # * If running the docusaurus site locally you will need to stop and start Docusaurus to clear the 'Module not found' errors after running this command
 
-if (-not (Get-Module Alt3.Docusaurus.Powershell -ListAvailable)) { Install-Module Alt3.Docusaurus.Powershell -Scope CurrentUser -Force -SkipPublisherCheck }
-if (-not (Get-Module PlatyPS -ListAvailable)) { Install-Module PlatyPS -Scope CurrentUser -Force -SkipPublisherCheck }
+# Alt3 2.x requires Microsoft.PowerShell.PlatyPS, whose YamlDotNet assembly conflicts with legacy PlatyPS.
+$alt3DocusaurusVersion = "1.0.37"
+$platyPSVersion = "0.14.2"
+
+if (-not (Get-Module Alt3.Docusaurus.Powershell -ListAvailable | Where-Object { $_.Version -eq $alt3DocusaurusVersion })) { Install-Module Alt3.Docusaurus.Powershell -RequiredVersion $alt3DocusaurusVersion -Scope CurrentUser -Force -SkipPublisherCheck }
+if (-not (Get-Module PlatyPS -ListAvailable | Where-Object { $_.Version -eq $platyPSVersion })) { Install-Module PlatyPS -RequiredVersion $platyPSVersion -Scope CurrentUser -Force -SkipPublisherCheck }
 if (-not (Get-Module Pester -ListAvailable)) { Install-Module Pester -MinimumVersion 5.7.1 -MaximumVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck }
 
-Import-Module Alt3.Docusaurus.Powershell
-Import-Module PlatyPS
+Import-Module Alt3.Docusaurus.Powershell -RequiredVersion $alt3DocusaurusVersion
+Import-Module PlatyPS -RequiredVersion $platyPSVersion
 Import-Module Pester
 Import-Module DnsClient
 


### PR DESCRIPTION
## Summary

- pin `Alt3.Docusaurus.Powershell` to 1.0.37
- pin legacy `PlatyPS` to 0.14.2
- require those exact versions during both installation and import

## Root cause

`Alt3.Docusaurus.Powershell` 2.0.0 was published between the last passing and first failing command-reference workflow runs. Version 2.0.0 depends on `Microsoft.PowerShell.PlatyPS` 1.0.2, which loads signed `YamlDotNet` 15. The existing build then imports legacy `PlatyPS` 0.14.2, which attempts to load its unsigned `YamlDotNet` 0.0 assembly into the same PowerShell process and fails with `Assembly with same name is already loaded`.

This failure is unrelated to the content of the triggering PR and affects every workflow that runs `build/Update-CommandReference.ps1` in a fresh environment.

## Why not migrate to Alt3 2.0 here?

A trial migration completed generation but produced five command-help warnings, removed two existing command pages, and rewrote 485 generated command files. That should be reviewed as a separate documentation migration rather than included in this focused CI repair.

## Validation

- reproduced the legacy/new PlatyPS `YamlDotNet` collision locally
- parsed the updated PowerShell script successfully
- passed PSScriptAnalyzer
- ran the complete command-reference generator using the pinned module versions without errors
- confirmed the worktree contains no generated command documentation changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned documentation build tools to specific versions for more consistent command reference generation.
  * Updated module installation and loading to use the required versions only when they are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->