### PR TITLE
Fix Test-MtConnection formatting tests on Windows

### DIFF
--- a/powershell/tests/functions/Test-MtConnection.Tests.ps1
+++ b/powershell/tests/functions/Test-MtConnection.Tests.ps1
@@ -512,7 +512,7 @@ Describe 'Test-MtConnection — requested service formatting' {
         )
 
         $ExpectedServiceOrder | ForEach-Object {
-            $Rendered | Should -Match "(?m)^$([regex]::Escape($_))\s+: Not connected$"
+            $Rendered | Should -Match "(?m)^$([regex]::Escape($_))\s+: Not connected\r?$"
         }
 
         for ($i = 1; $i -lt $ExpectedServiceOrder.Count; $i++) {
@@ -543,8 +543,8 @@ Describe 'Test-MtConnection — requested service formatting' {
         $Rendered = $Result | Out-String
 
         @($Result.ServicesChecked) | Should -Be @('Graph', 'GitHub')
-        $Rendered | Should -Match '(?m)^Microsoft Graph\s+: Not connected$'
-        $Rendered | Should -Match '(?m)^GitHub\s+: Not connected$'
+        $Rendered | Should -Match '(?m)^Microsoft Graph\s+: Not connected\r?$'
+        $Rendered | Should -Match '(?m)^GitHub\s+: Not connected\r?$'
         $Rendered | Should -Not -Match '(?m)^Azure\s+:'
     }
 
@@ -571,7 +571,7 @@ Describe 'Test-MtConnection — requested service formatting' {
         )
 
         $ExpectedServiceOrder | ForEach-Object {
-            $Rendered | Should -Match "(?m)^$([regex]::Escape($_))\s+: Not connected$"
+            $Rendered | Should -Match "(?m)^$([regex]::Escape($_))\s+: Not connected\r?$"
         }
 
         for ($i = 1; $i -lt $ExpectedServiceOrder.Count; $i++) {
@@ -594,7 +594,7 @@ Describe 'Test-MtConnection — requested service formatting' {
         $Rendered = Test-MtConnection -Service $Service -Details | Out-String
 
         $Rendered |
-            Should -Match '(?m)^Exchange Online Protection\s+: Not connected$'
+            Should -Match '(?m)^Exchange Online Protection\s+: Not connected\r?$'
     }
 }
 


### PR DESCRIPTION
## Summary

- make `Test-MtConnection` formatting assertions accept both LF and CRLF line endings
- preserve the existing exact service labels, ordering, and disconnected status checks

## Root cause

`Out-String` uses CRLF on Windows. In multiline .NET regular expressions, `$` matches before `\n` but not before the preceding `\r`, so assertions ending in `Not connected$` failed only on Windows.

## Validation

- `powershell/tests/pester.ps1 -TestGeneral:$false -TestFunctions:$true -Include Test-MtConnection.Tests.ps1 -Output Detailed` — 35 passed, 0 failed
- direct CRLF regex reproduction
- `Invoke-ScriptAnalyzer` with error severity
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of disconnected service-status output across multiple scenarios.
  * Tests now support Windows-style line endings for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->