### PR TITLE
Suppress warnings for filtered NotRun tests

### DIFF
--- a/powershell/internal/ConvertTo-MtMaesterResult.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResult.ps1
@@ -287,7 +287,7 @@
         if ($titleStart -gt 0) {
             $testId = $name.Substring(0, $titleStart).Trim()
             $testTitle = $name.Substring($titleStart + 1).Trim()
-        } else {
+        } elseif ($test.Result -ne 'NotRun') {
             Write-Warning "Test name does not contain a ':' character. Please use the format 'TestId: TestTitle' → $name"
         }
         $testResultDetail = $__MtSession.TestResultDetail[$test.ExpandedName]

--- a/powershell/tests/functions/ConvertTo-MtMaesterResult.Tests.ps1
+++ b/powershell/tests/functions/ConvertTo-MtMaesterResult.Tests.ps1
@@ -1,5 +1,50 @@
 BeforeAll {
     Import-Module "$PSScriptRoot/../../Maester.psd1" -Force
+
+    function Get-PesterResultsFixture {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $TestName,
+
+            [Parameter(Mandatory = $true)]
+            [string] $Result
+        )
+
+        $duration = if ($Result -eq 'NotRun') { [TimeSpan]::Zero } else { [TimeSpan]::FromSeconds(1) }
+        $pesterTest = [PSCustomObject]@{
+            ExpandedName = $TestName
+            Result       = $Result
+            ErrorRecord  = @()
+            ScriptBlock  = [scriptblock]::Create('$true | Should -BeTrue')
+            Block        = [PSCustomObject]@{
+                Tag          = @('MT.1068')
+                ExpandedName = 'MT.1068'
+            }
+            Duration     = $duration
+            Tag          = @('MT.1068')
+        }
+
+        return [PSCustomObject]@{
+            Tests             = @($pesterTest)
+            Containers        = @(
+                [PSCustomObject]@{
+                    Blocks = @(
+                        [PSCustomObject]@{
+                            Name   = 'MT.1068'
+                            Result = $Result
+                            Tag    = @('MT.1068')
+                        }
+                    )
+                }
+            )
+            Result            = $Result
+            ExecutedAt        = [DateTime]::UtcNow
+            Duration          = $duration
+            UserDuration      = $duration
+            DiscoveryDuration = [TimeSpan]::Zero
+            FrameworkDuration = [TimeSpan]::Zero
+        }
+    }
 }
 
 Describe 'ConvertTo-MtMaesterResult' {
@@ -77,6 +122,36 @@ Describe 'ConvertTo-MtMaesterResult' {
             $result.InvestigateCount | Should -Be 1
             $result.SkippedCount | Should -Be 0
             $result.Tests[0].ResultDetail.TestResult | Should -Match 'Manual review required'
+        }
+    }
+
+    It 'Does not warn about malformed names for filtered NotRun tests' {
+        $testName = 'Should pass all rules'
+        $pesterResults = Get-PesterResultsFixture -TestName $testName -Result 'NotRun'
+        InModuleScope Maester -Parameters @{ TestName = $testName; PesterResults = $pesterResults } {
+            $warnings = @()
+            $result = ConvertTo-MtMaesterResult -PesterResults $PesterResults -WarningVariable warnings -WarningAction SilentlyContinue
+
+            $warnings | Should -BeNullOrEmpty
+            $result.Tests | Should -HaveCount 1
+            $result.Tests[0].Id | Should -Be $TestName
+            $result.Tests[0].Title | Should -Be $TestName
+            $result.Tests[0].Result | Should -Be 'NotRun'
+            $result.NotRunCount | Should -Be 1
+        }
+    }
+
+    It 'Warns about malformed names for executed tests' {
+        $pesterResults = Get-PesterResultsFixture -TestName 'Should pass all rules' -Result 'Passed'
+        InModuleScope Maester -Parameters @{ PesterResults = $pesterResults } {
+            $warnings = @()
+            $result = ConvertTo-MtMaesterResult -PesterResults $PesterResults -WarningVariable warnings -WarningAction SilentlyContinue
+
+            $warnings | Should -HaveCount 1
+            $warnings[0].Message | Should -Match "Test name does not contain a ':' character"
+            $result.Tests | Should -HaveCount 1
+            $result.Tests[0].Result | Should -Be 'Passed'
+            $result.PassedCount | Should -Be 1
         }
     }
 }


### PR DESCRIPTION
Closes #1989

## What changed

- Suppress the generic missing-colon naming warning only when Pester marks a discovered test as `NotRun`.
- Preserve conversion, IDs, titles, result details, counts, and report inclusion for those filtered tests.
- Add focused regression coverage proving filtered `NotRun` tests remain quiet while malformed executed tests still warn.

## Root cause

Pester discovers the full Maester suite before applying execution filters. `ConvertTo-MtMaesterResult` converted all discovered results and validated the `TestId: TestTitle` format before its `NotRun` handling. Inner test names such as `Should pass all rules` therefore produced one warning each even though they were filtered and never executed. In smoke run 30085246002 this generated 11,393 warnings while only `MT.1068` was selected.

## User impact

Filtered smoke and targeted runs no longer flood Actions logs with misleading naming warnings. Malformed tests that actually execute continue to surface the warning, so the validation signal is retained.

## Validation

- `Invoke-Pester -Path ./powershell/tests/functions/ConvertTo-MtMaesterResult.Tests.ps1 -Output Detailed` — 3 passed, 0 failed
- PowerShell parser checks for both changed files — passed
- `Invoke-ScriptAnalyzer` for both changed files — no findings
- `git diff --check` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed test names no longer generate warnings when tests are filtered out and marked as **Not Run**.
  * Warnings continue to appear for executed tests with missing name delimiters.

* **Tests**
  * Added coverage to verify warning behavior and result handling for both skipped and executed tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->