### PR TITLE
Limit tenant smoke runs to PowerShell changes

### DIFF
--- a/.github/workflows/maester-action-smoke-test.md
+++ b/.github/workflows/maester-action-smoke-test.md
@@ -24,7 +24,7 @@ In `maester365/maester`, create a GitHub Actions environment named exactly
 `maester-smoke-test`. Configure it before adding credentials:
 
 1. Do not configure required reviewers. Approved-pull-request quick runs and
-   every full run after a merge to `main` must start automatically.
+   full runs after PowerShell changes merge to `main` must start automatically.
 2. Disable **Allow administrators to bypass configured protection rules**.
 3. Restrict deployment branches and tags to the `main` branch.
 
@@ -170,8 +170,10 @@ write permission, mail permission, or client secret is required.
   that check to the `Protect main` ruleset's required status checks after this
   workflow has been merged to `main`; enabling it earlier would prevent this
   pull request from producing the new check.
-- Every push to `main`, including a merged pull request, starts the full
-  cross-platform Graph run automatically.
+- A push to `main` starts the full cross-platform Graph run only when it
+  includes a PowerShell script, module, or data-file change matching
+  `**/*.ps1`, `**/*.psm1`, or `**/*.psd1`. Documentation-only and other
+  non-PowerShell merges do not start the full run.
 - A weekly Monday 05:17 UTC run exercises the full published preview.
 - A manual run from `main` can select quick or full and either the `preview` or
   `latest` module channel. Manual runs from another ref fail before tenant
@@ -184,9 +186,10 @@ trusted context job can read actions and pull requests and create the explicit
 merge-gate check, but cannot request an OIDC token. Only the protected matrix
 receives `contents: read` and `id-token: write`.
 
-The action is pinned to the immutable commit for `maester-action` v1.2.0.
-Public result summaries, public artifacts, and telemetry remain disabled.
-After Maester produces a result, the workflow transfers only the HTML report
-directly to the core-only private release repository. The matrix uses
-`fail-fast: false` so a failure on one operating system does not hide the other
-platform results.
+The action is pinned to the immutable commit for `maester-action` v1.2.0. The
+action's public result details, public artifacts, and telemetry remain disabled;
+the public run summary contains only links protected by the private report
+repository's access controls. After Maester produces a result, the workflow
+transfers only the HTML report directly to the core-only private release
+repository. The matrix uses `fail-fast: false` so a failure on one operating
+system does not hide the other platform results.

--- a/.github/workflows/maester-action-smoke-test.md
+++ b/.github/workflows/maester-action-smoke-test.md
@@ -4,7 +4,8 @@
 `maester365/maester-action` on Linux, Windows, and macOS against a real
 Microsoft 365 demo tenant. The same workflow supports two run types:
 
-- **Quick** runs only the fast, platform-neutral Graph check `MT.1068`.
+- **Quick** runs only the fast, platform-neutral Graph check `MT.1068` for an
+  approved pull request that changes a PowerShell file.
 - **Full** runs all public Graph checks. Exchange, Teams, private, preview, and
   long-running tests remain disabled.
 
@@ -25,6 +26,8 @@ In `maester365/maester`, create a GitHub Actions environment named exactly
 
 1. Do not configure required reviewers. Approved-pull-request quick runs and
    full runs after PowerShell changes merge to `main` must start automatically.
+   Approved non-PowerShell pull requests complete the quick check without
+   entering this environment.
 2. Disable **Allow administrators to bypass configured protection rules**.
 3. Restrict deployment branches and tags to the `main` branch.
 
@@ -158,18 +161,22 @@ write permission, mail permission, or client secret is required.
 ## Trigger and merge-gate strategy
 
 - An approved review on a ready pull request targeting `main` starts the quick
-  cross-platform run immediately.
+  cross-platform run immediately only when the pull request changes a
+  `*.ps1`, `*.psm1`, or `*.psd1` file.
 - The secretless `Demo tenant quick approval trigger` workflow only records the
   review event. A separate `workflow_run` job loaded from the default branch
   independently confirms that the pull request is open, is still on its
   approved commit, and that the approving reviewer has `write`, `maintain`, or
-  `admin` repository permission before requesting tenant credentials.
+  `admin` repository permission. It then reads the current changed-file list
+  before requesting tenant credentials.
 - The trusted runner creates a check named exactly
   **`Demo tenant quick smoke`** on the pull request's current test merge commit
