### PR TITLE
Prevent duplicate Discord digest posts

### DIFF
--- a/.github/scripts/discord-codebase-digest.mjs
+++ b/.github/scripts/discord-codebase-digest.mjs
@@ -17,6 +17,7 @@ const discordWebhook = parseDiscordWebhookUrl(process.env.DISCORD_CODEBASE_WEBHO
 const avatarUrl = process.env.DISCORD_AVATAR_URL;
 const now = new Date(process.env.DIGEST_NOW || Date.now());
 const mode = process.env.DIGEST_MODE || "daily";
+const triggerSchedule = process.env.DIGEST_TRIGGER_SCHEDULE || "";
 
 if (!token) {
   fail("GITHUB_TOKEN is required.");
@@ -33,9 +34,12 @@ if (mode === "monthly-backfill") {
 }
 
 async function runDailyDigest({ owner, repo }) {
-  if (!dryRun && !forcePost && melbourneHour(now) !== 9) {
-    console.log(`Skipping: local time in ${TIME_ZONE} is ${formatMelbourne(now)}, not 9am.`);
-    process.exit(0);
+  if (!dryRun && !forcePost) {
+    const skipReason = dailyPostSkipReason(now, triggerSchedule);
+    if (skipReason) {
+      console.log(`Skipping: ${skipReason}`);
+      process.exit(0);
+    }
   }
 
   const until = now;
@@ -785,6 +789,35 @@ function melbourneParts(date) {
     minute: Number(parts.find((part) => part.type === "minute")?.value),
     second: Number(parts.find((part) => part.type === "second")?.value),
   };
+}
+
+function dailyPostSkipReason(date, schedule) {
+  if (schedule) {
+    const expectedSchedule = expectedDailySchedule(date);
+    if (schedule !== expectedSchedule) {
+      return `schedule ${schedule} is not the active ${TIME_ZONE} schedule (${expectedSchedule}) for ${formatMelbourneDate(date)}.`;
+    }
+
+    return null;
+  }
+
+  if (melbourneHour(date) !== 9) {
+    return `local time in ${TIME_ZONE} is ${formatMelbourne(date)}, not 9am.`;
+  }
+
+  return null;
+}
+
+function expectedDailySchedule(date) {
+  return melbourneUtcOffsetHours(date) === 11
+    ? "0 22 * * *"
+    : "0 23 * * *";
+}
+
+function melbourneUtcOffsetHours(date) {
+  const parts = melbourneParts(date);
+  const localAsUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+  return Math.round((localAsUtc - date.getTime()) / (60 * 60 * 1000));
 }
 
 function melbourneHour(date) {

--- a/.github/workflows/discord-codebase-digest.yml
+++ b/.github/workflows/discord-codebase-digest.yml
@@ -54,4 +54,5 @@ jobs:
           DIGEST_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           DIGEST_FORCE_POST: ${{ github.event_name == 'workflow_dispatch' && inputs.force_post || false }}
           DIGEST_SINCE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.since_hours || '24' }}
+          DIGEST_TRIGGER_SCHEDULE: ${{ github.event_name == 'schedule' && github.event.schedule || '' }}
         run: node .github/scripts/discord-codebase-digest.mjs


### PR DESCRIPTION
## Summary
- prevent delayed inactive UTC cron runs from posting duplicate daily Discord digests
- pass the triggering cron expression into the digest script
- choose the active cron from the current Australia/Melbourne UTC offset, so AEST uses 23:00 UTC and AEDT uses 22:00 UTC

## Why
GitHub scheduled workflows can start late. The workflow runs at both 22:00 and 23:00 UTC to handle Melbourne daylight saving, but the script only checked whether the actual runtime hour was 9am in Melbourne. In AEST, the 22:00 UTC run can be delayed into the 9am hour and post, then the 23:00 UTC run posts again.

## Validation
- node --check .github/scripts/discord-codebase-digest.mjs
- simulated delayed AEST inactive cron at 9:53am Melbourne and verified it skips
- simulated delayed AEDT inactive cron at 9:53am Melbourne and verified it skips
- verified non-scheduled/manual behavior still skips outside 9am unless forced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily digest scheduling to respect the configured trigger schedule.
  * Added handling for Melbourne daylight-saving time changes to ensure digests run on the correct local day and time.
  * Prevented manually triggered runs from being incorrectly skipped due to schedule checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->