-  and marks it successful only when all three operating systems complete. Add
-  that check to the `Protect main` ruleset's required status checks after this
-  workflow has been merged to `main`; enabling it earlier would prevent this
-  pull request from producing the new check.
+  and marks it successful only when all three operating systems complete. If
+  no PowerShell file changed, it completes the same check with a `skipped`
+  conclusion without requesting OIDC or tenant credentials. Add that check to
+  the `Protect main` ruleset's required status checks after this workflow has
+  been merged to `main`; enabling it earlier would prevent this pull request
+  from producing the new check.
 - A push to `main` starts the full cross-platform Graph run only when it
   includes a PowerShell script, module, or data-file change matching
   `**/*.ps1`, `**/*.psm1`, or `**/*.psd1`. Documentation-only and other

--- a/.github/workflows/maester-action-smoke-test.yaml
+++ b/.github/workflows/maester-action-smoke-test.yaml
@@ -184,6 +184,55 @@ jobs:
             const detailsUrl =
               `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/` +
               `${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            const pullFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            if (pullFiles.length < pull.changed_files) {
+              core.setFailed(
+                `GitHub returned ${pullFiles.length} of ${pull.changed_files} ` +
+                'changed files; refusing to skip the tenant smoke test.',
+              );
+              setContext();
+              return;
+            }
+
+            const isPowerShellFile = (path) =>
+              /\.(ps1|psd1|psm1)$/.test(path || '');
+            const hasPowerShellChange = pullFiles.some((file) =>
+              isPowerShellFile(file.filename) ||
+              isPowerShellFile(file.previous_filename)
+            );
+            if (!hasPowerShellChange) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'Demo tenant quick smoke',
+                head_sha: pull.merge_commit_sha,
+                details_url: detailsUrl,
+                status: 'completed',
+                conclusion: 'skipped',
+                completed_at: new Date().toISOString(),
+                output: {
+                  title: 'Quick smoke skipped — no PowerShell changes',
+                  summary:
+                    `Pull request #${pullNumber} has no changed ` +
+                    '`*.ps1`, `*.psm1`, or `*.psd1` files. No tenant ' +
+                    'credentials were requested.',
+                },
+              });
+              core.notice(
+                'No PowerShell files changed; completed the quick check without tenant access.',
+              );
+              setContext({
+                pullRequestNumber: String(pullNumber),
+              });
+              return;
+            }
+
             const {data: checkRun} = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/maester-action-smoke-test.yaml
+++ b/.github/workflows/maester-action-smoke-test.yaml
@@ -3,6 +3,10 @@ name: Demo tenant Invoke-Maester smoke test
 on:
   push:
     branches: [main]
+    paths:
+      - "**/*.ps1"
+      - "**/*.psd1"
+      - "**/*.psm1"
   workflow_run:
     workflows: ["Demo tenant quick approval trigger"]
     types: [completed]


### PR DESCRIPTION
## Summary

- run the automatic post-merge Full smoke test only when a push to `main` changes a `*.ps1`, `*.psm1`, or `*.psd1` file
- run the approved-PR Quick tenant matrix only when the pull request changes one of those PowerShell file types
- complete `Demo tenant quick smoke` as `skipped` for approved non-PowerShell pull requests without requesting OIDC or tenant credentials
- keep manual runs and the weekly Full drift run unchanged
- document the filtered trigger and access-controlled private report links

## Why

The cross-platform tenant runs are unnecessary for documentation-only changes. Matching PowerShell extensions across the repository still covers module code, Maester tests, and PowerShell build scripts outside the `powershell/` directory.

The stable Quick check is still created for approved non-PowerShell pull requests so it can remain a required merge check without blocking documentation changes.

## Security

The trusted default-branch workflow validates the current maintainer approval and test merge commit before reading the pull request file list. It checks both current and previous filenames so deleting or renaming a PowerShell file still runs Quick. If GitHub does not return the complete changed-file list, the workflow fails closed and does not create a passing check.

## Validation

- `actionlint` v1.7.12
- Ruby YAML parser
- `git diff --check`
- local path-classification cases for module source, tests, build scripts, and documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated smoke-test triggers to run only when PowerShell files change.
  * Pull requests without PowerShell changes now complete the quick check as skipped without requesting protected-environment credentials.
  * Improved handling when the changed-file list cannot be fully retrieved.

* **Documentation**
  * Clarified smoke-test behavior, merge-gate configuration, and protected result reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->