### PR TITLE
Fix test suite documentation links

### DIFF
--- a/website/docs/tests/cis/readme.md
+++ b/website/docs/tests/cis/readme.md
@@ -18,52 +18,52 @@ These tests verify tenant and organization configuration against CIS Benchmark r
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [CIS.GH.1.2.2](../CIS.GH.1.2.2) | (L1) Ensure repository creation is limited to specific members | Medium | CIS GH Level 1 |
-| [CIS.GH.1.2.3](../CIS.GH.1.2.3) | (L1) Ensure repository deletion is limited to specific users | High | CIS GH Level 1 |
-| [CIS.GH.1.2.4](../CIS.GH.1.2.4) | (L1) Ensure issue deletion is limited to specific users | Medium | CIS GH Level 1 |
-| [CIS.GH.1.3.2](../CIS.GH.1.3.2) | (L1) Ensure team creation is limited to specific members | Medium | CIS GH Level 1 |
-| [CIS.GH.1.3.8](../CIS.GH.1.3.8) | (L1) Ensure strict base permissions are set for repositories | High | CIS GH Level 1 |
-| [CIS.M365.1.1.1](../CIS.M365.1.1.1) | (L1) Ensure Administrative accounts are cloud-only | High | CIS E3 Level 1 |
-| [CIS.M365.1.1.3](../CIS.M365.1.1.3) | (L1) Ensure that between two and four global admins are designated | High | CIS E3 Level 1 |
-| [CIS.M365.1.2.1](../CIS.M365.1.2.1) | (L2) Ensure that only organizationally managed/approved public groups exist | Medium | CIS E3 Level 2 |
-| [CIS.M365.1.2.2](../CIS.M365.1.2.2) | (L1) Ensure sign-in to shared mailboxes is blocked | High | CIS E3 Level 1 |
-| [CIS.M365.1.3.1](../CIS.M365.1.3.1) | (L1) Ensure the 'Password expiration policy' is set to 'Set passwords to never expire (recommended)' | High | CIS E3 Level 1 |
-| [CIS.M365.1.3.3](../CIS.M365.1.3.3) | (L2) Ensure 'External sharing' of calendars is not available | Medium | CIS E3 Level 2 |
-| [CIS.M365.1.3.4](../CIS.M365.1.3.4) | Ensure | Unknown | CIS E3 Level 1 |
-| [CIS.M365.1.3.5](../CIS.M365.1.3.5) | Ensure internal phishing protection for Forms is enabled | Unknown | CIS E3 Level 1 |
-| [CIS.M365.1.3.6](../CIS.M365.1.3.6) | (L2) Ensure the customer lockbox feature is enabled | High | CIS E5 Level 2 |
-| [CIS.M365.1.3.7](../CIS.M365.1.3.7) | Ensure | Unknown | CIS E3 Level 2 |
-| [CIS.M365.2.1.1](../CIS.M365.2.1.1) | (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy) | Medium | CIS E5 Level 2 |
-| [CIS.M365.2.1.2](../CIS.M365.2.1.2) | (L1) Ensure the Common Attachment Types Filter is enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.3](../CIS.M365.2.1.3) | (L1) Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.4](../CIS.M365.2.1.4) | (L2) Ensure Safe Attachments policy is enabled (Only Checks Default Policy) | High | CIS E5 Level 2 |
-| [CIS.M365.2.1.5](../CIS.M365.2.1.5) | (L2) Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled | High | CIS E5 Level 2 |
-| [CIS.M365.2.1.6](../CIS.M365.2.1.6) | (L1) Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.7](../CIS.M365.2.1.7) | (L1) Ensure that an anti-phishing policy has been created (Only Checks Default Policy) | Medium | CIS E5 Level 1 |
-| [CIS.M365.2.1.9](../CIS.M365.2.1.9) | (L1) Ensure that DKIM is enabled for all Exchange Online Domains | High | CIS E3 Level 1 |
-| [CIS.M365.2.1.11](../CIS.M365.2.1.11) | (L2) Ensure comprehensive attachment filtering is applied | High | CIS E3 Level 2 |
-| [CIS.M365.2.1.12](../CIS.M365.2.1.12) | (L1) Ensure the connection filter IP allow list is not used (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.13](../CIS.M365.2.1.13) | (L1) Ensure the connection filter safe list is off (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.4.4](../CIS.M365.2.4.4) | (L1) Ensure Zero-hour auto purge for Microsoft Teams is on (Only Checks ZAP is enabled) | Medium | CIS E5 Level 1 |
-| [CIS.M365.3.1.1](../CIS.M365.3.1.1) | (L1) Ensure Microsoft 365 audit log search is Enabled | High | CIS E3 Level 1 |
-| [CIS.M365.4.1](../CIS.M365.4.1) | Ensure devices without a compliance policy are marked | Unknown | CIS E3 Level 2 |
-| [CIS.M365.5.1.2.2](../CIS.M365.5.1.2.2) | Ensure third party integrated applications are not allowed | Unknown | CIS E3 Level 2 |
-| [CIS.M365.5.1.2.3](../CIS.M365.5.1.2.3) | Ensure | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.1.3.1](../CIS.M365.5.1.3.1) | Ensure a dynamic group for guest users is created | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.1.5.1](../CIS.M365.5.1.5.1) | Ensure user consent to apps accessing company data on their behalf is not allowed | Unknown | CIS E3 Level 2 |
-| [CIS.M365.5.1.5.2](../CIS.M365.5.1.5.2) | Ensure the admin consent workflow is enabled | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.1.6.2](../CIS.M365.5.1.6.2) | Ensure that guest user access is restricted | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.2.3.5](../CIS.M365.5.2.3.5) | Ensure weak authentication methods are disabled | Unknown | CIS E3 Level 1 |
-| [CIS.M365.6.5.3](../CIS.M365.6.5.3) | Ensure additional storage providers are restricted in Outlook on the web | Unknown | CIS E3 Level 2 |
-| [CIS.M365.7.2.2](../CIS.M365.7.2.2) | Ensure SharePoint and OneDrive integration with Azure AD B2B is enabled | Unknown | SharePoint Online |
-| [CIS.M365.7.2.5](../CIS.M365.7.2.5) | Ensure that SharePoint guest users cannot share items they don | Unknown | SharePoint Online |
-| [CIS.M365.7.2.7](../CIS.M365.7.2.7) | Ensure link sharing is restricted in SharePoint and OneDrive | Unknown | SharePoint Online |
-| [CIS.M365.7.2.9](../CIS.M365.7.2.9) | Ensure guest access to a site or OneDrive will expire automatically | Unknown | SharePoint Online |
-| [CIS.M365.7.2.11](../CIS.M365.7.2.11) | Ensure the SharePoint default sharing link permission is set | Unknown | SharePoint Online |
-| [CIS.M365.7.3.1](../CIS.M365.7.3.1) | Ensure Office 365 SharePoint infected files are disallowed for download | Unknown | SharePoint Online |
-| [CIS.M365.8.1.1](../CIS.M365.8.1.1) | (L2) Ensure external file sharing in Teams is enabled for only approved cloud storage services | Medium | CIS M365 v6.0.1 |
-| [CIS.M365.8.2.2](../CIS.M365.8.2.2) | (L1) Ensure communication with unmanaged Teams users is disabled | Medium | CIS M365 v6.0.1 |
-| [CIS.M365.8.2.3](../CIS.M365.8.2.3) | Ensure external Teams users cannot initiate conversations | Unknown | CIS M365 v6.0.1 |
-| [CIS.M365.8.4.1](../CIS.M365.8.4.1) | (L1) Ensure all or a majority of third-party and custom apps are blocked | High | CIS M365 v6.0.1 |
-| [CIS.M365.8.5.3](../CIS.M365.8.5.3) | (L1) Ensure only people in my org can bypass the lobby | Medium | CIS E3 Level 1 |
-| [CIS.M365.8.6.1](../CIS.M365.8.6.1) | (L1) Ensure users can report security concerns in Teams to internal destination | Medium | CIS E3 Level 1 |
+| [CIS.GH.1.2.2](./CIS.GH.1.2.2.md) | (L1) Ensure repository creation is limited to specific members | Medium | CIS GH Level 1 |
+| [CIS.GH.1.2.3](./CIS.GH.1.2.3.md) | (L1) Ensure repository deletion is limited to specific users | High | CIS GH Level 1 |
+| [CIS.GH.1.2.4](./CIS.GH.1.2.4.md) | (L1) Ensure issue deletion is limited to specific users | Medium | CIS GH Level 1 |
+| [CIS.GH.1.3.2](./CIS.GH.1.3.2.md) | (L1) Ensure team creation is limited to specific members | Medium | CIS GH Level 1 |
+| [CIS.GH.1.3.8](./CIS.GH.1.3.8.md) | (L1) Ensure strict base permissions are set for repositories | High | CIS GH Level 1 |
+| [CIS.M365.1.1.1](./CIS.M365.1.1.1.md) | (L1) Ensure Administrative accounts are cloud-only | High | CIS E3 Level 1 |
+| [CIS.M365.1.1.3](./CIS.M365.1.1.3.md) | (L1) Ensure that between two and four global admins are designated | High | CIS E3 Level 1 |
+| [CIS.M365.1.2.1](./CIS.M365.1.2.1.md) | (L2) Ensure that only organizationally managed/approved public groups exist | Medium | CIS E3 Level 2 |
+| [CIS.M365.1.2.2](./CIS.M365.1.2.2.md) | (L1) Ensure sign-in to shared mailboxes is blocked | High | CIS E3 Level 1 |
+| [CIS.M365.1.3.1](./CIS.M365.1.3.1.md) | (L1) Ensure the 'Password expiration policy' is set to 'Set passwords to never expire (recommended)' | High | CIS E3 Level 1 |
+| [CIS.M365.1.3.3](./CIS.M365.1.3.3.md) | (L2) Ensure 'External sharing' of calendars is not available | Medium | CIS E3 Level 2 |
+| [CIS.M365.1.3.4](./CIS.M365.1.3.4.md) | Ensure | Unknown | CIS E3 Level 1 |
+| [CIS.M365.1.3.5](./CIS.M365.1.3.5.md) | Ensure internal phishing protection for Forms is enabled | Unknown | CIS E3 Level 1 |
+| [CIS.M365.1.3.6](./CIS.M365.1.3.6.md) | (L2) Ensure the customer lockbox feature is enabled | High | CIS E5 Level 2 |
+| [CIS.M365.1.3.7](./CIS.M365.1.3.7.md) | Ensure | Unknown | CIS E3 Level 2 |
+| [CIS.M365.2.1.1](./CIS.M365.2.1.1.md) | (L2) Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy) | Medium | CIS E5 Level 2 |
+| [CIS.M365.2.1.2](./CIS.M365.2.1.2.md) | (L1) Ensure the Common Attachment Types Filter is enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.3](./CIS.M365.2.1.3.md) | (L1) Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.4](./CIS.M365.2.1.4.md) | (L2) Ensure Safe Attachments policy is enabled (Only Checks Default Policy) | High | CIS E5 Level 2 |
+| [CIS.M365.2.1.5](./CIS.M365.2.1.5.md) | (L2) Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled | High | CIS E5 Level 2 |
+| [CIS.M365.2.1.6](./CIS.M365.2.1.6.md) | (L1) Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.7](./CIS.M365.2.1.7.md) | (L1) Ensure that an anti-phishing policy has been created (Only Checks Default Policy) | Medium | CIS E5 Level 1 |
+| [CIS.M365.2.1.9](./CIS.M365.2.1.9.md) | (L1) Ensure that DKIM is enabled for all Exchange Online Domains | High | CIS E3 Level 1 |
+| [CIS.M365.2.1.11](./CIS.M365.2.1.11.md) | (L2) Ensure comprehensive attachment filtering is applied | High | CIS E3 Level 2 |
+| [CIS.M365.2.1.12](./CIS.M365.2.1.12.md) | (L1) Ensure the connection filter IP allow list is not used (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.13](./CIS.M365.2.1.13.md) | (L1) Ensure the connection filter safe list is off (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.4.4](./CIS.M365.2.4.4.md) | (L1) Ensure Zero-hour auto purge for Microsoft Teams is on (Only Checks ZAP is enabled) | Medium | CIS E5 Level 1 |
+| [CIS.M365.3.1.1](./CIS.M365.3.1.1.md) | (L1) Ensure Microsoft 365 audit log search is Enabled | High | CIS E3 Level 1 |
+| [CIS.M365.4.1](./CIS.M365.4.1.md) | Ensure devices without a compliance policy are marked | Unknown | CIS E3 Level 2 |
+| [CIS.M365.5.1.2.2](./CIS.M365.5.1.2.2.md) | Ensure third party integrated applications are not allowed | Unknown | CIS E3 Level 2 |
+| [CIS.M365.5.1.2.3](./CIS.M365.5.1.2.3.md) | Ensure | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.1.3.1](./CIS.M365.5.1.3.1.md) | Ensure a dynamic group for guest users is created | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.1.5.1](./CIS.M365.5.1.5.1.md) | Ensure user consent to apps accessing company data on their behalf is not allowed | Unknown | CIS E3 Level 2 |
+| [CIS.M365.5.1.5.2](./CIS.M365.5.1.5.2.md) | Ensure the admin consent workflow is enabled | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.1.6.2](./CIS.M365.5.1.6.2.md) | Ensure that guest user access is restricted | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.2.3.5](./CIS.M365.5.2.3.5.md) | Ensure weak authentication methods are disabled | Unknown | CIS E3 Level 1 |
+| [CIS.M365.6.5.3](./CIS.M365.6.5.3.md) | Ensure additional storage providers are restricted in Outlook on the web | Unknown | CIS E3 Level 2 |
+| [CIS.M365.7.2.2](./CIS.M365.7.2.2.md) | Ensure SharePoint and OneDrive integration with Azure AD B2B is enabled | Unknown | SharePoint Online |
+| [CIS.M365.7.2.5](./CIS.M365.7.2.5.md) | Ensure that SharePoint guest users cannot share items they don | Unknown | SharePoint Online |
+| [CIS.M365.7.2.7](./CIS.M365.7.2.7.md) | Ensure link sharing is restricted in SharePoint and OneDrive | Unknown | SharePoint Online |
+| [CIS.M365.7.2.9](./CIS.M365.7.2.9.md) | Ensure guest access to a site or OneDrive will expire automatically | Unknown | SharePoint Online |
+| [CIS.M365.7.2.11](./CIS.M365.7.2.11.md) | Ensure the SharePoint default sharing link permission is set | Unknown | SharePoint Online |
+| [CIS.M365.7.3.1](./CIS.M365.7.3.1.md) | Ensure Office 365 SharePoint infected files are disallowed for download | Unknown | SharePoint Online |
+| [CIS.M365.8.1.1](./CIS.M365.8.1.1.md) | (L2) Ensure external file sharing in Teams is enabled for only approved cloud storage services | Medium | CIS M365 v6.0.1 |
+| [CIS.M365.8.2.2](./CIS.M365.8.2.2.md) | (L1) Ensure communication with unmanaged Teams users is disabled | Medium | CIS M365 v6.0.1 |
+| [CIS.M365.8.2.3](./CIS.M365.8.2.3.md) | Ensure external Teams users cannot initiate conversations | Unknown | CIS M365 v6.0.1 |
+| [CIS.M365.8.4.1](./CIS.M365.8.4.1.md) | (L1) Ensure all or a majority of third-party and custom apps are blocked | High | CIS M365 v6.0.1 |
+| [CIS.M365.8.5.3](./CIS.M365.8.5.3.md) | (L1) Ensure only people in my org can bypass the lobby | Medium | CIS E3 Level 1 |
+| [CIS.M365.8.6.1](./CIS.M365.8.6.1.md) | (L1) Ensure users can report security concerns in Teams to internal destination | Medium | CIS E3 Level 1 |

--- a/website/docs/tests/cisa/readme.md
+++ b/website/docs/tests/cisa/readme.md
@@ -18,76 +18,76 @@ These tests verify Microsoft 365 tenant configuration against CISA Secure Cloud 
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [CISA.MS.AAD.1.1](../CISA.MS.AAD.1.1) | Legacy authentication SHALL be blocked. | High | Entra ID P1 |
-| [CISA.MS.AAD.2.1](../CISA.MS.AAD.2.1) | Users detected as high risk SHALL be blocked. | High | Entra ID P2 |
-| [CISA.MS.AAD.2.2](../CISA.MS.AAD.2.2) | A notification SHOULD be sent to the administrator when high-risk users are detected. | High | Entra ID P2 |
-| [CISA.MS.AAD.2.3](../CISA.MS.AAD.2.3) | Sign-ins detected as high risk SHALL be blocked. | High | Entra ID P2 |
-| [CISA.MS.AAD.3.1](../CISA.MS.AAD.3.1) | Phishing-resistant MFA SHALL be enforced for all users. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.2](../CISA.MS.AAD.3.2) | If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.3](../CISA.MS.AAD.3.3) | If Microsoft Authenticator is enabled, it SHALL be configured to show login context information. | Medium | Entra ID P1 |
-| [CISA.MS.AAD.3.4](../CISA.MS.AAD.3.4) | The Authentication Methods Manage Migration feature SHALL be set to Migration Complete. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.5](../CISA.MS.AAD.3.5) | The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.6](../CISA.MS.AAD.3.6) | Phishing-resistant MFA SHALL be required for highly privileged roles. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.7](../CISA.MS.AAD.3.7) | Managed devices SHOULD be required for authentication. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.8](../CISA.MS.AAD.3.8) | Managed Devices SHOULD be required to register MFA. | High | Entra ID P1 |
-| [CISA.MS.AAD.4.1](../CISA.MS.AAD.4.1) | Security logs SHALL be sent to the agency's security operations center for monitoring. | High | Entra ID P1 |
-| [CISA.MS.AAD.5.1](../CISA.MS.AAD.5.1) | Only administrators SHALL be allowed to register applications. | High | Entra ID Free |
-| [CISA.MS.AAD.5.2](../CISA.MS.AAD.5.2) | Only administrators SHALL be allowed to consent to applications. | High | Entra ID Free |
-| [CISA.MS.AAD.5.3](../CISA.MS.AAD.5.3) | An admin consent workflow SHALL be configured for applications. | High | Entra ID Free |
-| [CISA.MS.AAD.5.4](../CISA.MS.AAD.5.4) | Group owners SHALL NOT be allowed to consent to applications. | High | Entra ID Free |
-| [CISA.MS.AAD.6.1](../CISA.MS.AAD.6.1) | User passwords SHALL NOT expire. | High | Entra ID Free |
-| [CISA.MS.AAD.7.1](../CISA.MS.AAD.7.1) | A minimum of two users and a maximum of eight users SHALL be provisioned with the Global Administrator role. | High | Entra ID Free |
-| [CISA.MS.AAD.7.2](../CISA.MS.AAD.7.2) | Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator. | High | Entra ID Free |
-| [CISA.MS.AAD.7.3](../CISA.MS.AAD.7.3) | Privileged users SHALL be provisioned cloud-only accounts separate from an on-premises directory or other federated identity providers. | High | Entra ID Free |
-| [CISA.MS.AAD.7.4](../CISA.MS.AAD.7.4) | Permanent active role assignments SHALL NOT be allowed for highly privileged roles. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.5](../CISA.MS.AAD.7.5) | Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.6](../CISA.MS.AAD.7.6) | Activation of the Global Administrator role SHALL require approval. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.7](../CISA.MS.AAD.7.7) | Eligible and Active highly privileged role assignments SHALL trigger an alert. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.8](../CISA.MS.AAD.7.8) | User activation of the Global Administrator role SHALL trigger an alert. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.9](../CISA.MS.AAD.7.9) | User activation of other highly privileged roles SHOULD trigger an alert. | High | Entra ID P2 |
-| [CISA.MS.AAD.8.1](../CISA.MS.AAD.8.1) | Guest users SHOULD have limited or restricted access to Azure AD directory objects. | Medium | Entra ID Free |
-| [CISA.MS.AAD.8.2](../CISA.MS.AAD.8.2) | Only users with the Guest Inviter role SHOULD be able to invite guest users. | High | Entra ID Free |
-| [CISA.MS.AAD.8.3](../CISA.MS.AAD.8.3) | Guest invites SHOULD only be allowed to specific external domains that have been authorized by the agency for legitimate business purposes. | Medium | Entra ID Free |
-| [CISA.MS.EXO.1.1](../CISA.MS.EXO.1.1) | Automatic forwarding to external domains SHALL be disabled. | High | exchange |
-| [CISA.MS.EXO.2.1](../CISA.MS.EXO.2.1) | A list of approved IP addresses for sending mail SHALL be maintained. | Medium | Deprecated |
-| [CISA.MS.EXO.2.2](../CISA.MS.EXO.2.2) | An SPF policy SHALL be published for each domain, designating only these addresses as approved senders. | Medium | exchange |
-| [CISA.MS.EXO.3.1](../CISA.MS.EXO.3.1) | DKIM SHOULD be enabled for all domains. | Medium | exchange |
-| [CISA.MS.EXO.4.1](../CISA.MS.EXO.4.1) | A DMARC policy SHALL be published for every second-level domain. | Medium | exchange |
-| [CISA.MS.EXO.4.2](../CISA.MS.EXO.4.2) | The DMARC message rejection option SHALL be p=reject. | High | exchange |
-| [CISA.MS.EXO.4.3](../CISA.MS.EXO.4.3) | The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov. | Medium | exchange |
-| [CISA.MS.EXO.5.1](../CISA.MS.EXO.5.1) | SMTP AUTH SHALL be disabled. | High | exchange |
-| [CISA.MS.EXO.6.1](../CISA.MS.EXO.6.1) | Contact folders SHALL NOT be shared with all domains. | Medium | exchange |
-| [CISA.MS.EXO.6.2](../CISA.MS.EXO.6.2) | Calendar details SHALL NOT be shared with all domains. | Medium | exchange |
-| [CISA.MS.EXO.7.1](../CISA.MS.EXO.7.1) | External sender warnings SHALL be implemented. | Medium | exchange |
-| [CISA.MS.EXO.8.1](../CISA.MS.EXO.8.1) | A DLP solution SHALL be used. | High | exchange |
-| [CISA.MS.EXO.8.2](../CISA.MS.EXO.8.2) | The DLP solution SHALL protect personally identifiable information (PII) and sensitive information, as defined by the agency. | Medium | exchange |
-| [CISA.MS.EXO.8.3](../CISA.MS.EXO.8.3) | The selected DLP solution SHOULD offer services comparable to the native DLP solution offered by Microsoft. | Medium | exchange |
-| [CISA.MS.EXO.8.4](../CISA.MS.EXO.8.4) | At a minimum, the DLP solution SHALL restrict sharing credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN) via email. | High | exchange |
-| [CISA.MS.EXO.9.1](../CISA.MS.EXO.9.1) | Emails SHALL be filtered by attachment file types. | Medium | exchange |
-| [CISA.MS.EXO.9.2](../CISA.MS.EXO.9.2) | The attachment filter SHOULD attempt to determine the true file type and assess the file extension. | Medium | exchange |
-| [CISA.MS.EXO.9.3](../CISA.MS.EXO.9.3) | Disallowed file types SHALL be determined and enforced. | High | exchange |
-| [CISA.MS.EXO.9.4](../CISA.MS.EXO.9.4) | Alternatively chosen filtering solutions SHOULD offer services comparable to Microsoft Defender's Common Attachment Filter. | Medium | exchange |
-| [CISA.MS.EXO.9.5](../CISA.MS.EXO.9.5) | At a minimum, click-to-run files SHOULD be blocked (e.g., .exe, .cmd, and .vbe). | High | exchange |
-| [CISA.MS.EXO.10.1](../CISA.MS.EXO.10.1) | Emails SHALL be scanned for malware. | High | exchange |
-| [CISA.MS.EXO.10.2](../CISA.MS.EXO.10.2) | Emails identified as containing malware SHALL be quarantined or dropped. | High | exchange |
-| [CISA.MS.EXO.10.3](../CISA.MS.EXO.10.3) | Email scanning SHALL be capable of reviewing emails after delivery. | High | exchange |
-| [CISA.MS.EXO.11.1](../CISA.MS.EXO.11.1) | Impersonation protection checks SHOULD be used. | High | exchange |
-| [CISA.MS.EXO.11.2](../CISA.MS.EXO.11.2) | User warnings, comparable to the user safety tips included with EOP, SHOULD be displayed. | Medium | exchange |
-| [CISA.MS.EXO.11.3](../CISA.MS.EXO.11.3) | The phishing protection solution SHOULD include an AI-based phishing detection tool comparable to EOP Mailbox Intelligence. | Medium | exchange |
-| [CISA.MS.EXO.12.1](../CISA.MS.EXO.12.1) | IP allow lists SHOULD NOT be created. | Medium | exchange |
-| [CISA.MS.EXO.12.2](../CISA.MS.EXO.12.2) | Safe lists SHOULD NOT be enabled. | Medium | exchange |
-| [CISA.MS.EXO.13.1](../CISA.MS.EXO.13.1) | Mailbox auditing SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.14.1](../CISA.MS.EXO.14.1) | A spam filter SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.14.2](../CISA.MS.EXO.14.2) | Spam and high confidence spam SHALL be moved to either the junk email folder or the quarantine folder. | Medium | exchange |
-| [CISA.MS.EXO.14.3](../CISA.MS.EXO.14.3) | Allowed domains SHALL NOT be added to inbound anti-spam protection policies. | Medium | exchange |
-| [CISA.MS.EXO.14.4](../CISA.MS.EXO.14.4) | If a third-party party filtering solution is used, the solution SHOULD offer services comparable to the native spam filtering offered by Microsoft. | Medium | exchange |
-| [CISA.MS.EXO.15.1](../CISA.MS.EXO.15.1) | URL comparison with a block-list SHOULD be enabled. | Medium | exchange |
-| [CISA.MS.EXO.15.2](../CISA.MS.EXO.15.2) | Direct download links SHOULD be scanned for malware. | High | exchange |
-| [CISA.MS.EXO.15.3](../CISA.MS.EXO.15.3) | User click tracking SHOULD be enabled. | Medium | exchange |
-| [CISA.MS.EXO.16.1](../CISA.MS.EXO.16.1) | Alerts SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.16.2](../CISA.MS.EXO.16.2) | Alerts SHOULD be sent to a monitored address or incorporated into a security information and event management (SIEM) system. | Medium | exchange |
-| [CISA.MS.EXO.17.1](../CISA.MS.EXO.17.1) | Microsoft Purview Audit (Standard) logging SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.17.2](../CISA.MS.EXO.17.2) | Microsoft Purview Audit (Premium) logging SHALL be enabled. | Medium | Deprecated |
-| [CISA.MS.EXO.17.3](../CISA.MS.EXO.17.3) | Audit logs SHALL be maintained for at least the minimum duration dictated by OMB M-21-31 (Appendix C). | Medium | exchange |
-| [CISA.MS.SHAREPOINT.1.1](../CISA.MS.SHAREPOINT.1.1) | External sharing for SharePoint SHALL be limited to Existing guests or Only People in your organization. | Medium | spo |
-| [CISA.MS.SHAREPOINT.1.3](../CISA.MS.SHAREPOINT.1.3) | External sharing SHALL be restricted to approved external domains and/or users in approved security groups per interagency collaboration needs. | High | spo |
+| [CISA.MS.AAD.1.1](./CISA.MS.AAD.1.1.md) | Legacy authentication SHALL be blocked. | High | Entra ID P1 |
+| [CISA.MS.AAD.2.1](./CISA.MS.AAD.2.1.md) | Users detected as high risk SHALL be blocked. | High | Entra ID P2 |
+| [CISA.MS.AAD.2.2](./CISA.MS.AAD.2.2.md) | A notification SHOULD be sent to the administrator when high-risk users are detected. | High | Entra ID P2 |
+| [CISA.MS.AAD.2.3](./CISA.MS.AAD.2.3.md) | Sign-ins detected as high risk SHALL be blocked. | High | Entra ID P2 |
+| [CISA.MS.AAD.3.1](./CISA.MS.AAD.3.1.md) | Phishing-resistant MFA SHALL be enforced for all users. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.2](./CISA.MS.AAD.3.2.md) | If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.3](./CISA.MS.AAD.3.3.md) | If Microsoft Authenticator is enabled, it SHALL be configured to show login context information. | Medium | Entra ID P1 |
+| [CISA.MS.AAD.3.4](./CISA.MS.AAD.3.4.md) | The Authentication Methods Manage Migration feature SHALL be set to Migration Complete. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.5](./CISA.MS.AAD.3.5.md) | The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.6](./CISA.MS.AAD.3.6.md) | Phishing-resistant MFA SHALL be required for highly privileged roles. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.7](./CISA.MS.AAD.3.7.md) | Managed devices SHOULD be required for authentication. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.8](./CISA.MS.AAD.3.8.md) | Managed Devices SHOULD be required to register MFA. | High | Entra ID P1 |
+| [CISA.MS.AAD.4.1](./CISA.MS.AAD.4.1.md) | Security logs SHALL be sent to the agency's security operations center for monitoring. | High | Entra ID P1 |
+| [CISA.MS.AAD.5.1](./CISA.MS.AAD.5.1.md) | Only administrators SHALL be allowed to register applications. | High | Entra ID Free |
+| [CISA.MS.AAD.5.2](./CISA.MS.AAD.5.2.md) | Only administrators SHALL be allowed to consent to applications. | High | Entra ID Free |
+| [CISA.MS.AAD.5.3](./CISA.MS.AAD.5.3.md) | An admin consent workflow SHALL be configured for applications. | High | Entra ID Free |
+| [CISA.MS.AAD.5.4](./CISA.MS.AAD.5.4.md) | Group owners SHALL NOT be allowed to consent to applications. | High | Entra ID Free |
+| [CISA.MS.AAD.6.1](./CISA.MS.AAD.6.1.md) | User passwords SHALL NOT expire. | High | Entra ID Free |
+| [CISA.MS.AAD.7.1](./CISA.MS.AAD.7.1.md) | A minimum of two users and a maximum of eight users SHALL be provisioned with the Global Administrator role. | High | Entra ID Free |
+| [CISA.MS.AAD.7.2](./CISA.MS.AAD.7.2.md) | Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator. | High | Entra ID Free |
+| [CISA.MS.AAD.7.3](./CISA.MS.AAD.7.3.md) | Privileged users SHALL be provisioned cloud-only accounts separate from an on-premises directory or other federated identity providers. | High | Entra ID Free |
+| [CISA.MS.AAD.7.4](./CISA.MS.AAD.7.4.md) | Permanent active role assignments SHALL NOT be allowed for highly privileged roles. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.5](./CISA.MS.AAD.7.5.md) | Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.6](./CISA.MS.AAD.7.6.md) | Activation of the Global Administrator role SHALL require approval. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.7](./CISA.MS.AAD.7.7.md) | Eligible and Active highly privileged role assignments SHALL trigger an alert. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.8](./CISA.MS.AAD.7.8.md) | User activation of the Global Administrator role SHALL trigger an alert. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.9](./CISA.MS.AAD.7.9.md) | User activation of other highly privileged roles SHOULD trigger an alert. | High | Entra ID P2 |
+| [CISA.MS.AAD.8.1](./CISA.MS.AAD.8.1.md) | Guest users SHOULD have limited or restricted access to Azure AD directory objects. | Medium | Entra ID Free |
+| [CISA.MS.AAD.8.2](./CISA.MS.AAD.8.2.md) | Only users with the Guest Inviter role SHOULD be able to invite guest users. | High | Entra ID Free |
+| [CISA.MS.AAD.8.3](./CISA.MS.AAD.8.3.md) | Guest invites SHOULD only be allowed to specific external domains that have been authorized by the agency for legitimate business purposes. | Medium | Entra ID Free |
+| [CISA.MS.EXO.1.1](./CISA.MS.EXO.1.1.md) | Automatic forwarding to external domains SHALL be disabled. | High | exchange |
+| [CISA.MS.EXO.2.1](./CISA.MS.EXO.2.1.md) | A list of approved IP addresses for sending mail SHALL be maintained. | Medium | Deprecated |
+| [CISA.MS.EXO.2.2](./CISA.MS.EXO.2.2.md) | An SPF policy SHALL be published for each domain, designating only these addresses as approved senders. | Medium | exchange |
+| [CISA.MS.EXO.3.1](./CISA.MS.EXO.3.1.md) | DKIM SHOULD be enabled for all domains. | Medium | exchange |
+| [CISA.MS.EXO.4.1](./CISA.MS.EXO.4.1.md) | A DMARC policy SHALL be published for every second-level domain. | Medium | exchange |
+| [CISA.MS.EXO.4.2](./CISA.MS.EXO.4.2.md) | The DMARC message rejection option SHALL be p=reject. | High | exchange |
+| [CISA.MS.EXO.4.3](./CISA.MS.EXO.4.3.md) | The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov. | Medium | exchange |
+| [CISA.MS.EXO.5.1](./CISA.MS.EXO.5.1.md) | SMTP AUTH SHALL be disabled. | High | exchange |
+| [CISA.MS.EXO.6.1](./CISA.MS.EXO.6.1.md) | Contact folders SHALL NOT be shared with all domains. | Medium | exchange |
+| [CISA.MS.EXO.6.2](./CISA.MS.EXO.6.2.md) | Calendar details SHALL NOT be shared with all domains. | Medium | exchange |
+| [CISA.MS.EXO.7.1](./CISA.MS.EXO.7.1.md) | External sender warnings SHALL be implemented. | Medium | exchange |
+| [CISA.MS.EXO.8.1](./CISA.MS.EXO.8.1.md) | A DLP solution SHALL be used. | High | exchange |
+| [CISA.MS.EXO.8.2](./CISA.MS.EXO.8.2.md) | The DLP solution SHALL protect personally identifiable information (PII) and sensitive information, as defined by the agency. | Medium | exchange |
+| [CISA.MS.EXO.8.3](./CISA.MS.EXO.8.3.md) | The selected DLP solution SHOULD offer services comparable to the native DLP solution offered by Microsoft. | Medium | exchange |
+| [CISA.MS.EXO.8.4](./CISA.MS.EXO.8.4.md) | At a minimum, the DLP solution SHALL restrict sharing credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN) via email. | High | exchange |
+| [CISA.MS.EXO.9.1](./CISA.MS.EXO.9.1.md) | Emails SHALL be filtered by attachment file types. | Medium | exchange |
+| [CISA.MS.EXO.9.2](./CISA.MS.EXO.9.2.md) | The attachment filter SHOULD attempt to determine the true file type and assess the file extension. | Medium | exchange |
+| [CISA.MS.EXO.9.3](./CISA.MS.EXO.9.3.md) | Disallowed file types SHALL be determined and enforced. | High | exchange |
+| [CISA.MS.EXO.9.4](./CISA.MS.EXO.9.4.md) | Alternatively chosen filtering solutions SHOULD offer services comparable to Microsoft Defender's Common Attachment Filter. | Medium | exchange |
+| [CISA.MS.EXO.9.5](./CISA.MS.EXO.9.5.md) | At a minimum, click-to-run files SHOULD be blocked (e.g., .exe, .cmd, and .vbe). | High | exchange |
+| [CISA.MS.EXO.10.1](./CISA.MS.EXO.10.1.md) | Emails SHALL be scanned for malware. | High | exchange |
+| [CISA.MS.EXO.10.2](./CISA.MS.EXO.10.2.md) | Emails identified as containing malware SHALL be quarantined or dropped. | High | exchange |
+| [CISA.MS.EXO.10.3](./CISA.MS.EXO.10.3.md) | Email scanning SHALL be capable of reviewing emails after delivery. | High | exchange |
+| [CISA.MS.EXO.11.1](./CISA.MS.EXO.11.1.md) | Impersonation protection checks SHOULD be used. | High | exchange |
+| [CISA.MS.EXO.11.2](./CISA.MS.EXO.11.2.md) | User warnings, comparable to the user safety tips included with EOP, SHOULD be displayed. | Medium | exchange |
+| [CISA.MS.EXO.11.3](./CISA.MS.EXO.11.3.md) | The phishing protection solution SHOULD include an AI-based phishing detection tool comparable to EOP Mailbox Intelligence. | Medium | exchange |
+| [CISA.MS.EXO.12.1](./CISA.MS.EXO.12.1.md) | IP allow lists SHOULD NOT be created. | Medium | exchange |
+| [CISA.MS.EXO.12.2](./CISA.MS.EXO.12.2.md) | Safe lists SHOULD NOT be enabled. | Medium | exchange |
+| [CISA.MS.EXO.13.1](./CISA.MS.EXO.13.1.md) | Mailbox auditing SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.14.1](./CISA.MS.EXO.14.1.md) | A spam filter SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.14.2](./CISA.MS.EXO.14.2.md) | Spam and high confidence spam SHALL be moved to either the junk email folder or the quarantine folder. | Medium | exchange |
+| [CISA.MS.EXO.14.3](./CISA.MS.EXO.14.3.md) | Allowed domains SHALL NOT be added to inbound anti-spam protection policies. | Medium | exchange |
+| [CISA.MS.EXO.14.4](./CISA.MS.EXO.14.4.md) | If a third-party party filtering solution is used, the solution SHOULD offer services comparable to the native spam filtering offered by Microsoft. | Medium | exchange |
+| [CISA.MS.EXO.15.1](./CISA.MS.EXO.15.1.md) | URL comparison with a block-list SHOULD be enabled. | Medium | exchange |
+| [CISA.MS.EXO.15.2](./CISA.MS.EXO.15.2.md) | Direct download links SHOULD be scanned for malware. | High | exchange |
+| [CISA.MS.EXO.15.3](./CISA.MS.EXO.15.3.md) | User click tracking SHOULD be enabled. | Medium | exchange |
+| [CISA.MS.EXO.16.1](./CISA.MS.EXO.16.1.md) | Alerts SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.16.2](./CISA.MS.EXO.16.2.md) | Alerts SHOULD be sent to a monitored address or incorporated into a security information and event management (SIEM) system. | Medium | exchange |
+| [CISA.MS.EXO.17.1](./CISA.MS.EXO.17.1.md) | Microsoft Purview Audit (Standard) logging SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.17.2](./CISA.MS.EXO.17.2.md) | Microsoft Purview Audit (Premium) logging SHALL be enabled. | Medium | Deprecated |
+| [CISA.MS.EXO.17.3](./CISA.MS.EXO.17.3.md) | Audit logs SHALL be maintained for at least the minimum duration dictated by OMB M-21-31 (Appendix C). | Medium | exchange |
+| [CISA.MS.SHAREPOINT.1.1](./CISA.MS.SHAREPOINT.1.1.md) | External sharing for SharePoint SHALL be limited to Existing guests or Only People in your organization. | Medium | spo |
+| [CISA.MS.SHAREPOINT.1.3](./CISA.MS.SHAREPOINT.1.3.md) | External sharing SHALL be restricted to approved external domains and/or users in approved security groups per interagency collaboration needs. | High | spo |

--- a/website/docs/tests/eidsca/readme.md
+++ b/website/docs/tests/eidsca/readme.md
@@ -18,47 +18,47 @@ These tests are based on the Entra ID Security Config Analyzer and verify Micros
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [EIDSCA.AF01](../EIDSCA.AF01) | Authentication Method - FIDO2 security key - State. | High | General |
-| [EIDSCA.AF02](../EIDSCA.AF02) | Authentication Method - FIDO2 security key - Allow self-service set up. | Medium | General |
-| [EIDSCA.AF03](../EIDSCA.AF03) | Authentication Method - FIDO2 security key - Enforce attestation. | High | General |
-| [EIDSCA.AF04](../EIDSCA.AF04) | Authentication Method - FIDO2 security key - Enforce key restrictions. | High | General |
-| [EIDSCA.AF05](../EIDSCA.AF05) | Authentication Method - FIDO2 security key - Restricted. | High | General |
-| [EIDSCA.AF06](../EIDSCA.AF06) | Authentication Method - FIDO2 security key - Restrict specific keys. | Medium | General |
-| [EIDSCA.AG01](../EIDSCA.AG01) | Authentication Method - General Settings - Manage migration. | High | General |
-| [EIDSCA.AG02](../EIDSCA.AG02) | Authentication Method - General Settings - Report suspicious activity - State. | Medium | General |
-| [EIDSCA.AG03](../EIDSCA.AG03) | Authentication Method - General Settings - Report suspicious activity - Included users/groups. | Medium | General |
-| [EIDSCA.AM01](../EIDSCA.AM01) | Authentication Method - Microsoft Authenticator - State. | High | General |
-| [EIDSCA.AM02](../EIDSCA.AM02) | Authentication Method - Microsoft Authenticator - Allow use of Microsoft Authenticator OTP. | Medium | General |
-| [EIDSCA.AM03](../EIDSCA.AM03) | Authentication Method - Microsoft Authenticator - Require number matching for push notifications. | Medium | General |
-| [EIDSCA.AM04](../EIDSCA.AM04) | Authentication Method - Microsoft Authenticator - Included users/groups of number matching for push notifications. | Medium | General |
-| [EIDSCA.AM06](../EIDSCA.AM06) | Authentication Method - Microsoft Authenticator - Show application name in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AM07](../EIDSCA.AM07) | Authentication Method - Microsoft Authenticator - Included users/groups to show application name in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AM09](../EIDSCA.AM09) | Authentication Method - Microsoft Authenticator - Show geographic location in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AM10](../EIDSCA.AM10) | Authentication Method - Microsoft Authenticator - Included users/groups to show geographic location in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AP01](../EIDSCA.AP01) | Default Authorization Settings - Enabled Self service password reset for administrators. | High | General |
-| [EIDSCA.AP04](../EIDSCA.AP04) | Default Authorization Settings - Guest invite restrictions. | Medium | General |
-| [EIDSCA.AP05](../EIDSCA.AP05) | Default Authorization Settings - Sign-up for email based subscription. | Medium | General |
-| [EIDSCA.AP06](../EIDSCA.AP06) | Default Authorization Settings - User can join the tenant by email validation. | Medium | General |
-| [EIDSCA.AP07](../EIDSCA.AP07) | Default Authorization Settings - Guest user access. | High | General |
-| [EIDSCA.AP08](../EIDSCA.AP08) | Default Authorization Settings - User consent policy assigned for applications. | Medium | General |
-| [EIDSCA.AP09](../EIDSCA.AP09) | Default Authorization Settings - Allow user consent on risk-based apps. | Medium | General |
-| [EIDSCA.AP10](../EIDSCA.AP10) | Default Authorization Settings - Default User Role Permissions - Allowed to create Apps. | High | General |
-| [EIDSCA.AP14](../EIDSCA.AP14) | Default Authorization Settings - Default User Role Permissions - Allowed to read other users. | High | General |
-| [EIDSCA.AS04](../EIDSCA.AS04) | Authentication Method - SMS - Use for sign-in. | High | General |
-| [EIDSCA.AT01](../EIDSCA.AT01) | Authentication Method - Temporary Access Pass - State. | High | General |
-| [EIDSCA.AT02](../EIDSCA.AT02) | Authentication Method - Temporary Access Pass - One-time. | High | General |
-| [EIDSCA.AV01](../EIDSCA.AV01) | Authentication Method - Voice call - State. | High | General |
-| [EIDSCA.CP01](../EIDSCA.CP01) | Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. | High | General |
-| [EIDSCA.CP03](../EIDSCA.CP03) | Default Settings - Consent Policy Settings - Block user consent for risky apps. | High | General |
-| [EIDSCA.CP04](../EIDSCA.CP04) | Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. | Medium | General |
-| [EIDSCA.CR01](../EIDSCA.CR01) | Consent Framework - Admin Consent Request - Policy to enable or disable admin consent request feature. | High | General |
-| [EIDSCA.CR02](../EIDSCA.CR02) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. | Medium | General |
-| [EIDSCA.CR03](../EIDSCA.CR03) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. | Medium | General |
-| [EIDSCA.CR04](../EIDSCA.CR04) | Consent Framework - Admin Consent Request - Consent request duration (days). | High | General |
-| [EIDSCA.PR01](../EIDSCA.PR01) | Default Settings - Password Rule Settings - Password Protection - Mode. | High | General |
-| [EIDSCA.PR02](../EIDSCA.PR02) | Default Settings - Password Rule Settings - Password Protection - Enable password protection on Windows Server Active Directory. | High | General |
-| [EIDSCA.PR03](../EIDSCA.PR03) | Default Settings - Password Rule Settings - Enforce custom list. | Medium | General |
-| [EIDSCA.PR05](../EIDSCA.PR05) | Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. | Medium | General |
-| [EIDSCA.PR06](../EIDSCA.PR06) | Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. | Medium | General |
-| [EIDSCA.ST08](../EIDSCA.ST08) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to become Group Owner. | Medium | General |
-| [EIDSCA.ST09](../EIDSCA.ST09) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to have access to groups content. | Medium | General |
+| [EIDSCA.AF01](./EIDSCA.AF01.md) | Authentication Method - FIDO2 security key - State. | High | General |
+| [EIDSCA.AF02](./EIDSCA.AF02.md) | Authentication Method - FIDO2 security key - Allow self-service set up. | Medium | General |
+| [EIDSCA.AF03](./EIDSCA.AF03.md) | Authentication Method - FIDO2 security key - Enforce attestation. | High | General |
+| [EIDSCA.AF04](./EIDSCA.AF04.md) | Authentication Method - FIDO2 security key - Enforce key restrictions. | High | General |
+| [EIDSCA.AF05](./EIDSCA.AF05.md) | Authentication Method - FIDO2 security key - Restricted. | High | General |
+| [EIDSCA.AF06](./EIDSCA.AF06.md) | Authentication Method - FIDO2 security key - Restrict specific keys. | Medium | General |
+| [EIDSCA.AG01](./EIDSCA.AG01.md) | Authentication Method - General Settings - Manage migration. | High | General |
+| [EIDSCA.AG02](./EIDSCA.AG02.md) | Authentication Method - General Settings - Report suspicious activity - State. | Medium | General |
+| [EIDSCA.AG03](./EIDSCA.AG03.md) | Authentication Method - General Settings - Report suspicious activity - Included users/groups. | Medium | General |
+| [EIDSCA.AM01](./EIDSCA.AM01.md) | Authentication Method - Microsoft Authenticator - State. | High | General |
+| [EIDSCA.AM02](./EIDSCA.AM02.md) | Authentication Method - Microsoft Authenticator - Allow use of Microsoft Authenticator OTP. | Medium | General |
+| [EIDSCA.AM03](./EIDSCA.AM03.md) | Authentication Method - Microsoft Authenticator - Require number matching for push notifications. | Medium | General |
+| [EIDSCA.AM04](./EIDSCA.AM04.md) | Authentication Method - Microsoft Authenticator - Included users/groups of number matching for push notifications. | Medium | General |
+| [EIDSCA.AM06](./EIDSCA.AM06.md) | Authentication Method - Microsoft Authenticator - Show application name in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AM07](./EIDSCA.AM07.md) | Authentication Method - Microsoft Authenticator - Included users/groups to show application name in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AM09](./EIDSCA.AM09.md) | Authentication Method - Microsoft Authenticator - Show geographic location in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AM10](./EIDSCA.AM10.md) | Authentication Method - Microsoft Authenticator - Included users/groups to show geographic location in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AP01](./EIDSCA.AP01.md) | Default Authorization Settings - Enabled Self service password reset for administrators. | High | General |
+| [EIDSCA.AP04](./EIDSCA.AP04.md) | Default Authorization Settings - Guest invite restrictions. | Medium | General |
+| [EIDSCA.AP05](./EIDSCA.AP05.md) | Default Authorization Settings - Sign-up for email based subscription. | Medium | General |
+| [EIDSCA.AP06](./EIDSCA.AP06.md) | Default Authorization Settings - User can join the tenant by email validation. | Medium | General |
+| [EIDSCA.AP07](./EIDSCA.AP07.md) | Default Authorization Settings - Guest user access. | High | General |
+| [EIDSCA.AP08](./EIDSCA.AP08.md) | Default Authorization Settings - User consent policy assigned for applications. | Medium | General |
+| [EIDSCA.AP09](./EIDSCA.AP09.md) | Default Authorization Settings - Allow user consent on risk-based apps. | Medium | General |
+| [EIDSCA.AP10](./EIDSCA.AP10.md) | Default Authorization Settings - Default User Role Permissions - Allowed to create Apps. | High | General |
+| [EIDSCA.AP14](./EIDSCA.AP14.md) | Default Authorization Settings - Default User Role Permissions - Allowed to read other users. | High | General |
+| [EIDSCA.AS04](./EIDSCA.AS04.md) | Authentication Method - SMS - Use for sign-in. | High | General |
+| [EIDSCA.AT01](./EIDSCA.AT01.md) | Authentication Method - Temporary Access Pass - State. | High | General |
+| [EIDSCA.AT02](./EIDSCA.AT02.md) | Authentication Method - Temporary Access Pass - One-time. | High | General |
+| [EIDSCA.AV01](./EIDSCA.AV01.md) | Authentication Method - Voice call - State. | High | General |
+| [EIDSCA.CP01](./EIDSCA.CP01.md) | Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. | High | General |
+| [EIDSCA.CP03](./EIDSCA.CP03.md) | Default Settings - Consent Policy Settings - Block user consent for risky apps. | High | General |
+| [EIDSCA.CP04](./EIDSCA.CP04.md) | Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. | Medium | General |
+| [EIDSCA.CR01](./EIDSCA.CR01.md) | Consent Framework - Admin Consent Request - Policy to enable or disable admin consent request feature. | High | General |
+| [EIDSCA.CR02](./EIDSCA.CR02.md) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. | Medium | General |
+| [EIDSCA.CR03](./EIDSCA.CR03.md) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. | Medium | General |
+| [EIDSCA.CR04](./EIDSCA.CR04.md) | Consent Framework - Admin Consent Request - Consent request duration (days). | High | General |
+| [EIDSCA.PR01](./EIDSCA.PR01.md) | Default Settings - Password Rule Settings - Password Protection - Mode. | High | General |
+| [EIDSCA.PR02](./EIDSCA.PR02.md) | Default Settings - Password Rule Settings - Password Protection - Enable password protection on Windows Server Active Directory. | High | General |
+| [EIDSCA.PR03](./EIDSCA.PR03.md) | Default Settings - Password Rule Settings - Enforce custom list. | Medium | General |
+| [EIDSCA.PR05](./EIDSCA.PR05.md) | Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. | Medium | General |
+| [EIDSCA.PR06](./EIDSCA.PR06.md) | Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. | Medium | General |
+| [EIDSCA.ST08](./EIDSCA.ST08.md) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to become Group Owner. | Medium | General |
+| [EIDSCA.ST09](./EIDSCA.ST09.md) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to have access to groups content. | Medium | General |

--- a/website/docs/tests/maester/readme.md
+++ b/website/docs/tests/maester/readme.md
@@ -18,152 +18,152 @@ These tests are maintained by the Maester community and validate Microsoft 365, 
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [MT.1001](../MT.1001) | At least one Conditional Access policy is configured with device compliance. | Medium | CA |
-| [MT.1002](../MT.1002) | App management restrictions on applications and service principals is configured and enabled. | High | App |
-| [MT.1003](../MT.1003) | At least one Conditional Access policy is configured with All Apps. | High | CA |
-| [MT.1004](../MT.1004) | At least one Conditional Access policy is configured with All Apps and All Users. | High | CA |
-| [MT.1005](../MT.1005) | All Conditional Access policies are configured to exclude at least one emergency/break glass account or group. | High | CA |
-| [MT.1006](../MT.1006) | At least one Conditional Access policy is configured to require MFA for admins. | High | CA |
-| [MT.1007](../MT.1007) | At least one Conditional Access policy is configured to require MFA for all users. | High | CA |
-| [MT.1008](../MT.1008) | At least one Conditional Access policy is configured to require MFA for Azure management. | High | CA |
-| [MT.1009](../MT.1009) | At least one Conditional Access policy is configured to block other legacy authentication. | High | CA |
-| [MT.1010](../MT.1010) | At least one Conditional Access policy is configured to block legacy authentication for Exchange ActiveSync. | High | CA |
-| [MT.1011](../MT.1011) | At least one Conditional Access policy is configured to secure security info registration only from a trusted location. | High | CA |
-| [MT.1012](../MT.1012) | At least one Conditional Access policy is configured to require MFA for risky sign-ins. | High | CA |
-| [MT.1013](../MT.1013) | At least one Conditional Access policy is configured to require new password when user risk is high. | High | CA |
-| [MT.1014](../MT.1014) | At least one Conditional Access policy is configured to require compliant or Entra hybrid joined devices for admins. | High | CA |
-| [MT.1015](../MT.1015) | At least one Conditional Access policy is configured to block access for unknown or unsupported device platforms. | Medium | CA |
-| [MT.1016](../MT.1016) | At least one Conditional Access policy is configured to require MFA for guest access. | High | CA |
-| [MT.1017](../MT.1017) | At least one Conditional Access policy is configured to enforce non persistent browser session for non-corporate devices. | High | CA |
-| [MT.1018](../MT.1018) | At least one Conditional Access policy is configured to enforce sign-in frequency for non-corporate devices. | Medium | CA |
-| [MT.1019](../MT.1019) | At least one Conditional Access policy is configured to enable application enforced restrictions. | Medium | CA |
-| [MT.1020](../MT.1020) | All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. | High | CA |
-| [MT.1021](../MT.1021) | Security Defaults are enabled. | High | CA |
-| [MT.1022](../MT.1022) | All users utilizing a P1 license should be licensed. | Medium | CA |
-| [MT.1023](../MT.1023) | All users utilizing a P2 license should be licensed. | Medium | CA |
-| [MT.1024](../MT.1024) | MT.1024.$($RecommendationId -replace | Unknown | Entra |
-| [MT.1025](../MT.1025) | No external user with permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1026](../MT.1026) | No hybrid user with permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1027](../MT.1027) | No Service Principal with Client Secret and permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1028](../MT.1028) | No user with mailbox and permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1029](../MT.1029) | Stale accounts are not assigned to privileged roles. | High | Privileged |
-| [MT.1030](../MT.1030) | Eligible role assignments on Control Plane are in use by administrators. | High | Privileged |
-| [MT.1031](../MT.1031) | Privileged role on Control Plane are managed by PIM only. | High | Privileged |
-| [MT.1032](../MT.1032) | Limited number of Global Admins are assigned. | High | Privileged |
-| [MT.1033](../MT.1033) | MT.1033.$($RegularUsers.IndexOf($_)): User should be blocked from using legacy authentication ($($_.userPrincipalName)) | Unknown | CA |
-| [MT.1034](../MT.1034) | MT.1034.$($EmergencyAccessUsers.IndexOf($_)): Emergency access users should not be blocked ($($_.userPrincipalName)) | Unknown | CA |
-| [MT.1035](../MT.1035) | All security groups assigned to Conditional Access Policies should be protected by RMAU. | High | CA |
-| [MT.1036](../MT.1036) | All excluded objects should have a fallback include in another policy. | Medium | CA |
-| [MT.1037](../MT.1037) | Only users with Presenter role are allowed to present in Teams meetings | High | Teams |
-| [MT.1038](../MT.1038) | Conditional Access policies should not include or exclude deleted groups. | Medium | CA |
-| [MT.1039](../MT.1039) | Ensure MailTips are enabled for end users | Low | Exchange |
-| [MT.1041](../MT.1041) | Ensure users installing Outlook add-ins is not allowed | High | Exchange |
-| [MT.1042](../MT.1042) | Restrict dial-in users from bypassing a meeting lobby | Medium | Teams |
-| [MT.1043](../MT.1043) | Ensure Spam confidence level (SCL) is configured in mail transport rules with specific domains | Medium | Exchange |
-| [MT.1044](../MT.1044) | Ensure modern authentication for Exchange Online is enabled | High | Exchange |
-| [MT.1045](../MT.1045) | Only invited users should be automatically admitted to Teams meetings | Medium | Teams |
-| [MT.1046](../MT.1046) | Restrict anonymous users from joining meetings | Medium | Teams |
-| [MT.1047](../MT.1047) | Restrict anonymous users from starting Teams meetings | Medium | Teams |
-| [MT.1048](../MT.1048) | Limit external participants from having control in a Teams meeting | Medium | Teams |
-| [MT.1049](../MT.1049) | Conditional Access policies for User Risk and Sign-in Risk should be configured separately. | High | CA |
-| [MT.1050](../MT.1050) | Apps with high-risk permissions having a direct path to Global Admin | High | App |
-| [MT.1051](../MT.1051) | Apps with high-risk permissions having an indirect path to Global Admin | High | App |
-| [MT.1052](../MT.1052) | At least one Conditional Access policy is targeting the Device Code authentication flow. | High | CA |
-| [MT.1053](../MT.1053) | Ensure intune device clean-up rule is configured | Medium | Intune |
-| [MT.1054](../MT.1054) | Ensure built-in Device Compliance Policy marks devices with no compliance policy assigned as 'Not compliant' | Medium | Intune |
-| [MT.1055](../MT.1055) | Microsoft 365 Group (and Team) creation should be restricted to approved users. | Medium | Group |
-| [MT.1056](../MT.1056) | Ensure that no person has permanent access to all Azure subscriptions at the root scope | High | Privileged |
-| [MT.1057](../MT.1057) | Ensure Microsoft 365 Group (and Team) expiration is configured to notify users. | Medium | App |
-| [MT.1058](../MT.1058) | Ensure Microsoft 365 Group (and Team) expiration is configured to auto-expire groups. | Medium | App |
-| [MT.1059](../MT.1059) | Microsoft Defender for Identity health issues should be resolved | Medium | Defender |
-| [MT.1061](../MT.1061) | Device registration MFA control conflicts with Conditional Access policies | Medium | CA |
-| [MT.1062](../MT.1062) | Ensure Direct Send is set to be rejected | Medium | Exchange |
-| [MT.1063](../MT.1063) | All app registration owners should have MFA registered | High | App |
-| [MT.1064](../MT.1064) | Management group creation should be limited to users with explicit write access | High | Azure |
-| [MT.1065](../MT.1065) | Soft Delete should be enabled on all Recovery Services Vaults | High | Backup |
-| [MT.1066](../MT.1066) | Conditional Access policies should not include or exclude deleted users, groups, or roles. | Medium | CA |
-| [MT.1067](../MT.1067) | Authentication methods policies should not reference deleted groups. | Medium | Authentication |
-| [MT.1068](../MT.1068) | Restrict non-admin users from creating tenants | Medium | Entra |
-| [MT.1069](../MT.1069) | Restrict non-admin users from creating security groups. | Low | Entra |
-| [MT.1070](../MT.1070) | Restrict device join to selected users/groups or none. | Medium | Entra |
-| [MT.1071](../MT.1071) | At least one Conditional Access policy explicitly includes Azure DevOps. | Medium | CA |
-| [MT.1072](../MT.1072) | Conditional access policies should not use the deprecated Approved Client App grant. | High | CA |
-| [MT.1073](../MT.1073) | Soft- and hard-matching of synchronized objects should be blocked. | Medium | Entra |
-| [MT.1074](../MT.1074) | Mailboxes should not send outbound mails using the .onmicrosoft.com domain. | Medium | Exchange |
-| [MT.1075](../MT.1075) | Third Party Entra Apps should only have explicitly assigned users instead of All Users. | Medium | App |
-| [MT.1076](../MT.1076) | MOERA SHOULD NOT be used for sent mail. | High | Exchange |
-| [MT.1077](../MT.1077) | App registrations with privileged API permissions should not have owners | Medium | Privileged |
-| [MT.1078](../MT.1078) | App registrations with highly privileged directory roles should not have owners | Medium | Privileged |
-| [MT.1079](../MT.1079) | Privileged API permissions on service principals should not remain unused | Medium | Privileged |
-| [MT.1080](../MT.1080) | Credentials, tokens, or cookies from highly privileged users should not be exposed on vulnerable endpoints | Medium | Privileged |
-| [MT.1081](../MT.1081) | Hybrid users should not be assigned Entra ID role assignments | Medium | Privileged |
-| [MT.1083](../MT.1083) | Ensure Delicensing Resiliency is enabled | Low | Exchange |
-| [MT.1084](../MT.1084) | Seamless Single SignOn should be disabled for all domains in EntraID Connect servers. | High | Entra |
-| [MT.1085](../MT.1085) | Pending approvals for Critical Asset Management should not be present | Medium | Entra |
-| [MT.1086](../MT.1086) | Devices should not share both critical and non-critical user credentials. | Low | XSPM |
-| [MT.1087](../MT.1087) | Devices should not be publicly exposed with remotely exploitable, highly likely to be exploited, high or critical severity CVE's. | High | XSPM |
-| [MT.1088](../MT.1088) | Devices with critical credentials should be protected by TPM. | Medium | XSPM |
-| [MT.1089](../MT.1089) | Devices with critical credentials should be protected by Credential Guard. | Medium | XSPM |
-| [MT.1090](../MT.1090) | Global administrator role should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
-| [MT.1091](../MT.1091) | Registering user should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
-| [MT.1092](../MT.1092) | Intune APNS certificate should be valid for more than 30 days | High | Intune |
-| [MT.1093](../MT.1093) | Apple Automated Device Enrollment Tokens should be valid for more than 30 days | High | Intune |
-| [MT.1094](../MT.1094) | Apple Volume Purchase Program Tokens should be valid for more than 30 days | High | Intune |
-| [MT.1095](../MT.1095) | Android Enterprise Account Connection should be healthy | High | Intune |
-| [MT.1096](../MT.1096) | Intune Multi Admin approval should be configured | Medium | Intune |
-| [MT.1097](../MT.1097) | Certificate Connectors should be healthy and running supported versions | High | Intune |
-| [MT.1098](../MT.1098) | Mobile Threat Defense Connectors should be healthy | Critical | Intune |
-| [MT.1099](../MT.1099) | Windows Diagnostic Data Processing should be enabled | Low | Intune |
-| [MT.1100](../MT.1100) | Intune Audit Logs should be retained | High | Intune |
-| [MT.1101](../MT.1101) | Default Branding Profile should be customized | Low | Intune |
-| [MT.1102](../MT.1102) | Windows Feature Update Policy Settings should not reference end of support builds | High | Intune |
-| [MT.1103](../MT.1103) | Intune RBAC groups should be protected by Restricted Management Administrative Units or Role Assignable groups | High | Intune |
-| [MT.1105](../MT.1105) | MDM Authority should be set to Microsoft Intune | Low | Intune |
-| [MT.1106](../MT.1106) | Catalog resources must have valid roles (no stale app roles or deleted SPNs) | Medium | Governance |
-| [MT.1107](../MT.1107) | Access packages and catalogs should not reference deleted groups | Medium | Governance |
-| [MT.1108](../MT.1108) | Access packages should not have inactive or orphaned assignment policies | Medium | Governance |
-| [MT.1109](../MT.1109) | Access package approval workflows must have valid approvers | Medium | Governance |
-| [MT.1110](../MT.1110) | No catalog should contain resources without any associated access packages | Medium | Governance |
-| [MT.1111](../MT.1111) | High privileged user should be linked to an identity | Low | Privileged |
-| [MT.1112](../MT.1112) | Privileged user accounts should not remain enabled when the linked primary account is disabled | Medium | Privileged |
-| [MT.1113](../MT.1113) | AI agents should not be shared with broad access control policies | High | AIAgent |
-| [MT.1114](../MT.1114) | AI agents should require user authentication | High | AIAgent |
-| [MT.1115](../MT.1115) | AI agents should not have risky HTTP configurations | Medium | AIAgent |
-| [MT.1116](../MT.1116) | AI agents should not send email with AI-controlled inputs | High | AIAgent |
-| [MT.1117](../MT.1117) | Published AI agents should not be dormant | Low | AIAgent |
-| [MT.1118](../MT.1118) | AI agents should avoid using author (maker) authentication for tools | Medium | AIAgent |
-| [MT.1119](../MT.1119) | AI agents should not have hard-coded credentials in topics | High | AIAgent |
-| [MT.1120](../MT.1120) | AI agents should not use MCP server tools without review | Medium | AIAgent |
-| [MT.1121](../MT.1121) | AI agents with generative orchestration should have custom instructions | Medium | AIAgent |
-| [MT.1122](../MT.1122) | AI agents should not have orphaned ownership | Medium | AIAgent |
-| [MT.1123](../MT.1123) | Ensure BitLocker full disk encryption is configured via Intune | High | Intune |
-| [MT.1147](../MT.1147) | Do not sync krbtgt_AzureAD to Entra ID | High | Entra |
-| [MT.1148](../MT.1148) | Archive Scanning should be enabled | High | Defender |
-| [MT.1149](../MT.1149) | Behavior Monitoring should be enabled | High | Defender |
-| [MT.1150](../MT.1150) | Cloud Protection should be enabled | High | Defender |
-| [MT.1151](../MT.1151) | Email Scanning should be enabled | High | Defender |
-| [MT.1152](../MT.1152) | Script Scanning should be enabled | High | Defender |
-| [MT.1153](../MT.1153) | Real-time Monitoring should be enabled | High | Defender |
-| [MT.1154](../MT.1154) | Full Scan Removable Drives should be enabled | High | Defender |
-| [MT.1155](../MT.1155) | Full Scan Mapped Drives should be disabled for performance | High | Defender |
-| [MT.1156](../MT.1156) | Scanning Network Files should be enabled | High | Defender |
-| [MT.1157](../MT.1157) | CPU Load Factor should be optimized (20-30%) | High | Defender |
-| [MT.1158](../MT.1158) | Scan should be scheduled | High | Defender |
-| [MT.1159](../MT.1159) | Quick Scan Time configuration is not required | High | Defender |
-| [MT.1160](../MT.1160) | Signatures should be checked before scan | High | Defender |
-| [MT.1161](../MT.1161) | Cloud Block Level should be High or higher | High | Defender |
-| [MT.1162](../MT.1162) | Cloud Extended Timeout should be 30-50 seconds | High | Defender |
-| [MT.1163](../MT.1163) | Signature Update Interval should be 1-4 hours | High | Defender |
-| [MT.1164](../MT.1164) | PUA Protection should be enabled | High | Defender |
-| [MT.1165](../MT.1165) | Network Protection should be enabled | High | Defender |
-| [MT.1166](../MT.1166) | Local Admin Merge should be disabled | High | Defender |
-| [MT.1167](../MT.1167) | Real-Time Scan Direction should cover both directions | High | Defender |
-| [MT.1168](../MT.1168) | Cleaned Malware should be retained for at least 30 days | High | Defender |
-| [MT.1169](../MT.1169) | Catch-up Full Scan should be disabled | High | Defender |
-| [MT.1170](../MT.1170) | Catch-up Quick Scan should be disabled | High | Defender |
-| [MT.1171](../MT.1171) | Sample Submission should send safe samples automatically | High | Defender |
-| [MT.1177](../MT.1177) | Ensure LAPS Configuration Policy is properly set | Unknown | Intune |
-| [MT.1178](../MT.1178) | Ensure ASR Rules are configured correctly | High | Intune |
-| [MT.1179](../MT.1179) | Ensure App Control for Business is enabled | High | Intune |
-| [MT.1180](../MT.1180) | Ensure Managed Installer Rules are configured correctly | Medium | Intune |
-| [MT.1182](../MT.1182) | Entra managed and verified domains should have mature DMARC policy (p=reject, pct=100). | Unknown | Entra |
+| [MT.1001](./MT.1001.md) | At least one Conditional Access policy is configured with device compliance. | Medium | CA |
+| [MT.1002](./MT.1002.md) | App management restrictions on applications and service principals is configured and enabled. | High | App |
+| [MT.1003](./MT.1003.md) | At least one Conditional Access policy is configured with All Apps. | High | CA |
+| [MT.1004](./MT.1004.md) | At least one Conditional Access policy is configured with All Apps and All Users. | High | CA |
+| [MT.1005](./MT.1005.md) | All Conditional Access policies are configured to exclude at least one emergency/break glass account or group. | High | CA |
+| [MT.1006](./MT.1006.md) | At least one Conditional Access policy is configured to require MFA for admins. | High | CA |
+| [MT.1007](./MT.1007.md) | At least one Conditional Access policy is configured to require MFA for all users. | High | CA |
+| [MT.1008](./MT.1008.md) | At least one Conditional Access policy is configured to require MFA for Azure management. | High | CA |
+| [MT.1009](./MT.1009.md) | At least one Conditional Access policy is configured to block other legacy authentication. | High | CA |
+| [MT.1010](./MT.1010.md) | At least one Conditional Access policy is configured to block legacy authentication for Exchange ActiveSync. | High | CA |
+| [MT.1011](./MT.1011.md) | At least one Conditional Access policy is configured to secure security info registration only from a trusted location. | High | CA |
+| [MT.1012](./MT.1012.md) | At least one Conditional Access policy is configured to require MFA for risky sign-ins. | High | CA |
+| [MT.1013](./MT.1013.md) | At least one Conditional Access policy is configured to require new password when user risk is high. | High | CA |
+| [MT.1014](./MT.1014.md) | At least one Conditional Access policy is configured to require compliant or Entra hybrid joined devices for admins. | High | CA |
+| [MT.1015](./MT.1015.md) | At least one Conditional Access policy is configured to block access for unknown or unsupported device platforms. | Medium | CA |
+| [MT.1016](./MT.1016.md) | At least one Conditional Access policy is configured to require MFA for guest access. | High | CA |
+| [MT.1017](./MT.1017.md) | At least one Conditional Access policy is configured to enforce non persistent browser session for non-corporate devices. | High | CA |
+| [MT.1018](./MT.1018.md) | At least one Conditional Access policy is configured to enforce sign-in frequency for non-corporate devices. | Medium | CA |
+| [MT.1019](./MT.1019.md) | At least one Conditional Access policy is configured to enable application enforced restrictions. | Medium | CA |
+| [MT.1020](./MT.1020.md) | All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. | High | CA |
+| [MT.1021](./MT.1021.md) | Security Defaults are enabled. | High | CA |
+| [MT.1022](./MT.1022.md) | All users utilizing a P1 license should be licensed. | Medium | CA |
+| [MT.1023](./MT.1023.md) | All users utilizing a P2 license should be licensed. | Medium | CA |
+| [MT.1024](./MT.1024.md) | MT.1024.$($RecommendationId -replace | Unknown | Entra |
+| [MT.1025](./MT.1025.md) | No external user with permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1026](./MT.1026.md) | No hybrid user with permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1027](./MT.1027.md) | No Service Principal with Client Secret and permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1028](./MT.1028.md) | No user with mailbox and permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1029](./MT.1029.md) | Stale accounts are not assigned to privileged roles. | High | Privileged |
+| [MT.1030](./MT.1030.md) | Eligible role assignments on Control Plane are in use by administrators. | High | Privileged |
+| [MT.1031](./MT.1031.md) | Privileged role on Control Plane are managed by PIM only. | High | Privileged |
+| [MT.1032](./MT.1032.md) | Limited number of Global Admins are assigned. | High | Privileged |
+| [MT.1033](./MT.1033.md) | MT.1033.$($RegularUsers.IndexOf($_)): User should be blocked from using legacy authentication ($($_.userPrincipalName)) | Unknown | CA |
+| [MT.1034](./MT.1034.md) | MT.1034.$($EmergencyAccessUsers.IndexOf($_)): Emergency access users should not be blocked ($($_.userPrincipalName)) | Unknown | CA |
+| [MT.1035](./MT.1035.md) | All security groups assigned to Conditional Access Policies should be protected by RMAU. | High | CA |
+| [MT.1036](./MT.1036.md) | All excluded objects should have a fallback include in another policy. | Medium | CA |
+| [MT.1037](./MT.1037.md) | Only users with Presenter role are allowed to present in Teams meetings | High | Teams |
+| [MT.1038](./MT.1038.md) | Conditional Access policies should not include or exclude deleted groups. | Medium | CA |
+| [MT.1039](./MT.1039.md) | Ensure MailTips are enabled for end users | Low | Exchange |
+| [MT.1041](./MT.1041.md) | Ensure users installing Outlook add-ins is not allowed | High | Exchange |
+| [MT.1042](./MT.1042.md) | Restrict dial-in users from bypassing a meeting lobby | Medium | Teams |
+| [MT.1043](./MT.1043.md) | Ensure Spam confidence level (SCL) is configured in mail transport rules with specific domains | Medium | Exchange |
+| [MT.1044](./MT.1044.md) | Ensure modern authentication for Exchange Online is enabled | High | Exchange |
+| [MT.1045](./MT.1045.md) | Only invited users should be automatically admitted to Teams meetings | Medium | Teams |
+| [MT.1046](./MT.1046.md) | Restrict anonymous users from joining meetings | Medium | Teams |
+| [MT.1047](./MT.1047.md) | Restrict anonymous users from starting Teams meetings | Medium | Teams |
+| [MT.1048](./MT.1048.md) | Limit external participants from having control in a Teams meeting | Medium | Teams |
+| [MT.1049](./MT.1049.md) | Conditional Access policies for User Risk and Sign-in Risk should be configured separately. | High | CA |
+| [MT.1050](./MT.1050.md) | Apps with high-risk permissions having a direct path to Global Admin | High | App |
+| [MT.1051](./MT.1051.md) | Apps with high-risk permissions having an indirect path to Global Admin | High | App |
+| [MT.1052](./MT.1052.md) | At least one Conditional Access policy is targeting the Device Code authentication flow. | High | CA |
+| [MT.1053](./MT.1053.md) | Ensure intune device clean-up rule is configured | Medium | Intune |
+| [MT.1054](./MT.1054.md) | Ensure built-in Device Compliance Policy marks devices with no compliance policy assigned as 'Not compliant' | Medium | Intune |
+| [MT.1055](./MT.1055.md) | Microsoft 365 Group (and Team) creation should be restricted to approved users. | Medium | Group |
+| [MT.1056](./MT.1056.md) | Ensure that no person has permanent access to all Azure subscriptions at the root scope | High | Privileged |
+| [MT.1057](./MT.1057.md) | Ensure Microsoft 365 Group (and Team) expiration is configured to notify users. | Medium | App |
+| [MT.1058](./MT.1058.md) | Ensure Microsoft 365 Group (and Team) expiration is configured to auto-expire groups. | Medium | App |
+| [MT.1059](./MT.1059.md) | Microsoft Defender for Identity health issues should be resolved | Medium | Defender |
+| [MT.1061](./MT.1061.md) | Device registration MFA control conflicts with Conditional Access policies | Medium | CA |
+| [MT.1062](./MT.1062.md) | Ensure Direct Send is set to be rejected | Medium | Exchange |
+| [MT.1063](./MT.1063.md) | All app registration owners should have MFA registered | High | App |
+| [MT.1064](./MT.1064.md) | Management group creation should be limited to users with explicit write access | High | Azure |
+| [MT.1065](./MT.1065.md) | Soft Delete should be enabled on all Recovery Services Vaults | High | Backup |
+| [MT.1066](./MT.1066.md) | Conditional Access policies should not include or exclude deleted users, groups, or roles. | Medium | CA |
+| [MT.1067](./MT.1067.md) | Authentication methods policies should not reference deleted groups. | Medium | Authentication |
+| [MT.1068](./MT.1068.md) | Restrict non-admin users from creating tenants | Medium | Entra |
+| [MT.1069](./MT.1069.md) | Restrict non-admin users from creating security groups. | Low | Entra |
+| [MT.1070](./MT.1070.md) | Restrict device join to selected users/groups or none. | Medium | Entra |
+| [MT.1071](./MT.1071.md) | At least one Conditional Access policy explicitly includes Azure DevOps. | Medium | CA |
+| [MT.1072](./MT.1072.md) | Conditional access policies should not use the deprecated Approved Client App grant. | High | CA |
+| [MT.1073](./MT.1073.md) | Soft- and hard-matching of synchronized objects should be blocked. | Medium | Entra |
+| [MT.1074](./MT.1074.md) | Mailboxes should not send outbound mails using the .onmicrosoft.com domain. | Medium | Exchange |
+| [MT.1075](./MT.1075.md) | Third Party Entra Apps should only have explicitly assigned users instead of All Users. | Medium | App |
+| [MT.1076](./MT.1076.md) | MOERA SHOULD NOT be used for sent mail. | High | Exchange |
+| [MT.1077](./MT.1077.md) | App registrations with privileged API permissions should not have owners | Medium | Privileged |
+| [MT.1078](./MT.1078.md) | App registrations with highly privileged directory roles should not have owners | Medium | Privileged |
+| [MT.1079](./MT.1079.md) | Privileged API permissions on service principals should not remain unused | Medium | Privileged |
+| [MT.1080](./MT.1080.md) | Credentials, tokens, or cookies from highly privileged users should not be exposed on vulnerable endpoints | Medium | Privileged |
+| [MT.1081](./MT.1081.md) | Hybrid users should not be assigned Entra ID role assignments | Medium | Privileged |
+| [MT.1083](./MT.1083.md) | Ensure Delicensing Resiliency is enabled | Low | Exchange |
+| [MT.1084](./MT.1084.md) | Seamless Single SignOn should be disabled for all domains in EntraID Connect servers. | High | Entra |
+| [MT.1085](./MT.1085.md) | Pending approvals for Critical Asset Management should not be present | Medium | Entra |
+| [MT.1086](./MT.1086.md) | Devices should not share both critical and non-critical user credentials. | Low | XSPM |
+| [MT.1087](./MT.1087.md) | Devices should not be publicly exposed with remotely exploitable, highly likely to be exploited, high or critical severity CVE's. | High | XSPM |
+| [MT.1088](./MT.1088.md) | Devices with critical credentials should be protected by TPM. | Medium | XSPM |
+| [MT.1089](./MT.1089.md) | Devices with critical credentials should be protected by Credential Guard. | Medium | XSPM |
+| [MT.1090](./MT.1090.md) | Global administrator role should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
+| [MT.1091](./MT.1091.md) | Registering user should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
+| [MT.1092](./MT.1092.md) | Intune APNS certificate should be valid for more than 30 days | High | Intune |
+| [MT.1093](./MT.1093.md) | Apple Automated Device Enrollment Tokens should be valid for more than 30 days | High | Intune |
+| [MT.1094](./MT.1094.md) | Apple Volume Purchase Program Tokens should be valid for more than 30 days | High | Intune |
+| [MT.1095](./MT.1095.md) | Android Enterprise Account Connection should be healthy | High | Intune |
+| [MT.1096](./MT.1096.md) | Intune Multi Admin approval should be configured | Medium | Intune |
+| [MT.1097](./MT.1097.md) | Certificate Connectors should be healthy and running supported versions | High | Intune |
+| [MT.1098](./MT.1098.md) | Mobile Threat Defense Connectors should be healthy | Critical | Intune |
+| [MT.1099](./MT.1099.md) | Windows Diagnostic Data Processing should be enabled | Low | Intune |
+| [MT.1100](./MT.1100.md) | Intune Audit Logs should be retained | High | Intune |
+| [MT.1101](./MT.1101.md) | Default Branding Profile should be customized | Low | Intune |
+| [MT.1102](./MT.1102.md) | Windows Feature Update Policy Settings should not reference end of support builds | High | Intune |
+| [MT.1103](./MT.1103.md) | Intune RBAC groups should be protected by Restricted Management Administrative Units or Role Assignable groups | High | Intune |
+| [MT.1105](./MT.1105.md) | MDM Authority should be set to Microsoft Intune | Low | Intune |
+| [MT.1106](./MT.1106.md) | Catalog resources must have valid roles (no stale app roles or deleted SPNs) | Medium | Governance |
+| [MT.1107](./MT.1107.md) | Access packages and catalogs should not reference deleted groups | Medium | Governance |
+| [MT.1108](./MT.1108.md) | Access packages should not have inactive or orphaned assignment policies | Medium | Governance |
+| [MT.1109](./MT.1109.md) | Access package approval workflows must have valid approvers | Medium | Governance |
+| [MT.1110](./MT.1110.md) | No catalog should contain resources without any associated access packages | Medium | Governance |
+| [MT.1111](./MT.1111.md) | High privileged user should be linked to an identity | Low | Privileged |
+| [MT.1112](./MT.1112.md) | Privileged user accounts should not remain enabled when the linked primary account is disabled | Medium | Privileged |
+| [MT.1113](./MT.1113.md) | AI agents should not be shared with broad access control policies | High | AIAgent |
+| [MT.1114](./MT.1114.md) | AI agents should require user authentication | High | AIAgent |
+| [MT.1115](./MT.1115.md) | AI agents should not have risky HTTP configurations | Medium | AIAgent |
+| [MT.1116](./MT.1116.md) | AI agents should not send email with AI-controlled inputs | High | AIAgent |
+| [MT.1117](./MT.1117.md) | Published AI agents should not be dormant | Low | AIAgent |
+| [MT.1118](./MT.1118.md) | AI agents should avoid using author (maker) authentication for tools | Medium | AIAgent |
+| [MT.1119](./MT.1119.md) | AI agents should not have hard-coded credentials in topics | High | AIAgent |
+| [MT.1120](./MT.1120.md) | AI agents should not use MCP server tools without review | Medium | AIAgent |
+| [MT.1121](./MT.1121.md) | AI agents with generative orchestration should have custom instructions | Medium | AIAgent |
+| [MT.1122](./MT.1122.md) | AI agents should not have orphaned ownership | Medium | AIAgent |
+| [MT.1123](./MT.1123.md) | Ensure BitLocker full disk encryption is configured via Intune | High | Intune |
+| [MT.1147](./MT.1147.md) | Do not sync krbtgt_AzureAD to Entra ID | High | Entra |
+| [MT.1148](./MT.1148.md) | Archive Scanning should be enabled | High | Defender |
+| [MT.1149](./MT.1149.md) | Behavior Monitoring should be enabled | High | Defender |
+| [MT.1150](./MT.1150.md) | Cloud Protection should be enabled | High | Defender |
+| [MT.1151](./MT.1151.md) | Email Scanning should be enabled | High | Defender |
+| [MT.1152](./MT.1152.md) | Script Scanning should be enabled | High | Defender |
+| [MT.1153](./MT.1153.md) | Real-time Monitoring should be enabled | High | Defender |
+| [MT.1154](./MT.1154.md) | Full Scan Removable Drives should be enabled | High | Defender |
+| [MT.1155](./MT.1155.md) | Full Scan Mapped Drives should be disabled for performance | High | Defender |
+| [MT.1156](./MT.1156.md) | Scanning Network Files should be enabled | High | Defender |
+| [MT.1157](./MT.1157.md) | CPU Load Factor should be optimized (20-30%) | High | Defender |
+| [MT.1158](./MT.1158.md) | Scan should be scheduled | High | Defender |
+| [MT.1159](./MT.1159.md) | Quick Scan Time configuration is not required | High | Defender |
+| [MT.1160](./MT.1160.md) | Signatures should be checked before scan | High | Defender |
+| [MT.1161](./MT.1161.md) | Cloud Block Level should be High or higher | High | Defender |
+| [MT.1162](./MT.1162.md) | Cloud Extended Timeout should be 30-50 seconds | High | Defender |
+| [MT.1163](./MT.1163.md) | Signature Update Interval should be 1-4 hours | High | Defender |
+| [MT.1164](./MT.1164.md) | PUA Protection should be enabled | High | Defender |
+| [MT.1165](./MT.1165.md) | Network Protection should be enabled | High | Defender |
+| [MT.1166](./MT.1166.md) | Local Admin Merge should be disabled | High | Defender |
+| [MT.1167](./MT.1167.md) | Real-Time Scan Direction should cover both directions | High | Defender |
+| [MT.1168](./MT.1168.md) | Cleaned Malware should be retained for at least 30 days | High | Defender |
+| [MT.1169](./MT.1169.md) | Catch-up Full Scan should be disabled | High | Defender |
+| [MT.1170](./MT.1170.md) | Catch-up Quick Scan should be disabled | High | Defender |
+| [MT.1171](./MT.1171.md) | Sample Submission should send safe samples automatically | High | Defender |
+| [MT.1177](./MT.1177.md) | Ensure LAPS Configuration Policy is properly set | Unknown | Intune |
+| [MT.1178](./MT.1178.md) | Ensure ASR Rules are configured correctly | High | Intune |
+| [MT.1179](./MT.1179.md) | Ensure App Control for Business is enabled | High | Intune |
+| [MT.1180](./MT.1180.md) | Ensure Managed Installer Rules are configured correctly | Medium | Intune |
+| [MT.1182](./MT.1182.md) | Entra managed and verified domains should have mature DMARC policy (p=reject, pct=100). | Unknown | Entra |

--- a/website/docs/tests/orca/readme.md
+++ b/website/docs/tests/orca/readme.md
@@ -18,70 +18,70 @@ These tests validate Exchange Online security configuration checks from ORCA.
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [ORCA.100](../ORCA.100) | Bulk Complaint Level threshold is between 4 and 6. | Medium | EXO |
-| [ORCA.101](../ORCA.101) | Bulk is marked as spam. | Medium | EXO |
-| [ORCA.102](../ORCA.102) | Advanced Spam filter options are turned off. | Medium | EXO |
-| [ORCA.103](../ORCA.103) | Outbound spam filter policy settings configured. | Medium | EXO |
-| [ORCA.104](../ORCA.104) | High Confidence Phish action set to Quarantine message. | High | EXO |
-| [ORCA.105](../ORCA.105) | Safe Links Synchronous URL detonation is enabled. | Medium | EXO |
-| [ORCA.106](../ORCA.106) | Quarantine retention period is 30 days. | Medium | EXO |
-| [ORCA.107](../ORCA.107) | End-user spam notification is enabled. | Low | EXO |
-| [ORCA.108](../ORCA.108) | DKIM signing is set up for all your custom domains. | Medium | EXO |
-| [ORCA.108.1](../ORCA.108.1) | DNS Records have been set up to support DKIM. | Medium | EXO |
-| [ORCA.109](../ORCA.109) | Senders are not being allow listed in an unsafe manner. | Medium | EXO |
-| [ORCA.110](../ORCA.110) | Internal Sender notifications are disabled. | Medium | EXO |
-| [ORCA.111](../ORCA.111) | Anti-phishing policy exists and EnableUnauthenticatedSender is true. | High | EXO |
-| [ORCA.112](../ORCA.112) | Anti-spoofing protection action is configured to Move message to the recipients' Junk Email folders in Anti-phishing policy. | Medium | EXO |
-| [ORCA.113](../ORCA.113) | AllowClickThrough is disabled in Safe Links policies. | Medium | EXO |
-| [ORCA.114](../ORCA.114) | No IP Allow Lists have been configured. | High | EXO |
-| [ORCA.115](../ORCA.115) | Mailbox intelligence based impersonation protection is enabled in anti-phishing policies. | Medium | EXO |
-| [ORCA.116](../ORCA.116) | Mailbox intelligence based impersonation protection action set to move message to junk mail folder. | Medium | EXO |
-| [ORCA.118.1](../ORCA.118.1) | Domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | High | EXO |
-| [ORCA.118.2](../ORCA.118.2) | Domains are not being allow listed in an unsafe manner in Transport Rules. | High | EXO |
-| [ORCA.118.3](../ORCA.118.3) | Your own domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | Medium | EXO |
-| [ORCA.118.4](../ORCA.118.4) | Your own domains are not being allow listed in an unsafe manner in Transport Rules. | Medium | EXO |
-| [ORCA.119](../ORCA.119) | Similar Domains Safety Tips is enabled. | Info | EXO |
-| [ORCA.120.1](../ORCA.120.1) | Zero Hour Autopurge Enabled for Phish. | Medium | EXO |
-| [ORCA.120.2](../ORCA.120.2) | Zero Hour Autopurge Enabled for Malware. | Medium | EXO |
-| [ORCA.120.3](../ORCA.120.3) | Zero Hour Autopurge Enabled for Spam. | Medium | EXO |
-| [ORCA.121](../ORCA.121) | Supported filter policy action used. | Low | EXO |
-| [ORCA.123](../ORCA.123) | Unusual Characters Safety Tips is enabled. | Info | EXO |
-| [ORCA.124](../ORCA.124) | Safe attachments unknown malware response set to block messages. | High | EXO |
-| [ORCA.139](../ORCA.139) | Spam action set to move message to junk mail folder or quarantine. | Low | EXO |
-| [ORCA.140](../ORCA.140) | High Confidence Spam action set to Quarantine message. | High | EXO |
-| [ORCA.141](../ORCA.141) | Bulk action set to Move message to Junk Email Folder. | Medium | EXO |
-| [ORCA.142](../ORCA.142) | Phish action set to Quarantine message. | Medium | EXO |
-| [ORCA.143](../ORCA.143) | Safety Tips are enabled. | Info | EXO |
-| [ORCA.156](../ORCA.156) | Safe Links Policies are tracking when user clicks on safe links. | Medium | EXO |
-| [ORCA.158](../ORCA.158) | Safe Attachments is enabled for SharePoint and Teams. | Medium | EXO |
-| [ORCA.179](../ORCA.179) | Safe Links is enabled intra-organization. | Medium | EXO |
-| [ORCA.180](../ORCA.180) | Anti-phishing policy exists and EnableSpoofIntelligence is true. | Medium | EXO |
-| [ORCA.189](../ORCA.189) | Safe Attachments is not bypassed. | Medium | EXO |
-| [ORCA.189.2](../ORCA.189.2) | Safe Links is not bypassed. | High | EXO |
-| [ORCA.205](../ORCA.205) | Common attachment type filter is enabled. | Medium | EXO |
-| [ORCA.220](../ORCA.220) | Advanced Phish filter Threshold level is adequate. | Medium | EXO |
-| [ORCA.221](../ORCA.221) | Mailbox intelligence is enabled in anti-phishing policies. | Medium | EXO |
-| [ORCA.222](../ORCA.222) | Domain Impersonation action is set to move to Quarantine. | Medium | EXO |
-| [ORCA.223](../ORCA.223) | User impersonation action is set to move to Quarantine. | High | EXO |
-| [ORCA.224](../ORCA.224) | Similar Users Safety Tips is enabled. | Info | EXO |
-| [ORCA.225](../ORCA.225) | Safe Documents is enabled for Office clients. | Medium | EXO |
-| [ORCA.226](../ORCA.226) | Each domain has a Safe Link policy applied to it. | Medium | EXO |
-| [ORCA.227](../ORCA.227) | Each domain has a Safe Attachments policy applied to it. | Medium | EXO |
-| [ORCA.228](../ORCA.228) | No trusted senders in Anti-phishing policy. | High | EXO |
-| [ORCA.229](../ORCA.229) | No trusted domains in Anti-phishing policy. | Medium | EXO |
-| [ORCA.230](../ORCA.230) | Each domain has a Anti-phishing policy applied to it, or the default policy is being used. | Medium | EXO |
-| [ORCA.231](../ORCA.231) | Each domain has a anti-spam policy applied to it, or the default policy is being used. | Medium | EXO |
-| [ORCA.232](../ORCA.232) | Each domain has a malware filter policy applied to it, or the default policy is being used. | High | EXO |
-| [ORCA.233](../ORCA.233) | Domains are pointed directly at EOP or enhanced filtering is used. | Medium | EXO |
-| [ORCA.233.1](../ORCA.233.1) | Domains are pointed directly at EOP or enhanced filtering is configured on all default connectors. | Medium | EXO |
-| [ORCA.234](../ORCA.234) | Click through is disabled for Safe Documents. | Medium | EXO |
-| [ORCA.235](../ORCA.235) | SPF records is set up for all your custom domains. | Medium | EXO |
-| [ORCA.236](../ORCA.236) | Safe Links is enabled for emails. | Medium | EXO |
-| [ORCA.237](../ORCA.237) | Safe Links is enabled for teams messages. | Medium | EXO |
-| [ORCA.238](../ORCA.238) | Safe Links is enabled for office documents. | Medium | EXO |
-| [ORCA.239](../ORCA.239) | No exclusions for the built-in protection policies. | High | EXO |
-| [ORCA.240](../ORCA.240) | Outlook is configured to display external tags for external emails. | Medium | EXO |
-| [ORCA.241](../ORCA.241) | Anti-phishing policy exists and EnableFirstContactSafetyTips is true. | Medium | EXO |
-| [ORCA.242](../ORCA.242) | Important protection alerts responsible for AIR activities are enabled. | High | EXO |
-| [ORCA.243](../ORCA.243) | Authenticated Receive Chain is set up for domains not pointing to EOP/MDO, or all domains point to EOP/MDO. | Medium | EXO |
-| [ORCA.244](../ORCA.244) | Policies are configured to honor sending domains DMARC. | Medium | EXO |
+| [ORCA.100](./ORCA.100.md) | Bulk Complaint Level threshold is between 4 and 6. | Medium | EXO |
+| [ORCA.101](./ORCA.101.md) | Bulk is marked as spam. | Medium | EXO |
+| [ORCA.102](./ORCA.102.md) | Advanced Spam filter options are turned off. | Medium | EXO |
+| [ORCA.103](./ORCA.103.md) | Outbound spam filter policy settings configured. | Medium | EXO |
+| [ORCA.104](./ORCA.104.md) | High Confidence Phish action set to Quarantine message. | High | EXO |
+| [ORCA.105](./ORCA.105.md) | Safe Links Synchronous URL detonation is enabled. | Medium | EXO |
+| [ORCA.106](./ORCA.106.md) | Quarantine retention period is 30 days. | Medium | EXO |
+| [ORCA.107](./ORCA.107.md) | End-user spam notification is enabled. | Low | EXO |
+| [ORCA.108](./ORCA.108.md) | DKIM signing is set up for all your custom domains. | Medium | EXO |
+| [ORCA.108.1](./ORCA.108.1.md) | DNS Records have been set up to support DKIM. | Medium | EXO |
+| [ORCA.109](./ORCA.109.md) | Senders are not being allow listed in an unsafe manner. | Medium | EXO |
+| [ORCA.110](./ORCA.110.md) | Internal Sender notifications are disabled. | Medium | EXO |
+| [ORCA.111](./ORCA.111.md) | Anti-phishing policy exists and EnableUnauthenticatedSender is true. | High | EXO |
+| [ORCA.112](./ORCA.112.md) | Anti-spoofing protection action is configured to Move message to the recipients' Junk Email folders in Anti-phishing policy. | Medium | EXO |
+| [ORCA.113](./ORCA.113.md) | AllowClickThrough is disabled in Safe Links policies. | Medium | EXO |
+| [ORCA.114](./ORCA.114.md) | No IP Allow Lists have been configured. | High | EXO |
+| [ORCA.115](./ORCA.115.md) | Mailbox intelligence based impersonation protection is enabled in anti-phishing policies. | Medium | EXO |
+| [ORCA.116](./ORCA.116.md) | Mailbox intelligence based impersonation protection action set to move message to junk mail folder. | Medium | EXO |
+| [ORCA.118.1](./ORCA.118.1.md) | Domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | High | EXO |
+| [ORCA.118.2](./ORCA.118.2.md) | Domains are not being allow listed in an unsafe manner in Transport Rules. | High | EXO |
+| [ORCA.118.3](./ORCA.118.3.md) | Your own domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | Medium | EXO |
+| [ORCA.118.4](./ORCA.118.4.md) | Your own domains are not being allow listed in an unsafe manner in Transport Rules. | Medium | EXO |
+| [ORCA.119](./ORCA.119.md) | Similar Domains Safety Tips is enabled. | Info | EXO |
+| [ORCA.120.1](./ORCA.120.1.md) | Zero Hour Autopurge Enabled for Phish. | Medium | EXO |
+| [ORCA.120.2](./ORCA.120.2.md) | Zero Hour Autopurge Enabled for Malware. | Medium | EXO |
+| [ORCA.120.3](./ORCA.120.3.md) | Zero Hour Autopurge Enabled for Spam. | Medium | EXO |
+| [ORCA.121](./ORCA.121.md) | Supported filter policy action used. | Low | EXO |
+| [ORCA.123](./ORCA.123.md) | Unusual Characters Safety Tips is enabled. | Info | EXO |
+| [ORCA.124](./ORCA.124.md) | Safe attachments unknown malware response set to block messages. | High | EXO |
+| [ORCA.139](./ORCA.139.md) | Spam action set to move message to junk mail folder or quarantine. | Low | EXO |
+| [ORCA.140](./ORCA.140.md) | High Confidence Spam action set to Quarantine message. | High | EXO |
+| [ORCA.141](./ORCA.141.md) | Bulk action set to Move message to Junk Email Folder. | Medium | EXO |
+| [ORCA.142](./ORCA.142.md) | Phish action set to Quarantine message. | Medium | EXO |
+| [ORCA.143](./ORCA.143.md) | Safety Tips are enabled. | Info | EXO |
+| [ORCA.156](./ORCA.156.md) | Safe Links Policies are tracking when user clicks on safe links. | Medium | EXO |
+| [ORCA.158](./ORCA.158.md) | Safe Attachments is enabled for SharePoint and Teams. | Medium | EXO |
+| [ORCA.179](./ORCA.179.md) | Safe Links is enabled intra-organization. | Medium | EXO |
+| [ORCA.180](./ORCA.180.md) | Anti-phishing policy exists and EnableSpoofIntelligence is true. | Medium | EXO |
+| [ORCA.189](./ORCA.189.md) | Safe Attachments is not bypassed. | Medium | EXO |
+| [ORCA.189.2](./ORCA.189.2.md) | Safe Links is not bypassed. | High | EXO |
+| [ORCA.205](./ORCA.205.md) | Common attachment type filter is enabled. | Medium | EXO |
+| [ORCA.220](./ORCA.220.md) | Advanced Phish filter Threshold level is adequate. | Medium | EXO |
+| [ORCA.221](./ORCA.221.md) | Mailbox intelligence is enabled in anti-phishing policies. | Medium | EXO |
+| [ORCA.222](./ORCA.222.md) | Domain Impersonation action is set to move to Quarantine. | Medium | EXO |
+| [ORCA.223](./ORCA.223.md) | User impersonation action is set to move to Quarantine. | High | EXO |
+| [ORCA.224](./ORCA.224.md) | Similar Users Safety Tips is enabled. | Info | EXO |
+| [ORCA.225](./ORCA.225.md) | Safe Documents is enabled for Office clients. | Medium | EXO |
+| [ORCA.226](./ORCA.226.md) | Each domain has a Safe Link policy applied to it. | Medium | EXO |
+| [ORCA.227](./ORCA.227.md) | Each domain has a Safe Attachments policy applied to it. | Medium | EXO |
+| [ORCA.228](./ORCA.228.md) | No trusted senders in Anti-phishing policy. | High | EXO |
+| [ORCA.229](./ORCA.229.md) | No trusted domains in Anti-phishing policy. | Medium | EXO |
+| [ORCA.230](./ORCA.230.md) | Each domain has a Anti-phishing policy applied to it, or the default policy is being used. | Medium | EXO |
+| [ORCA.231](./ORCA.231.md) | Each domain has a anti-spam policy applied to it, or the default policy is being used. | Medium | EXO |
+| [ORCA.232](./ORCA.232.md) | Each domain has a malware filter policy applied to it, or the default policy is being used. | High | EXO |
+| [ORCA.233](./ORCA.233.md) | Domains are pointed directly at EOP or enhanced filtering is used. | Medium | EXO |
+| [ORCA.233.1](./ORCA.233.1.md) | Domains are pointed directly at EOP or enhanced filtering is configured on all default connectors. | Medium | EXO |
+| [ORCA.234](./ORCA.234.md) | Click through is disabled for Safe Documents. | Medium | EXO |
+| [ORCA.235](./ORCA.235.md) | SPF records is set up for all your custom domains. | Medium | EXO |
+| [ORCA.236](./ORCA.236.md) | Safe Links is enabled for emails. | Medium | EXO |
+| [ORCA.237](./ORCA.237.md) | Safe Links is enabled for teams messages. | Medium | EXO |
+| [ORCA.238](./ORCA.238.md) | Safe Links is enabled for office documents. | Medium | EXO |
+| [ORCA.239](./ORCA.239.md) | No exclusions for the built-in protection policies. | High | EXO |
+| [ORCA.240](./ORCA.240.md) | Outlook is configured to display external tags for external emails. | Medium | EXO |
+| [ORCA.241](./ORCA.241.md) | Anti-phishing policy exists and EnableFirstContactSafetyTips is true. | Medium | EXO |
+| [ORCA.242](./ORCA.242.md) | Important protection alerts responsible for AIR activities are enabled. | High | EXO |
+| [ORCA.243](./ORCA.243.md) | Authenticated Receive Chain is set up for domains not pointing to EOP/MDO, or all domains point to EOP/MDO. | Medium | EXO |
+| [ORCA.244](./ORCA.244.md) | Policies are configured to honor sending domains DMARC. | Medium | EXO |

--- a/website/scripts/generate-test-docs.mjs
+++ b/website/scripts/generate-test-docs.mjs
@@ -375,7 +375,7 @@ ${body.join("\n")}`;
 
 function renderSuiteIndex(suite, tests) {
   const config = suiteConfig[suite];
-  const rows = tests.map((test) => `| [${test.id}](../${test.id}) | ${escapeTable(test.title)} | ${escapeTable(test.severity)} | ${escapeTable(test.category)} |`).join("\n");
+  const rows = tests.map((test) => `| [${test.id}](./${test.id}.md) | ${escapeTable(test.title)} | ${escapeTable(test.severity)} | ${escapeTable(test.category)} |`).join("\n");
   return `---
 id: overview
 title: ${yamlQuote(config.title)}

--- a/website/versioned_docs/version-2.1.0/tests/cis/readme.md
+++ b/website/versioned_docs/version-2.1.0/tests/cis/readme.md
@@ -18,41 +18,41 @@ These tests verify Microsoft 365 tenant configuration against CIS Microsoft 365 
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [CIS.M365.1.1.1](../CIS.M365.1.1.1) | Ensure Administrative accounts are cloud-only | High | CIS E3 Level 1 |
-| [CIS.M365.1.1.3](../CIS.M365.1.1.3) | Ensure that between two and four global admins are designated | High | CIS E3 Level 1 |
-| [CIS.M365.1.2.1](../CIS.M365.1.2.1) | Ensure that only organizationally managed/approved public groups exist | Medium | CIS E3 Level 2 |
-| [CIS.M365.1.2.2](../CIS.M365.1.2.2) | Ensure sign-in to shared mailboxes is blocked | High | CIS E3 Level 1 |
-| [CIS.M365.1.3.1](../CIS.M365.1.3.1) | Ensure the 'Password expiration policy' is set to 'Set passwords to never expire (recommended)' | High | CIS E3 Level 1 |
-| [CIS.M365.1.3.3](../CIS.M365.1.3.3) | Ensure 'External sharing' of calendars is not available | Medium | CIS E3 Level 2 |
-| [CIS.M365.1.3.4](../CIS.M365.1.3.4) | Ensure 'User owned apps and services' is restricted | Unknown | CIS E3 Level 1 |
-| [CIS.M365.1.3.5](../CIS.M365.1.3.5) | Ensure internal phishing protection for Forms is enabled | Unknown | CIS E3 Level 1 |
-| [CIS.M365.1.3.6](../CIS.M365.1.3.6) | Ensure the customer lockbox feature is enabled | High | CIS E5 Level 2 |
-| [CIS.M365.1.3.7](../CIS.M365.1.3.7) | Ensure 'third-party storage services' are restricted in 'Microsoft 365 on the web'  | Unknown | CIS E3 Level 2 |
-| [CIS.M365.2.1.1](../CIS.M365.2.1.1) | Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy) | Medium | CIS E5 Level 2 |
-| [CIS.M365.2.1.2](../CIS.M365.2.1.2) | Ensure the Common Attachment Types Filter is enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.3](../CIS.M365.2.1.3) | Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.4](../CIS.M365.2.1.4) | Ensure Safe Attachments policy is enabled (Only Checks Default Policy) | High | CIS E5 Level 2 |
-| [CIS.M365.2.1.5](../CIS.M365.2.1.5) | Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled | High | CIS E5 Level 2 |
-| [CIS.M365.2.1.6](../CIS.M365.2.1.6) | Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.7](../CIS.M365.2.1.7) | Ensure that an anti-phishing policy has been created (Only Checks Default Policy) | Medium | CIS E5 Level 1 |
-| [CIS.M365.2.1.9](../CIS.M365.2.1.9) | Ensure that DKIM is enabled for all Exchange Online Domains | High | CIS E3 Level 1 |
-| [CIS.M365.2.1.11](../CIS.M365.2.1.11) | Ensure comprehensive attachment filtering is applied | High | CIS E3 Level 2 |
-| [CIS.M365.2.1.12](../CIS.M365.2.1.12) | Ensure the connection filter IP allow list is not used (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.1.13](../CIS.M365.2.1.13) | Ensure the connection filter safe list is off (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
-| [CIS.M365.2.4.4](../CIS.M365.2.4.4) | Ensure Zero-hour auto purge for Microsoft Teams is on (Only Checks ZAP is enabled) | Medium | CIS E5 Level 1 |
-| [CIS.M365.3.1.1](../CIS.M365.3.1.1) | Ensure Microsoft 365 audit log search is Enabled | High | CIS E3 Level 1 |
-| [CIS.M365.4.1](../CIS.M365.4.1) | Ensure devices without a compliance policy are marked | Unknown | CIS E3 Level 2 |
-| [CIS.M365.5.1.2.2](../CIS.M365.5.1.2.2) | Ensure third party integrated applications are not allowed | Unknown | CIS E3 Level 2 |
-| [CIS.M365.5.1.2.3](../CIS.M365.5.1.2.3) | Ensure 'Restrict non-admin users from creating tenants' is set to 'Yes' | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.1.3.1](../CIS.M365.5.1.3.1) | Ensure a dynamic group for guest users is created | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.1.5.1](../CIS.M365.5.1.5.1) | Ensure user consent to apps accessing company data on their behalf is not allowed | Unknown | CIS E3 Level 2 |
-| [CIS.M365.5.1.5.2](../CIS.M365.5.1.5.2) | Ensure the admin consent workflow is enabled | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.1.6.2](../CIS.M365.5.1.6.2) | Ensure that guest user access is restricted | Unknown | CIS E3 Level 1 |
-| [CIS.M365.5.2.3.5](../CIS.M365.5.2.3.5) | Ensure weak authentication methods are disabled | Unknown | CIS E3 Level 1 |
-| [CIS.M365.6.5.3](../CIS.M365.6.5.3) | Ensure additional storage providers are restricted in Outlook on the web | Unknown | CIS E3 Level 2 |
-| [CIS.M365.8.1.1](../CIS.M365.8.1.1) | Ensure external file sharing in Teams is enabled for only approved cloud storage services | Medium | CIS E5 Level 2 |
-| [CIS.M365.8.2.2](../CIS.M365.8.2.2) | Ensure communication with unmanaged Teams users is disabled | Medium | CIS E5 Level 1 |
-| [CIS.M365.8.2.3](../CIS.M365.8.2.3) | Ensure external Teams users cannot initiate conversations | Unknown | CIS E5 Level 1 |
-| [CIS.M365.8.4.1](../CIS.M365.8.4.1) | Ensure all or a majority of third-party and custom apps are blocked | High | CIS E5 Level 1 |
-| [CIS.M365.8.5.3](../CIS.M365.8.5.3) | Ensure only people in my org can bypass the lobby | Medium | CIS E3 Level 1 |
-| [CIS.M365.8.6.1](../CIS.M365.8.6.1) | Ensure users can report security concerns in Teams to internal destination | Medium | CIS E3 Level 1 |
+| [CIS.M365.1.1.1](./CIS.M365.1.1.1.md) | Ensure Administrative accounts are cloud-only | High | CIS E3 Level 1 |
+| [CIS.M365.1.1.3](./CIS.M365.1.1.3.md) | Ensure that between two and four global admins are designated | High | CIS E3 Level 1 |
+| [CIS.M365.1.2.1](./CIS.M365.1.2.1.md) | Ensure that only organizationally managed/approved public groups exist | Medium | CIS E3 Level 2 |
+| [CIS.M365.1.2.2](./CIS.M365.1.2.2.md) | Ensure sign-in to shared mailboxes is blocked | High | CIS E3 Level 1 |
+| [CIS.M365.1.3.1](./CIS.M365.1.3.1.md) | Ensure the 'Password expiration policy' is set to 'Set passwords to never expire (recommended)' | High | CIS E3 Level 1 |
+| [CIS.M365.1.3.3](./CIS.M365.1.3.3.md) | Ensure 'External sharing' of calendars is not available | Medium | CIS E3 Level 2 |
+| [CIS.M365.1.3.4](./CIS.M365.1.3.4.md) | Ensure 'User owned apps and services' is restricted | Unknown | CIS E3 Level 1 |
+| [CIS.M365.1.3.5](./CIS.M365.1.3.5.md) | Ensure internal phishing protection for Forms is enabled | Unknown | CIS E3 Level 1 |
+| [CIS.M365.1.3.6](./CIS.M365.1.3.6.md) | Ensure the customer lockbox feature is enabled | High | CIS E5 Level 2 |
+| [CIS.M365.1.3.7](./CIS.M365.1.3.7.md) | Ensure 'third-party storage services' are restricted in 'Microsoft 365 on the web'  | Unknown | CIS E3 Level 2 |
+| [CIS.M365.2.1.1](./CIS.M365.2.1.1.md) | Ensure Safe Links for Office Applications is Enabled (Only Checks Default Policy) | Medium | CIS E5 Level 2 |
+| [CIS.M365.2.1.2](./CIS.M365.2.1.2.md) | Ensure the Common Attachment Types Filter is enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.3](./CIS.M365.2.1.3.md) | Ensure notifications for internal users sending malware is Enabled (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.4](./CIS.M365.2.1.4.md) | Ensure Safe Attachments policy is enabled (Only Checks Default Policy) | High | CIS E5 Level 2 |
+| [CIS.M365.2.1.5](./CIS.M365.2.1.5.md) | Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled | High | CIS E5 Level 2 |
+| [CIS.M365.2.1.6](./CIS.M365.2.1.6.md) | Ensure Exchange Online Spam Policies are set to notify administrators (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.7](./CIS.M365.2.1.7.md) | Ensure that an anti-phishing policy has been created (Only Checks Default Policy) | Medium | CIS E5 Level 1 |
+| [CIS.M365.2.1.9](./CIS.M365.2.1.9.md) | Ensure that DKIM is enabled for all Exchange Online Domains | High | CIS E3 Level 1 |
+| [CIS.M365.2.1.11](./CIS.M365.2.1.11.md) | Ensure comprehensive attachment filtering is applied | High | CIS E3 Level 2 |
+| [CIS.M365.2.1.12](./CIS.M365.2.1.12.md) | Ensure the connection filter IP allow list is not used (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.1.13](./CIS.M365.2.1.13.md) | Ensure the connection filter safe list is off (Only Checks Default Policy) | Medium | CIS E3 Level 1 |
+| [CIS.M365.2.4.4](./CIS.M365.2.4.4.md) | Ensure Zero-hour auto purge for Microsoft Teams is on (Only Checks ZAP is enabled) | Medium | CIS E5 Level 1 |
+| [CIS.M365.3.1.1](./CIS.M365.3.1.1.md) | Ensure Microsoft 365 audit log search is Enabled | High | CIS E3 Level 1 |
+| [CIS.M365.4.1](./CIS.M365.4.1.md) | Ensure devices without a compliance policy are marked | Unknown | CIS E3 Level 2 |
+| [CIS.M365.5.1.2.2](./CIS.M365.5.1.2.2.md) | Ensure third party integrated applications are not allowed | Unknown | CIS E3 Level 2 |
+| [CIS.M365.5.1.2.3](./CIS.M365.5.1.2.3.md) | Ensure 'Restrict non-admin users from creating tenants' is set to 'Yes' | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.1.3.1](./CIS.M365.5.1.3.1.md) | Ensure a dynamic group for guest users is created | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.1.5.1](./CIS.M365.5.1.5.1.md) | Ensure user consent to apps accessing company data on their behalf is not allowed | Unknown | CIS E3 Level 2 |
+| [CIS.M365.5.1.5.2](./CIS.M365.5.1.5.2.md) | Ensure the admin consent workflow is enabled | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.1.6.2](./CIS.M365.5.1.6.2.md) | Ensure that guest user access is restricted | Unknown | CIS E3 Level 1 |
+| [CIS.M365.5.2.3.5](./CIS.M365.5.2.3.5.md) | Ensure weak authentication methods are disabled | Unknown | CIS E3 Level 1 |
+| [CIS.M365.6.5.3](./CIS.M365.6.5.3.md) | Ensure additional storage providers are restricted in Outlook on the web | Unknown | CIS E3 Level 2 |
+| [CIS.M365.8.1.1](./CIS.M365.8.1.1.md) | Ensure external file sharing in Teams is enabled for only approved cloud storage services | Medium | CIS E5 Level 2 |
+| [CIS.M365.8.2.2](./CIS.M365.8.2.2.md) | Ensure communication with unmanaged Teams users is disabled | Medium | CIS E5 Level 1 |
+| [CIS.M365.8.2.3](./CIS.M365.8.2.3.md) | Ensure external Teams users cannot initiate conversations | Unknown | CIS E5 Level 1 |
+| [CIS.M365.8.4.1](./CIS.M365.8.4.1.md) | Ensure all or a majority of third-party and custom apps are blocked | High | CIS E5 Level 1 |
+| [CIS.M365.8.5.3](./CIS.M365.8.5.3.md) | Ensure only people in my org can bypass the lobby | Medium | CIS E3 Level 1 |
+| [CIS.M365.8.6.1](./CIS.M365.8.6.1.md) | Ensure users can report security concerns in Teams to internal destination | Medium | CIS E3 Level 1 |

--- a/website/versioned_docs/version-2.1.0/tests/cisa/readme.md
+++ b/website/versioned_docs/version-2.1.0/tests/cisa/readme.md
@@ -18,76 +18,76 @@ These tests verify Microsoft 365 tenant configuration against CISA Secure Cloud 
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [CISA.MS.AAD.1.1](../CISA.MS.AAD.1.1) | Legacy authentication SHALL be blocked. | High | Entra ID P1 |
-| [CISA.MS.AAD.2.1](../CISA.MS.AAD.2.1) | Users detected as high risk SHALL be blocked. | High | Entra ID P2 |
-| [CISA.MS.AAD.2.2](../CISA.MS.AAD.2.2) | A notification SHOULD be sent to the administrator when high-risk users are detected. | High | Entra ID P2 |
-| [CISA.MS.AAD.2.3](../CISA.MS.AAD.2.3) | Sign-ins detected as high risk SHALL be blocked. | High | Entra ID P2 |
-| [CISA.MS.AAD.3.1](../CISA.MS.AAD.3.1) | Phishing-resistant MFA SHALL be enforced for all users. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.2](../CISA.MS.AAD.3.2) | If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.3](../CISA.MS.AAD.3.3) | If Microsoft Authenticator is enabled, it SHALL be configured to show login context information. | Medium | Entra ID P1 |
-| [CISA.MS.AAD.3.4](../CISA.MS.AAD.3.4) | The Authentication Methods Manage Migration feature SHALL be set to Migration Complete. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.5](../CISA.MS.AAD.3.5) | The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.6](../CISA.MS.AAD.3.6) | Phishing-resistant MFA SHALL be required for highly privileged roles. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.7](../CISA.MS.AAD.3.7) | Managed devices SHOULD be required for authentication. | High | Entra ID P1 |
-| [CISA.MS.AAD.3.8](../CISA.MS.AAD.3.8) | Managed Devices SHOULD be required to register MFA. | High | Entra ID P1 |
-| [CISA.MS.AAD.4.1](../CISA.MS.AAD.4.1) | Security logs SHALL be sent to the agency's security operations center for monitoring. | High | Entra ID P1 |
-| [CISA.MS.AAD.5.1](../CISA.MS.AAD.5.1) | Only administrators SHALL be allowed to register applications. | High | Entra ID Free |
-| [CISA.MS.AAD.5.2](../CISA.MS.AAD.5.2) | Only administrators SHALL be allowed to consent to applications. | High | Entra ID Free |
-| [CISA.MS.AAD.5.3](../CISA.MS.AAD.5.3) | An admin consent workflow SHALL be configured for applications. | High | Entra ID Free |
-| [CISA.MS.AAD.5.4](../CISA.MS.AAD.5.4) | Group owners SHALL NOT be allowed to consent to applications. | High | Entra ID Free |
-| [CISA.MS.AAD.6.1](../CISA.MS.AAD.6.1) | User passwords SHALL NOT expire. | High | Entra ID Free |
-| [CISA.MS.AAD.7.1](../CISA.MS.AAD.7.1) | A minimum of two users and a maximum of eight users SHALL be provisioned with the Global Administrator role. | High | Entra ID Free |
-| [CISA.MS.AAD.7.2](../CISA.MS.AAD.7.2) | Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator. | High | Entra ID Free |
-| [CISA.MS.AAD.7.3](../CISA.MS.AAD.7.3) | Privileged users SHALL be provisioned cloud-only accounts separate from an on-premises directory or other federated identity providers. | High | Entra ID Free |
-| [CISA.MS.AAD.7.4](../CISA.MS.AAD.7.4) | Permanent active role assignments SHALL NOT be allowed for highly privileged roles. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.5](../CISA.MS.AAD.7.5) | Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.6](../CISA.MS.AAD.7.6) | Activation of the Global Administrator role SHALL require approval. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.7](../CISA.MS.AAD.7.7) | Eligible and Active highly privileged role assignments SHALL trigger an alert. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.8](../CISA.MS.AAD.7.8) | User activation of the Global Administrator role SHALL trigger an alert. | High | Entra ID P2 |
-| [CISA.MS.AAD.7.9](../CISA.MS.AAD.7.9) | User activation of other highly privileged roles SHOULD trigger an alert. | High | Entra ID P2 |
-| [CISA.MS.AAD.8.1](../CISA.MS.AAD.8.1) | Guest users SHOULD have limited or restricted access to Azure AD directory objects. | Medium | Entra ID Free |
-| [CISA.MS.AAD.8.2](../CISA.MS.AAD.8.2) | Only users with the Guest Inviter role SHOULD be able to invite guest users. | High | Entra ID Free |
-| [CISA.MS.AAD.8.3](../CISA.MS.AAD.8.3) | Guest invites SHOULD only be allowed to specific external domains that have been authorized by the agency for legitimate business purposes. | Medium | Entra ID Free |
-| [CISA.MS.EXO.1.1](../CISA.MS.EXO.1.1) | Automatic forwarding to external domains SHALL be disabled. | High | exchange |
-| [CISA.MS.EXO.2.1](../CISA.MS.EXO.2.1) | A list of approved IP addresses for sending mail SHALL be maintained. | Medium | exchange |
-| [CISA.MS.EXO.2.2](../CISA.MS.EXO.2.2) | An SPF policy SHALL be published for each domain, designating only these addresses as approved senders. | Medium | exchange |
-| [CISA.MS.EXO.3.1](../CISA.MS.EXO.3.1) | DKIM SHOULD be enabled for all domains. | Medium | exchange |
-| [CISA.MS.EXO.4.1](../CISA.MS.EXO.4.1) | A DMARC policy SHALL be published for every second-level domain. | Medium | exchange |
-| [CISA.MS.EXO.4.2](../CISA.MS.EXO.4.2) | The DMARC message rejection option SHALL be p=reject. | High | exchange |
-| [CISA.MS.EXO.4.3](../CISA.MS.EXO.4.3) | The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov. | Medium | exchange |
-| [CISA.MS.EXO.5.1](../CISA.MS.EXO.5.1) | SMTP AUTH SHALL be disabled. | High | exchange |
-| [CISA.MS.EXO.6.1](../CISA.MS.EXO.6.1) | Contact folders SHALL NOT be shared with all domains. | Medium | exchange |
-| [CISA.MS.EXO.6.2](../CISA.MS.EXO.6.2) | Calendar details SHALL NOT be shared with all domains. | Medium | exchange |
-| [CISA.MS.EXO.7.1](../CISA.MS.EXO.7.1) | External sender warnings SHALL be implemented. | Medium | exchange |
-| [CISA.MS.EXO.8.1](../CISA.MS.EXO.8.1) | A DLP solution SHALL be used. | High | exchange |
-| [CISA.MS.EXO.8.2](../CISA.MS.EXO.8.2) | The DLP solution SHALL protect personally identifiable information (PII) and sensitive information, as defined by the agency. | Medium | exchange |
-| [CISA.MS.EXO.8.3](../CISA.MS.EXO.8.3) | The selected DLP solution SHOULD offer services comparable to the native DLP solution offered by Microsoft. | Medium | exchange |
-| [CISA.MS.EXO.8.4](../CISA.MS.EXO.8.4) | At a minimum, the DLP solution SHALL restrict sharing credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN) via email. | High | exchange |
-| [CISA.MS.EXO.9.1](../CISA.MS.EXO.9.1) | Emails SHALL be filtered by attachment file types. | Medium | exchange |
-| [CISA.MS.EXO.9.2](../CISA.MS.EXO.9.2) | The attachment filter SHOULD attempt to determine the true file type and assess the file extension. | Medium | exchange |
-| [CISA.MS.EXO.9.3](../CISA.MS.EXO.9.3) | Disallowed file types SHALL be determined and enforced. | High | exchange |
-| [CISA.MS.EXO.9.4](../CISA.MS.EXO.9.4) | Alternatively chosen filtering solutions SHOULD offer services comparable to Microsoft Defender's Common Attachment Filter. | Medium | exchange |
-| [CISA.MS.EXO.9.5](../CISA.MS.EXO.9.5) | At a minimum, click-to-run files SHOULD be blocked (e.g., .exe, .cmd, and .vbe). | High | exchange |
-| [CISA.MS.EXO.10.1](../CISA.MS.EXO.10.1) | Emails SHALL be scanned for malware. | High | exchange |
-| [CISA.MS.EXO.10.2](../CISA.MS.EXO.10.2) | Emails identified as containing malware SHALL be quarantined or dropped. | High | exchange |
-| [CISA.MS.EXO.10.3](../CISA.MS.EXO.10.3) | Email scanning SHALL be capable of reviewing emails after delivery. | High | exchange |
-| [CISA.MS.EXO.11.1](../CISA.MS.EXO.11.1) | Impersonation protection checks SHOULD be used. | High | exchange |
-| [CISA.MS.EXO.11.2](../CISA.MS.EXO.11.2) | User warnings, comparable to the user safety tips included with EOP, SHOULD be displayed. | Medium | exchange |
-| [CISA.MS.EXO.11.3](../CISA.MS.EXO.11.3) | The phishing protection solution SHOULD include an AI-based phishing detection tool comparable to EOP Mailbox Intelligence. | Medium | exchange |
-| [CISA.MS.EXO.12.1](../CISA.MS.EXO.12.1) | IP allow lists SHOULD NOT be created. | Medium | exchange |
-| [CISA.MS.EXO.12.2](../CISA.MS.EXO.12.2) | Safe lists SHOULD NOT be enabled. | Medium | exchange |
-| [CISA.MS.EXO.13.1](../CISA.MS.EXO.13.1) | Mailbox auditing SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.14.1](../CISA.MS.EXO.14.1) | A spam filter SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.14.2](../CISA.MS.EXO.14.2) | Spam and high confidence spam SHALL be moved to either the junk email folder or the quarantine folder. | Medium | exchange |
-| [CISA.MS.EXO.14.3](../CISA.MS.EXO.14.3) | Allowed domains SHALL NOT be added to inbound anti-spam protection policies. | Medium | exchange |
-| [CISA.MS.EXO.14.4](../CISA.MS.EXO.14.4) | If a third-party party filtering solution is used, the solution SHOULD offer services comparable to the native spam filtering offered by Microsoft. | Medium | exchange |
-| [CISA.MS.EXO.15.1](../CISA.MS.EXO.15.1) | URL comparison with a block-list SHOULD be enabled. | Medium | exchange |
-| [CISA.MS.EXO.15.2](../CISA.MS.EXO.15.2) | Direct download links SHOULD be scanned for malware. | High | exchange |
-| [CISA.MS.EXO.15.3](../CISA.MS.EXO.15.3) | User click tracking SHOULD be enabled. | Medium | exchange |
-| [CISA.MS.EXO.16.1](../CISA.MS.EXO.16.1) | Alerts SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.16.2](../CISA.MS.EXO.16.2) | Alerts SHOULD be sent to a monitored address or incorporated into a security information and event management (SIEM) system. | Medium | exchange |
-| [CISA.MS.EXO.17.1](../CISA.MS.EXO.17.1) | Microsoft Purview Audit (Standard) logging SHALL be enabled. | High | exchange |
-| [CISA.MS.EXO.17.2](../CISA.MS.EXO.17.2) | Microsoft Purview Audit (Premium) logging SHALL be enabled. | Medium | Deprecated |
-| [CISA.MS.EXO.17.3](../CISA.MS.EXO.17.3) | Audit logs SHALL be maintained for at least the minimum duration dictated by OMB M-21-31 (Appendix C). | Medium | exchange |
-| [CISA.MS.SHAREPOINT.1.1](../CISA.MS.SHAREPOINT.1.1) | External sharing for SharePoint SHALL be limited to Existing guests or Only People in your organization. | Medium | spo |
-| [CISA.MS.SHAREPOINT.1.3](../CISA.MS.SHAREPOINT.1.3) | External sharing SHALL be restricted to approved external domains and/or users in approved security groups per interagency collaboration needs. | High | spo |
+| [CISA.MS.AAD.1.1](./CISA.MS.AAD.1.1.md) | Legacy authentication SHALL be blocked. | High | Entra ID P1 |
+| [CISA.MS.AAD.2.1](./CISA.MS.AAD.2.1.md) | Users detected as high risk SHALL be blocked. | High | Entra ID P2 |
+| [CISA.MS.AAD.2.2](./CISA.MS.AAD.2.2.md) | A notification SHOULD be sent to the administrator when high-risk users are detected. | High | Entra ID P2 |
+| [CISA.MS.AAD.2.3](./CISA.MS.AAD.2.3.md) | Sign-ins detected as high risk SHALL be blocked. | High | Entra ID P2 |
+| [CISA.MS.AAD.3.1](./CISA.MS.AAD.3.1.md) | Phishing-resistant MFA SHALL be enforced for all users. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.2](./CISA.MS.AAD.3.2.md) | If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.3](./CISA.MS.AAD.3.3.md) | If Microsoft Authenticator is enabled, it SHALL be configured to show login context information. | Medium | Entra ID P1 |
+| [CISA.MS.AAD.3.4](./CISA.MS.AAD.3.4.md) | The Authentication Methods Manage Migration feature SHALL be set to Migration Complete. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.5](./CISA.MS.AAD.3.5.md) | The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.6](./CISA.MS.AAD.3.6.md) | Phishing-resistant MFA SHALL be required for highly privileged roles. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.7](./CISA.MS.AAD.3.7.md) | Managed devices SHOULD be required for authentication. | High | Entra ID P1 |
+| [CISA.MS.AAD.3.8](./CISA.MS.AAD.3.8.md) | Managed Devices SHOULD be required to register MFA. | High | Entra ID P1 |
+| [CISA.MS.AAD.4.1](./CISA.MS.AAD.4.1.md) | Security logs SHALL be sent to the agency's security operations center for monitoring. | High | Entra ID P1 |
+| [CISA.MS.AAD.5.1](./CISA.MS.AAD.5.1.md) | Only administrators SHALL be allowed to register applications. | High | Entra ID Free |
+| [CISA.MS.AAD.5.2](./CISA.MS.AAD.5.2.md) | Only administrators SHALL be allowed to consent to applications. | High | Entra ID Free |
+| [CISA.MS.AAD.5.3](./CISA.MS.AAD.5.3.md) | An admin consent workflow SHALL be configured for applications. | High | Entra ID Free |
+| [CISA.MS.AAD.5.4](./CISA.MS.AAD.5.4.md) | Group owners SHALL NOT be allowed to consent to applications. | High | Entra ID Free |
+| [CISA.MS.AAD.6.1](./CISA.MS.AAD.6.1.md) | User passwords SHALL NOT expire. | High | Entra ID Free |
+| [CISA.MS.AAD.7.1](./CISA.MS.AAD.7.1.md) | A minimum of two users and a maximum of eight users SHALL be provisioned with the Global Administrator role. | High | Entra ID Free |
+| [CISA.MS.AAD.7.2](./CISA.MS.AAD.7.2.md) | Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator. | High | Entra ID Free |
+| [CISA.MS.AAD.7.3](./CISA.MS.AAD.7.3.md) | Privileged users SHALL be provisioned cloud-only accounts separate from an on-premises directory or other federated identity providers. | High | Entra ID Free |
+| [CISA.MS.AAD.7.4](./CISA.MS.AAD.7.4.md) | Permanent active role assignments SHALL NOT be allowed for highly privileged roles. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.5](./CISA.MS.AAD.7.5.md) | Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.6](./CISA.MS.AAD.7.6.md) | Activation of the Global Administrator role SHALL require approval. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.7](./CISA.MS.AAD.7.7.md) | Eligible and Active highly privileged role assignments SHALL trigger an alert. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.8](./CISA.MS.AAD.7.8.md) | User activation of the Global Administrator role SHALL trigger an alert. | High | Entra ID P2 |
+| [CISA.MS.AAD.7.9](./CISA.MS.AAD.7.9.md) | User activation of other highly privileged roles SHOULD trigger an alert. | High | Entra ID P2 |
+| [CISA.MS.AAD.8.1](./CISA.MS.AAD.8.1.md) | Guest users SHOULD have limited or restricted access to Azure AD directory objects. | Medium | Entra ID Free |
+| [CISA.MS.AAD.8.2](./CISA.MS.AAD.8.2.md) | Only users with the Guest Inviter role SHOULD be able to invite guest users. | High | Entra ID Free |
+| [CISA.MS.AAD.8.3](./CISA.MS.AAD.8.3.md) | Guest invites SHOULD only be allowed to specific external domains that have been authorized by the agency for legitimate business purposes. | Medium | Entra ID Free |
+| [CISA.MS.EXO.1.1](./CISA.MS.EXO.1.1.md) | Automatic forwarding to external domains SHALL be disabled. | High | exchange |
+| [CISA.MS.EXO.2.1](./CISA.MS.EXO.2.1.md) | A list of approved IP addresses for sending mail SHALL be maintained. | Medium | exchange |
+| [CISA.MS.EXO.2.2](./CISA.MS.EXO.2.2.md) | An SPF policy SHALL be published for each domain, designating only these addresses as approved senders. | Medium | exchange |
+| [CISA.MS.EXO.3.1](./CISA.MS.EXO.3.1.md) | DKIM SHOULD be enabled for all domains. | Medium | exchange |
+| [CISA.MS.EXO.4.1](./CISA.MS.EXO.4.1.md) | A DMARC policy SHALL be published for every second-level domain. | Medium | exchange |
+| [CISA.MS.EXO.4.2](./CISA.MS.EXO.4.2.md) | The DMARC message rejection option SHALL be p=reject. | High | exchange |
+| [CISA.MS.EXO.4.3](./CISA.MS.EXO.4.3.md) | The DMARC point of contact for aggregate reports SHALL include reports@dmarc.cyber.dhs.gov. | Medium | exchange |
+| [CISA.MS.EXO.5.1](./CISA.MS.EXO.5.1.md) | SMTP AUTH SHALL be disabled. | High | exchange |
+| [CISA.MS.EXO.6.1](./CISA.MS.EXO.6.1.md) | Contact folders SHALL NOT be shared with all domains. | Medium | exchange |
+| [CISA.MS.EXO.6.2](./CISA.MS.EXO.6.2.md) | Calendar details SHALL NOT be shared with all domains. | Medium | exchange |
+| [CISA.MS.EXO.7.1](./CISA.MS.EXO.7.1.md) | External sender warnings SHALL be implemented. | Medium | exchange |
+| [CISA.MS.EXO.8.1](./CISA.MS.EXO.8.1.md) | A DLP solution SHALL be used. | High | exchange |
+| [CISA.MS.EXO.8.2](./CISA.MS.EXO.8.2.md) | The DLP solution SHALL protect personally identifiable information (PII) and sensitive information, as defined by the agency. | Medium | exchange |
+| [CISA.MS.EXO.8.3](./CISA.MS.EXO.8.3.md) | The selected DLP solution SHOULD offer services comparable to the native DLP solution offered by Microsoft. | Medium | exchange |
+| [CISA.MS.EXO.8.4](./CISA.MS.EXO.8.4.md) | At a minimum, the DLP solution SHALL restrict sharing credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN) via email. | High | exchange |
+| [CISA.MS.EXO.9.1](./CISA.MS.EXO.9.1.md) | Emails SHALL be filtered by attachment file types. | Medium | exchange |
+| [CISA.MS.EXO.9.2](./CISA.MS.EXO.9.2.md) | The attachment filter SHOULD attempt to determine the true file type and assess the file extension. | Medium | exchange |
+| [CISA.MS.EXO.9.3](./CISA.MS.EXO.9.3.md) | Disallowed file types SHALL be determined and enforced. | High | exchange |
+| [CISA.MS.EXO.9.4](./CISA.MS.EXO.9.4.md) | Alternatively chosen filtering solutions SHOULD offer services comparable to Microsoft Defender's Common Attachment Filter. | Medium | exchange |
+| [CISA.MS.EXO.9.5](./CISA.MS.EXO.9.5.md) | At a minimum, click-to-run files SHOULD be blocked (e.g., .exe, .cmd, and .vbe). | High | exchange |
+| [CISA.MS.EXO.10.1](./CISA.MS.EXO.10.1.md) | Emails SHALL be scanned for malware. | High | exchange |
+| [CISA.MS.EXO.10.2](./CISA.MS.EXO.10.2.md) | Emails identified as containing malware SHALL be quarantined or dropped. | High | exchange |
+| [CISA.MS.EXO.10.3](./CISA.MS.EXO.10.3.md) | Email scanning SHALL be capable of reviewing emails after delivery. | High | exchange |
+| [CISA.MS.EXO.11.1](./CISA.MS.EXO.11.1.md) | Impersonation protection checks SHOULD be used. | High | exchange |
+| [CISA.MS.EXO.11.2](./CISA.MS.EXO.11.2.md) | User warnings, comparable to the user safety tips included with EOP, SHOULD be displayed. | Medium | exchange |
+| [CISA.MS.EXO.11.3](./CISA.MS.EXO.11.3.md) | The phishing protection solution SHOULD include an AI-based phishing detection tool comparable to EOP Mailbox Intelligence. | Medium | exchange |
+| [CISA.MS.EXO.12.1](./CISA.MS.EXO.12.1.md) | IP allow lists SHOULD NOT be created. | Medium | exchange |
+| [CISA.MS.EXO.12.2](./CISA.MS.EXO.12.2.md) | Safe lists SHOULD NOT be enabled. | Medium | exchange |
+| [CISA.MS.EXO.13.1](./CISA.MS.EXO.13.1.md) | Mailbox auditing SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.14.1](./CISA.MS.EXO.14.1.md) | A spam filter SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.14.2](./CISA.MS.EXO.14.2.md) | Spam and high confidence spam SHALL be moved to either the junk email folder or the quarantine folder. | Medium | exchange |
+| [CISA.MS.EXO.14.3](./CISA.MS.EXO.14.3.md) | Allowed domains SHALL NOT be added to inbound anti-spam protection policies. | Medium | exchange |
+| [CISA.MS.EXO.14.4](./CISA.MS.EXO.14.4.md) | If a third-party party filtering solution is used, the solution SHOULD offer services comparable to the native spam filtering offered by Microsoft. | Medium | exchange |
+| [CISA.MS.EXO.15.1](./CISA.MS.EXO.15.1.md) | URL comparison with a block-list SHOULD be enabled. | Medium | exchange |
+| [CISA.MS.EXO.15.2](./CISA.MS.EXO.15.2.md) | Direct download links SHOULD be scanned for malware. | High | exchange |
+| [CISA.MS.EXO.15.3](./CISA.MS.EXO.15.3.md) | User click tracking SHOULD be enabled. | Medium | exchange |
+| [CISA.MS.EXO.16.1](./CISA.MS.EXO.16.1.md) | Alerts SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.16.2](./CISA.MS.EXO.16.2.md) | Alerts SHOULD be sent to a monitored address or incorporated into a security information and event management (SIEM) system. | Medium | exchange |
+| [CISA.MS.EXO.17.1](./CISA.MS.EXO.17.1.md) | Microsoft Purview Audit (Standard) logging SHALL be enabled. | High | exchange |
+| [CISA.MS.EXO.17.2](./CISA.MS.EXO.17.2.md) | Microsoft Purview Audit (Premium) logging SHALL be enabled. | Medium | Deprecated |
+| [CISA.MS.EXO.17.3](./CISA.MS.EXO.17.3.md) | Audit logs SHALL be maintained for at least the minimum duration dictated by OMB M-21-31 (Appendix C). | Medium | exchange |
+| [CISA.MS.SHAREPOINT.1.1](./CISA.MS.SHAREPOINT.1.1.md) | External sharing for SharePoint SHALL be limited to Existing guests or Only People in your organization. | Medium | spo |
+| [CISA.MS.SHAREPOINT.1.3](./CISA.MS.SHAREPOINT.1.3.md) | External sharing SHALL be restricted to approved external domains and/or users in approved security groups per interagency collaboration needs. | High | spo |

--- a/website/versioned_docs/version-2.1.0/tests/eidsca/readme.md
+++ b/website/versioned_docs/version-2.1.0/tests/eidsca/readme.md
@@ -18,47 +18,47 @@ These tests are based on the Entra ID Security Config Analyzer and verify Micros
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [EIDSCA.AF01](../EIDSCA.AF01) | Authentication Method - FIDO2 security key - State. | High | General |
-| [EIDSCA.AF02](../EIDSCA.AF02) | Authentication Method - FIDO2 security key - Allow self-service set up. | Medium | General |
-| [EIDSCA.AF03](../EIDSCA.AF03) | Authentication Method - FIDO2 security key - Enforce attestation. | High | General |
-| [EIDSCA.AF04](../EIDSCA.AF04) | Authentication Method - FIDO2 security key - Enforce key restrictions. | High | General |
-| [EIDSCA.AF05](../EIDSCA.AF05) | Authentication Method - FIDO2 security key - Restricted. | High | General |
-| [EIDSCA.AF06](../EIDSCA.AF06) | Authentication Method - FIDO2 security key - Restrict specific keys. | Medium | General |
-| [EIDSCA.AG01](../EIDSCA.AG01) | Authentication Method - General Settings - Manage migration. | High | General |
-| [EIDSCA.AG02](../EIDSCA.AG02) | Authentication Method - General Settings - Report suspicious activity - State. | Medium | General |
-| [EIDSCA.AG03](../EIDSCA.AG03) | Authentication Method - General Settings - Report suspicious activity - Included users/groups. | Medium | General |
-| [EIDSCA.AM01](../EIDSCA.AM01) | Authentication Method - Microsoft Authenticator - State. | High | General |
-| [EIDSCA.AM02](../EIDSCA.AM02) | Authentication Method - Microsoft Authenticator - Allow use of Microsoft Authenticator OTP. | Medium | General |
-| [EIDSCA.AM03](../EIDSCA.AM03) | Authentication Method - Microsoft Authenticator - Require number matching for push notifications. | Medium | General |
-| [EIDSCA.AM04](../EIDSCA.AM04) | Authentication Method - Microsoft Authenticator - Included users/groups of number matching for push notifications. | Medium | General |
-| [EIDSCA.AM06](../EIDSCA.AM06) | Authentication Method - Microsoft Authenticator - Show application name in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AM07](../EIDSCA.AM07) | Authentication Method - Microsoft Authenticator - Included users/groups to show application name in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AM09](../EIDSCA.AM09) | Authentication Method - Microsoft Authenticator - Show geographic location in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AM10](../EIDSCA.AM10) | Authentication Method - Microsoft Authenticator - Included users/groups to show geographic location in push and passwordless notifications. | Medium | General |
-| [EIDSCA.AP01](../EIDSCA.AP01) | Default Authorization Settings - Enabled Self service password reset for administrators. | High | General |
-| [EIDSCA.AP04](../EIDSCA.AP04) | Default Authorization Settings - Guest invite restrictions. | Medium | General |
-| [EIDSCA.AP05](../EIDSCA.AP05) | Default Authorization Settings - Sign-up for email based subscription. | Medium | General |
-| [EIDSCA.AP06](../EIDSCA.AP06) | Default Authorization Settings - User can join the tenant by email validation. | Medium | General |
-| [EIDSCA.AP07](../EIDSCA.AP07) | Default Authorization Settings - Guest user access. | High | General |
-| [EIDSCA.AP08](../EIDSCA.AP08) | Default Authorization Settings - User consent policy assigned for applications. | Medium | General |
-| [EIDSCA.AP09](../EIDSCA.AP09) | Default Authorization Settings - Allow user consent on risk-based apps. | Medium | General |
-| [EIDSCA.AP10](../EIDSCA.AP10) | Default Authorization Settings - Default User Role Permissions - Allowed to create Apps. | High | General |
-| [EIDSCA.AP14](../EIDSCA.AP14) | Default Authorization Settings - Default User Role Permissions - Allowed to read other users. | High | General |
-| [EIDSCA.AS04](../EIDSCA.AS04) | Authentication Method - SMS - Use for sign-in. | High | General |
-| [EIDSCA.AT01](../EIDSCA.AT01) | Authentication Method - Temporary Access Pass - State. | High | General |
-| [EIDSCA.AT02](../EIDSCA.AT02) | Authentication Method - Temporary Access Pass - One-time. | High | General |
-| [EIDSCA.AV01](../EIDSCA.AV01) | Authentication Method - Voice call - State. | High | General |
-| [EIDSCA.CP01](../EIDSCA.CP01) | Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. | High | General |
-| [EIDSCA.CP03](../EIDSCA.CP03) | Default Settings - Consent Policy Settings - Block user consent for risky apps. | High | General |
-| [EIDSCA.CP04](../EIDSCA.CP04) | Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. | Medium | General |
-| [EIDSCA.CR01](../EIDSCA.CR01) | Consent Framework - Admin Consent Request - Policy to enable or disable admin consent request feature. | High | General |
-| [EIDSCA.CR02](../EIDSCA.CR02) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. | Medium | General |
-| [EIDSCA.CR03](../EIDSCA.CR03) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. | Medium | General |
-| [EIDSCA.CR04](../EIDSCA.CR04) | Consent Framework - Admin Consent Request - Consent request duration (days). | High | General |
-| [EIDSCA.PR01](../EIDSCA.PR01) | Default Settings - Password Rule Settings - Password Protection - Mode. | High | General |
-| [EIDSCA.PR02](../EIDSCA.PR02) | Default Settings - Password Rule Settings - Password Protection - Enable password protection on Windows Server Active Directory. | High | General |
-| [EIDSCA.PR03](../EIDSCA.PR03) | Default Settings - Password Rule Settings - Enforce custom list. | Medium | General |
-| [EIDSCA.PR05](../EIDSCA.PR05) | Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. | Medium | General |
-| [EIDSCA.PR06](../EIDSCA.PR06) | Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. | Medium | General |
-| [EIDSCA.ST08](../EIDSCA.ST08) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to become Group Owner. | Medium | General |
-| [EIDSCA.ST09](../EIDSCA.ST09) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to have access to groups content. | Medium | General |
+| [EIDSCA.AF01](./EIDSCA.AF01.md) | Authentication Method - FIDO2 security key - State. | High | General |
+| [EIDSCA.AF02](./EIDSCA.AF02.md) | Authentication Method - FIDO2 security key - Allow self-service set up. | Medium | General |
+| [EIDSCA.AF03](./EIDSCA.AF03.md) | Authentication Method - FIDO2 security key - Enforce attestation. | High | General |
+| [EIDSCA.AF04](./EIDSCA.AF04.md) | Authentication Method - FIDO2 security key - Enforce key restrictions. | High | General |
+| [EIDSCA.AF05](./EIDSCA.AF05.md) | Authentication Method - FIDO2 security key - Restricted. | High | General |
+| [EIDSCA.AF06](./EIDSCA.AF06.md) | Authentication Method - FIDO2 security key - Restrict specific keys. | Medium | General |
+| [EIDSCA.AG01](./EIDSCA.AG01.md) | Authentication Method - General Settings - Manage migration. | High | General |
+| [EIDSCA.AG02](./EIDSCA.AG02.md) | Authentication Method - General Settings - Report suspicious activity - State. | Medium | General |
+| [EIDSCA.AG03](./EIDSCA.AG03.md) | Authentication Method - General Settings - Report suspicious activity - Included users/groups. | Medium | General |
+| [EIDSCA.AM01](./EIDSCA.AM01.md) | Authentication Method - Microsoft Authenticator - State. | High | General |
+| [EIDSCA.AM02](./EIDSCA.AM02.md) | Authentication Method - Microsoft Authenticator - Allow use of Microsoft Authenticator OTP. | Medium | General |
+| [EIDSCA.AM03](./EIDSCA.AM03.md) | Authentication Method - Microsoft Authenticator - Require number matching for push notifications. | Medium | General |
+| [EIDSCA.AM04](./EIDSCA.AM04.md) | Authentication Method - Microsoft Authenticator - Included users/groups of number matching for push notifications. | Medium | General |
+| [EIDSCA.AM06](./EIDSCA.AM06.md) | Authentication Method - Microsoft Authenticator - Show application name in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AM07](./EIDSCA.AM07.md) | Authentication Method - Microsoft Authenticator - Included users/groups to show application name in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AM09](./EIDSCA.AM09.md) | Authentication Method - Microsoft Authenticator - Show geographic location in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AM10](./EIDSCA.AM10.md) | Authentication Method - Microsoft Authenticator - Included users/groups to show geographic location in push and passwordless notifications. | Medium | General |
+| [EIDSCA.AP01](./EIDSCA.AP01.md) | Default Authorization Settings - Enabled Self service password reset for administrators. | High | General |
+| [EIDSCA.AP04](./EIDSCA.AP04.md) | Default Authorization Settings - Guest invite restrictions. | Medium | General |
+| [EIDSCA.AP05](./EIDSCA.AP05.md) | Default Authorization Settings - Sign-up for email based subscription. | Medium | General |
+| [EIDSCA.AP06](./EIDSCA.AP06.md) | Default Authorization Settings - User can join the tenant by email validation. | Medium | General |
+| [EIDSCA.AP07](./EIDSCA.AP07.md) | Default Authorization Settings - Guest user access. | High | General |
+| [EIDSCA.AP08](./EIDSCA.AP08.md) | Default Authorization Settings - User consent policy assigned for applications. | Medium | General |
+| [EIDSCA.AP09](./EIDSCA.AP09.md) | Default Authorization Settings - Allow user consent on risk-based apps. | Medium | General |
+| [EIDSCA.AP10](./EIDSCA.AP10.md) | Default Authorization Settings - Default User Role Permissions - Allowed to create Apps. | High | General |
+| [EIDSCA.AP14](./EIDSCA.AP14.md) | Default Authorization Settings - Default User Role Permissions - Allowed to read other users. | High | General |
+| [EIDSCA.AS04](./EIDSCA.AS04.md) | Authentication Method - SMS - Use for sign-in. | High | General |
+| [EIDSCA.AT01](./EIDSCA.AT01.md) | Authentication Method - Temporary Access Pass - State. | High | General |
+| [EIDSCA.AT02](./EIDSCA.AT02.md) | Authentication Method - Temporary Access Pass - One-time. | High | General |
+| [EIDSCA.AV01](./EIDSCA.AV01.md) | Authentication Method - Voice call - State. | High | General |
+| [EIDSCA.CP01](./EIDSCA.CP01.md) | Default Settings - Consent Policy Settings - Group owner consent for apps accessing data. | High | General |
+| [EIDSCA.CP03](./EIDSCA.CP03.md) | Default Settings - Consent Policy Settings - Block user consent for risky apps. | High | General |
+| [EIDSCA.CP04](./EIDSCA.CP04.md) | Default Settings - Consent Policy Settings - Users can request admin consent to apps they are unable to consent to. | Medium | General |
+| [EIDSCA.CR01](./EIDSCA.CR01.md) | Consent Framework - Admin Consent Request - Policy to enable or disable admin consent request feature. | High | General |
+| [EIDSCA.CR02](./EIDSCA.CR02.md) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications for requests. | Medium | General |
+| [EIDSCA.CR03](./EIDSCA.CR03.md) | Consent Framework - Admin Consent Request - Reviewers will receive email notifications when admin consent requests are about to expire. | Medium | General |
+| [EIDSCA.CR04](./EIDSCA.CR04.md) | Consent Framework - Admin Consent Request - Consent request duration (days). | High | General |
+| [EIDSCA.PR01](./EIDSCA.PR01.md) | Default Settings - Password Rule Settings - Password Protection - Mode. | High | General |
+| [EIDSCA.PR02](./EIDSCA.PR02.md) | Default Settings - Password Rule Settings - Password Protection - Enable password protection on Windows Server Active Directory. | High | General |
+| [EIDSCA.PR03](./EIDSCA.PR03.md) | Default Settings - Password Rule Settings - Enforce custom list. | Medium | General |
+| [EIDSCA.PR05](./EIDSCA.PR05.md) | Default Settings - Password Rule Settings - Smart Lockout - Lockout duration in seconds. | Medium | General |
+| [EIDSCA.PR06](./EIDSCA.PR06.md) | Default Settings - Password Rule Settings - Smart Lockout - Lockout threshold. | Medium | General |
+| [EIDSCA.ST08](./EIDSCA.ST08.md) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to become Group Owner. | Medium | General |
+| [EIDSCA.ST09](./EIDSCA.ST09.md) | Default Settings - Classification and M365 Groups - M365 groups - Allow Guests to have access to groups content. | Medium | General |

--- a/website/versioned_docs/version-2.1.0/tests/maester/readme.md
+++ b/website/versioned_docs/version-2.1.0/tests/maester/readme.md
@@ -18,147 +18,147 @@ These tests are maintained by the Maester community and validate Microsoft 365, 
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [MT.1001](../MT.1001) | At least one Conditional Access policy is configured with device compliance. | Medium | CA |
-| [MT.1002](../MT.1002) | App management restrictions on applications and service principals is configured and enabled. | High | App |
-| [MT.1003](../MT.1003) | At least one Conditional Access policy is configured with All Apps. | High | CA |
-| [MT.1004](../MT.1004) | At least one Conditional Access policy is configured with All Apps and All Users. | High | CA |
-| [MT.1005](../MT.1005) | All Conditional Access policies are configured to exclude at least one emergency/break glass account or group. | High | CA |
-| [MT.1006](../MT.1006) | At least one Conditional Access policy is configured to require MFA for admins. | High | CA |
-| [MT.1007](../MT.1007) | At least one Conditional Access policy is configured to require MFA for all users. | High | CA |
-| [MT.1008](../MT.1008) | At least one Conditional Access policy is configured to require MFA for Azure management. | High | CA |
-| [MT.1009](../MT.1009) | At least one Conditional Access policy is configured to block other legacy authentication. | High | CA |
-| [MT.1010](../MT.1010) | At least one Conditional Access policy is configured to block legacy authentication for Exchange ActiveSync. | High | CA |
-| [MT.1011](../MT.1011) | At least one Conditional Access policy is configured to secure security info registration only from a trusted location. | High | CA |
-| [MT.1012](../MT.1012) | At least one Conditional Access policy is configured to require MFA for risky sign-ins. | High | CA |
-| [MT.1013](../MT.1013) | At least one Conditional Access policy is configured to require new password when user risk is high. | High | CA |
-| [MT.1014](../MT.1014) | At least one Conditional Access policy is configured to require compliant or Entra hybrid joined devices for admins. | High | CA |
-| [MT.1015](../MT.1015) | At least one Conditional Access policy is configured to block access for unknown or unsupported device platforms. | Medium | CA |
-| [MT.1016](../MT.1016) | At least one Conditional Access policy is configured to require MFA for guest access. | High | CA |
-| [MT.1017](../MT.1017) | At least one Conditional Access policy is configured to enforce non persistent browser session for non-corporate devices. | High | CA |
-| [MT.1018](../MT.1018) | At least one Conditional Access policy is configured to enforce sign-in frequency for non-corporate devices. | Medium | CA |
-| [MT.1019](../MT.1019) | At least one Conditional Access policy is configured to enable application enforced restrictions. | Medium | CA |
-| [MT.1020](../MT.1020) | All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. | High | CA |
-| [MT.1021](../MT.1021) | Security Defaults are enabled. | High | CA |
-| [MT.1022](../MT.1022) | All users utilizing a P1 license should be licensed. | Medium | CA |
-| [MT.1023](../MT.1023) | All users utilizing a P2 license should be licensed. | Medium | CA |
-| [MT.1024](../MT.1024) | MT.1024.$($RecommendationId -replace | Unknown | Entra |
-| [MT.1025](../MT.1025) | No external user with permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1026](../MT.1026) | No hybrid user with permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1027](../MT.1027) | No Service Principal with Client Secret and permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1028](../MT.1028) | No user with mailbox and permanent role assignment on Control Plane. | High | Privileged |
-| [MT.1029](../MT.1029) | Stale accounts are not assigned to privileged roles. | High | Privileged |
-| [MT.1030](../MT.1030) | Eligible role assignments on Control Plane are in use by administrators. | High | Privileged |
-| [MT.1031](../MT.1031) | Privileged role on Control Plane are managed by PIM only. | High | Privileged |
-| [MT.1032](../MT.1032) | Limited number of Global Admins are assigned. | High | Privileged |
-| [MT.1033](../MT.1033) | MT.1033.$($RegularUsers.IndexOf($_)): User should be blocked from using legacy authentication ($($_.userPrincipalName)) | Unknown | CA |
-| [MT.1034](../MT.1034) | MT.1034.$($EmergencyAccessUsers.IndexOf($_)): Emergency access users should not be blocked ($($_.userPrincipalName)) | Unknown | CA |
-| [MT.1035](../MT.1035) | All security groups assigned to Conditional Access Policies should be protected by RMAU. | High | CA |
-| [MT.1036](../MT.1036) | All excluded objects should have a fallback include in another policy. | Medium | CA |
-| [MT.1037](../MT.1037) | Only users with Presenter role are allowed to present in Teams meetings | High | Teams |
-| [MT.1038](../MT.1038) | Conditional Access policies should not include or exclude deleted groups. | Medium | CA |
-| [MT.1039](../MT.1039) | Ensure MailTips are enabled for end users | Low | Exchange |
-| [MT.1041](../MT.1041) | Ensure users installing Outlook add-ins is not allowed | High | Exchange |
-| [MT.1042](../MT.1042) | Restrict dial-in users from bypassing a meeting lobby | Medium | Teams |
-| [MT.1043](../MT.1043) | Ensure Spam confidence level (SCL) is configured in mail transport rules with specific domains | Medium | Exchange |
-| [MT.1044](../MT.1044) | Ensure modern authentication for Exchange Online is enabled | High | Exchange |
-| [MT.1045](../MT.1045) | Only invited users should be automatically admitted to Teams meetings | Medium | Teams |
-| [MT.1046](../MT.1046) | Restrict anonymous users from joining meetings | Medium | Teams |
-| [MT.1047](../MT.1047) | Restrict anonymous users from starting Teams meetings | Medium | Teams |
-| [MT.1048](../MT.1048) | Limit external participants from having control in a Teams meeting | Medium | Teams |
-| [MT.1049](../MT.1049) | Conditional Access policies for User Risk and Sign-in Risk should be configured separately. | High | CA |
-| [MT.1050](../MT.1050) | Apps with high-risk permissions having a direct path to Global Admin | High | App |
-| [MT.1051](../MT.1051) | Apps with high-risk permissions having an indirect path to Global Admin | High | App |
-| [MT.1052](../MT.1052) | At least one Conditional Access policy is targeting the Device Code authentication flow. | High | CA |
-| [MT.1053](../MT.1053) | Ensure intune device clean-up rule is configured | Medium | Intune |
-| [MT.1054](../MT.1054) | Ensure built-in Device Compliance Policy marks devices with no compliance policy assigned as 'Not compliant' | Medium | Intune |
-| [MT.1055](../MT.1055) | Microsoft 365 Group (and Team) creation should be restricted to approved users. | Medium | Group |
-| [MT.1056](../MT.1056) | Ensure that no person has permanent access to all Azure subscriptions at the root scope | High | Privileged |
-| [MT.1057](../MT.1057) | Ensure Microsoft 365 Group (and Team) expiration is configured to notify users. | Medium | App |
-| [MT.1058](../MT.1058) | Ensure Microsoft 365 Group (and Team) expiration is configured to auto-expire groups. | Medium | App |
-| [MT.1059](../MT.1059) | Microsoft Defender for Identity health issues should be resolved | Medium | Defender |
-| [MT.1061](../MT.1061) | Device registration MFA control conflicts with Conditional Access policies | Medium | CA |
-| [MT.1062](../MT.1062) | Ensure Direct Send is set to be rejected | Medium | Exchange |
-| [MT.1063](../MT.1063) | All app registration owners should have MFA registered | High | App |
-| [MT.1064](../MT.1064) | Management group creation should be limited to users with explicit write access | High | Azure |
-| [MT.1065](../MT.1065) | Soft Delete should be enabled on all Recovery Services Vaults | High | Backup |
-| [MT.1066](../MT.1066) | Conditional Access policies should not include or exclude deleted users, groups, or roles. | Medium | CA |
-| [MT.1067](../MT.1067) | Authentication methods policies should not reference deleted groups. | Medium | Authentication |
-| [MT.1068](../MT.1068) | Restrict non-admin users from creating tenants | Medium | Entra |
-| [MT.1069](../MT.1069) | Restrict non-admin users from creating security groups. | Low | Entra |
-| [MT.1070](../MT.1070) | Restrict device join to selected users/groups or none. | Medium | Entra |
-| [MT.1071](../MT.1071) | At least one Conditional Access policy explicitly includes Azure DevOps. | Medium | CA |
-| [MT.1072](../MT.1072) | Conditional access policies should not use the deprecated Approved Client App grant. | High | CA |
-| [MT.1073](../MT.1073) | Soft- and hard-matching of synchronized objects should be blocked. | Medium | Entra |
-| [MT.1074](../MT.1074) | Mailboxes should not send outbound mails using the .onmicrosoft.com domain. | Medium | Exchange |
-| [MT.1075](../MT.1075) | Third Party Entra Apps should only have explicitly assigned users instead of All Users. | Medium | App |
-| [MT.1076](../MT.1076) | MOERA SHOULD NOT be used for sent mail. | High | Exchange |
-| [MT.1077](../MT.1077) | App registrations with privileged API permissions should not have owners | Medium | Privileged |
-| [MT.1078](../MT.1078) | App registrations with highly privileged directory roles should not have owners | Medium | Privileged |
-| [MT.1079](../MT.1079) | Privileged API permissions on service principals should not remain unused | Medium | Privileged |
-| [MT.1080](../MT.1080) | Credentials, tokens, or cookies from highly privileged users should not be exposed on vulnerable endpoints | Medium | Privileged |
-| [MT.1081](../MT.1081) | Hybrid users should not be assigned Entra ID role assignments | Medium | Privileged |
-| [MT.1083](../MT.1083) | Ensure Delicensing Resiliency is enabled | Low | Exchange |
-| [MT.1084](../MT.1084) | Seamless Single SignOn should be disabled for all domains in EntraID Connect servers. | High | Entra |
-| [MT.1085](../MT.1085) | Pending approvals for Critical Asset Management should not be present | Medium | Entra |
-| [MT.1086](../MT.1086) | Devices should not share both critical and non-critical user credentials. | Low | XSPM |
-| [MT.1087](../MT.1087) | Devices should not be publicly exposed with remotely exploitable, highly likely to be exploited, high or critical severity CVE's. | High | XSPM |
-| [MT.1088](../MT.1088) | Devices with critical credentials should be protected by TPM. | Medium | XSPM |
-| [MT.1089](../MT.1089) | Devices with critical credentials should be protected by Credential Guard. | Medium | XSPM |
-| [MT.1090](../MT.1090) | Global administrator role should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
-| [MT.1091](../MT.1091) | Registering user should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
-| [MT.1092](../MT.1092) | Intune APNS certificate should be valid for more than 30 days | High | Intune |
-| [MT.1093](../MT.1093) | Apple Automated Device Enrollment Tokens should be valid for more than 30 days | High | Intune |
-| [MT.1094](../MT.1094) | Apple Volume Purchase Program Tokens should be valid for more than 30 days | High | Intune |
-| [MT.1095](../MT.1095) | Android Enterprise Account Connection should be healthy | High | Intune |
-| [MT.1096](../MT.1096) | Intune Multi Admin approval should be configured | Medium | Intune |
-| [MT.1097](../MT.1097) | Certificate Connectors should be healthy and running supported versions | High | Intune |
-| [MT.1098](../MT.1098) | Mobile Threat Defense Connectors should be healthy | Critical | Intune |
-| [MT.1099](../MT.1099) | Windows Diagnostic Data Processing should be enabled | Low | Intune |
-| [MT.1100](../MT.1100) | Intune Audit Logs should be retained | High | Intune |
-| [MT.1101](../MT.1101) | Default Branding Profile should be customized | Low | Intune |
-| [MT.1102](../MT.1102) | Windows Feature Update Policy Settings should not reference end of support builds | High | Intune |
-| [MT.1103](../MT.1103) | Intune RBAC groups should be protected by Restricted Management Administrative Units or Role Assignable groups | High | Intune |
-| [MT.1105](../MT.1105) | MDM Authority should be set to Microsoft Intune | Low | Intune |
-| [MT.1106](../MT.1106) | Catalog resources must have valid roles (no stale app roles or deleted SPNs) | Medium | Governance |
-| [MT.1107](../MT.1107) | Access packages and catalogs should not reference deleted groups | Medium | Governance |
-| [MT.1108](../MT.1108) | Access packages should not have inactive or orphaned assignment policies | Medium | Governance |
-| [MT.1109](../MT.1109) | Access package approval workflows must have valid approvers | Medium | Governance |
-| [MT.1110](../MT.1110) | No catalog should contain resources without any associated access packages | Medium | Governance |
-| [MT.1111](../MT.1111) | High privileged user should be linked to an identity | Low | Privileged |
-| [MT.1112](../MT.1112) | Privileged user accounts should not remain enabled when the linked primary account is disabled | Medium | Privileged |
-| [MT.1113](../MT.1113) | AI agents should not be shared with broad access control policies | High | AIAgent |
-| [MT.1114](../MT.1114) | AI agents should require user authentication | High | AIAgent |
-| [MT.1115](../MT.1115) | AI agents should not have risky HTTP configurations | Medium | AIAgent |
-| [MT.1116](../MT.1116) | AI agents should not send email with AI-controlled inputs | High | AIAgent |
-| [MT.1117](../MT.1117) | Published AI agents should not be dormant | Low | AIAgent |
-| [MT.1118](../MT.1118) | AI agents should avoid using author (maker) authentication for tools | Medium | AIAgent |
-| [MT.1119](../MT.1119) | AI agents should not have hard-coded credentials in topics | High | AIAgent |
-| [MT.1120](../MT.1120) | AI agents should not use MCP server tools without review | Medium | AIAgent |
-| [MT.1121](../MT.1121) | AI agents with generative orchestration should have custom instructions | Medium | AIAgent |
-| [MT.1122](../MT.1122) | AI agents should not have orphaned ownership | Medium | AIAgent |
-| [MT.1123](../MT.1123) | Ensure BitLocker full disk encryption is configured via Intune | High | Intune |
-| [MT.1147](../MT.1147) | Do not sync krbtgt_AzureAD to Entra ID | High | Entra |
-| [MT.1148](../MT.1148) | Archive Scanning should be enabled | High | Defender |
-| [MT.1149](../MT.1149) | Behavior Monitoring should be enabled | High | Defender |
-| [MT.1150](../MT.1150) | Cloud Protection should be enabled | High | Defender |
-| [MT.1151](../MT.1151) | Email Scanning should be enabled | High | Defender |
-| [MT.1152](../MT.1152) | Script Scanning should be enabled | High | Defender |
-| [MT.1153](../MT.1153) | Real-time Monitoring should be enabled | High | Defender |
-| [MT.1154](../MT.1154) | Full Scan Removable Drives should be enabled | High | Defender |
-| [MT.1155](../MT.1155) | Full Scan Mapped Drives should be disabled for performance | High | Defender |
-| [MT.1156](../MT.1156) | Scanning Network Files should be enabled | High | Defender |
-| [MT.1157](../MT.1157) | CPU Load Factor should be optimized (20-30%) | High | Defender |
-| [MT.1158](../MT.1158) | Scan should be scheduled | High | Defender |
-| [MT.1159](../MT.1159) | Quick Scan Time configuration is not required | High | Defender |
-| [MT.1160](../MT.1160) | Signatures should be checked before scan | High | Defender |
-| [MT.1161](../MT.1161) | Cloud Block Level should be High or higher | High | Defender |
-| [MT.1162](../MT.1162) | Cloud Extended Timeout should be 30-50 seconds | High | Defender |
-| [MT.1163](../MT.1163) | Signature Update Interval should be 1-4 hours | High | Defender |
-| [MT.1164](../MT.1164) | PUA Protection should be enabled | High | Defender |
-| [MT.1165](../MT.1165) | Network Protection should be enabled | High | Defender |
-| [MT.1166](../MT.1166) | Local Admin Merge should be disabled | High | Defender |
-| [MT.1167](../MT.1167) | Real-Time Scan Direction should cover both directions | High | Defender |
-| [MT.1168](../MT.1168) | Cleaned Malware should be retained for at least 30 days | High | Defender |
-| [MT.1169](../MT.1169) | Catch-up Full Scan should be disabled | High | Defender |
-| [MT.1170](../MT.1170) | Catch-up Quick Scan should be disabled | High | Defender |
-| [MT.1171](../MT.1171) | Sample Submission should send safe samples automatically | High | Defender |
+| [MT.1001](./MT.1001.md) | At least one Conditional Access policy is configured with device compliance. | Medium | CA |
+| [MT.1002](./MT.1002.md) | App management restrictions on applications and service principals is configured and enabled. | High | App |
+| [MT.1003](./MT.1003.md) | At least one Conditional Access policy is configured with All Apps. | High | CA |
+| [MT.1004](./MT.1004.md) | At least one Conditional Access policy is configured with All Apps and All Users. | High | CA |
+| [MT.1005](./MT.1005.md) | All Conditional Access policies are configured to exclude at least one emergency/break glass account or group. | High | CA |
+| [MT.1006](./MT.1006.md) | At least one Conditional Access policy is configured to require MFA for admins. | High | CA |
+| [MT.1007](./MT.1007.md) | At least one Conditional Access policy is configured to require MFA for all users. | High | CA |
+| [MT.1008](./MT.1008.md) | At least one Conditional Access policy is configured to require MFA for Azure management. | High | CA |
+| [MT.1009](./MT.1009.md) | At least one Conditional Access policy is configured to block other legacy authentication. | High | CA |
+| [MT.1010](./MT.1010.md) | At least one Conditional Access policy is configured to block legacy authentication for Exchange ActiveSync. | High | CA |
+| [MT.1011](./MT.1011.md) | At least one Conditional Access policy is configured to secure security info registration only from a trusted location. | High | CA |
+| [MT.1012](./MT.1012.md) | At least one Conditional Access policy is configured to require MFA for risky sign-ins. | High | CA |
+| [MT.1013](./MT.1013.md) | At least one Conditional Access policy is configured to require new password when user risk is high. | High | CA |
+| [MT.1014](./MT.1014.md) | At least one Conditional Access policy is configured to require compliant or Entra hybrid joined devices for admins. | High | CA |
+| [MT.1015](./MT.1015.md) | At least one Conditional Access policy is configured to block access for unknown or unsupported device platforms. | Medium | CA |
+| [MT.1016](./MT.1016.md) | At least one Conditional Access policy is configured to require MFA for guest access. | High | CA |
+| [MT.1017](./MT.1017.md) | At least one Conditional Access policy is configured to enforce non persistent browser session for non-corporate devices. | High | CA |
+| [MT.1018](./MT.1018.md) | At least one Conditional Access policy is configured to enforce sign-in frequency for non-corporate devices. | Medium | CA |
+| [MT.1019](./MT.1019.md) | At least one Conditional Access policy is configured to enable application enforced restrictions. | Medium | CA |
+| [MT.1020](./MT.1020.md) | All Conditional Access policies are configured to exclude directory synchronization accounts or do not scope them. | High | CA |
+| [MT.1021](./MT.1021.md) | Security Defaults are enabled. | High | CA |
+| [MT.1022](./MT.1022.md) | All users utilizing a P1 license should be licensed. | Medium | CA |
+| [MT.1023](./MT.1023.md) | All users utilizing a P2 license should be licensed. | Medium | CA |
+| [MT.1024](./MT.1024.md) | MT.1024.$($RecommendationId -replace | Unknown | Entra |
+| [MT.1025](./MT.1025.md) | No external user with permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1026](./MT.1026.md) | No hybrid user with permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1027](./MT.1027.md) | No Service Principal with Client Secret and permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1028](./MT.1028.md) | No user with mailbox and permanent role assignment on Control Plane. | High | Privileged |
+| [MT.1029](./MT.1029.md) | Stale accounts are not assigned to privileged roles. | High | Privileged |
+| [MT.1030](./MT.1030.md) | Eligible role assignments on Control Plane are in use by administrators. | High | Privileged |
+| [MT.1031](./MT.1031.md) | Privileged role on Control Plane are managed by PIM only. | High | Privileged |
+| [MT.1032](./MT.1032.md) | Limited number of Global Admins are assigned. | High | Privileged |
+| [MT.1033](./MT.1033.md) | MT.1033.$($RegularUsers.IndexOf($_)): User should be blocked from using legacy authentication ($($_.userPrincipalName)) | Unknown | CA |
+| [MT.1034](./MT.1034.md) | MT.1034.$($EmergencyAccessUsers.IndexOf($_)): Emergency access users should not be blocked ($($_.userPrincipalName)) | Unknown | CA |
+| [MT.1035](./MT.1035.md) | All security groups assigned to Conditional Access Policies should be protected by RMAU. | High | CA |
+| [MT.1036](./MT.1036.md) | All excluded objects should have a fallback include in another policy. | Medium | CA |
+| [MT.1037](./MT.1037.md) | Only users with Presenter role are allowed to present in Teams meetings | High | Teams |
+| [MT.1038](./MT.1038.md) | Conditional Access policies should not include or exclude deleted groups. | Medium | CA |
+| [MT.1039](./MT.1039.md) | Ensure MailTips are enabled for end users | Low | Exchange |
+| [MT.1041](./MT.1041.md) | Ensure users installing Outlook add-ins is not allowed | High | Exchange |
+| [MT.1042](./MT.1042.md) | Restrict dial-in users from bypassing a meeting lobby | Medium | Teams |
+| [MT.1043](./MT.1043.md) | Ensure Spam confidence level (SCL) is configured in mail transport rules with specific domains | Medium | Exchange |
+| [MT.1044](./MT.1044.md) | Ensure modern authentication for Exchange Online is enabled | High | Exchange |
+| [MT.1045](./MT.1045.md) | Only invited users should be automatically admitted to Teams meetings | Medium | Teams |
+| [MT.1046](./MT.1046.md) | Restrict anonymous users from joining meetings | Medium | Teams |
+| [MT.1047](./MT.1047.md) | Restrict anonymous users from starting Teams meetings | Medium | Teams |
+| [MT.1048](./MT.1048.md) | Limit external participants from having control in a Teams meeting | Medium | Teams |
+| [MT.1049](./MT.1049.md) | Conditional Access policies for User Risk and Sign-in Risk should be configured separately. | High | CA |
+| [MT.1050](./MT.1050.md) | Apps with high-risk permissions having a direct path to Global Admin | High | App |
+| [MT.1051](./MT.1051.md) | Apps with high-risk permissions having an indirect path to Global Admin | High | App |
+| [MT.1052](./MT.1052.md) | At least one Conditional Access policy is targeting the Device Code authentication flow. | High | CA |
+| [MT.1053](./MT.1053.md) | Ensure intune device clean-up rule is configured | Medium | Intune |
+| [MT.1054](./MT.1054.md) | Ensure built-in Device Compliance Policy marks devices with no compliance policy assigned as 'Not compliant' | Medium | Intune |
+| [MT.1055](./MT.1055.md) | Microsoft 365 Group (and Team) creation should be restricted to approved users. | Medium | Group |
+| [MT.1056](./MT.1056.md) | Ensure that no person has permanent access to all Azure subscriptions at the root scope | High | Privileged |
+| [MT.1057](./MT.1057.md) | Ensure Microsoft 365 Group (and Team) expiration is configured to notify users. | Medium | App |
+| [MT.1058](./MT.1058.md) | Ensure Microsoft 365 Group (and Team) expiration is configured to auto-expire groups. | Medium | App |
+| [MT.1059](./MT.1059.md) | Microsoft Defender for Identity health issues should be resolved | Medium | Defender |
+| [MT.1061](./MT.1061.md) | Device registration MFA control conflicts with Conditional Access policies | Medium | CA |
+| [MT.1062](./MT.1062.md) | Ensure Direct Send is set to be rejected | Medium | Exchange |
+| [MT.1063](./MT.1063.md) | All app registration owners should have MFA registered | High | App |
+| [MT.1064](./MT.1064.md) | Management group creation should be limited to users with explicit write access | High | Azure |
+| [MT.1065](./MT.1065.md) | Soft Delete should be enabled on all Recovery Services Vaults | High | Backup |
+| [MT.1066](./MT.1066.md) | Conditional Access policies should not include or exclude deleted users, groups, or roles. | Medium | CA |
+| [MT.1067](./MT.1067.md) | Authentication methods policies should not reference deleted groups. | Medium | Authentication |
+| [MT.1068](./MT.1068.md) | Restrict non-admin users from creating tenants | Medium | Entra |
+| [MT.1069](./MT.1069.md) | Restrict non-admin users from creating security groups. | Low | Entra |
+| [MT.1070](./MT.1070.md) | Restrict device join to selected users/groups or none. | Medium | Entra |
+| [MT.1071](./MT.1071.md) | At least one Conditional Access policy explicitly includes Azure DevOps. | Medium | CA |
+| [MT.1072](./MT.1072.md) | Conditional access policies should not use the deprecated Approved Client App grant. | High | CA |
+| [MT.1073](./MT.1073.md) | Soft- and hard-matching of synchronized objects should be blocked. | Medium | Entra |
+| [MT.1074](./MT.1074.md) | Mailboxes should not send outbound mails using the .onmicrosoft.com domain. | Medium | Exchange |
+| [MT.1075](./MT.1075.md) | Third Party Entra Apps should only have explicitly assigned users instead of All Users. | Medium | App |
+| [MT.1076](./MT.1076.md) | MOERA SHOULD NOT be used for sent mail. | High | Exchange |
+| [MT.1077](./MT.1077.md) | App registrations with privileged API permissions should not have owners | Medium | Privileged |
+| [MT.1078](./MT.1078.md) | App registrations with highly privileged directory roles should not have owners | Medium | Privileged |
+| [MT.1079](./MT.1079.md) | Privileged API permissions on service principals should not remain unused | Medium | Privileged |
+| [MT.1080](./MT.1080.md) | Credentials, tokens, or cookies from highly privileged users should not be exposed on vulnerable endpoints | Medium | Privileged |
+| [MT.1081](./MT.1081.md) | Hybrid users should not be assigned Entra ID role assignments | Medium | Privileged |
+| [MT.1083](./MT.1083.md) | Ensure Delicensing Resiliency is enabled | Low | Exchange |
+| [MT.1084](./MT.1084.md) | Seamless Single SignOn should be disabled for all domains in EntraID Connect servers. | High | Entra |
+| [MT.1085](./MT.1085.md) | Pending approvals for Critical Asset Management should not be present | Medium | Entra |
+| [MT.1086](./MT.1086.md) | Devices should not share both critical and non-critical user credentials. | Low | XSPM |
+| [MT.1087](./MT.1087.md) | Devices should not be publicly exposed with remotely exploitable, highly likely to be exploited, high or critical severity CVE's. | High | XSPM |
+| [MT.1088](./MT.1088.md) | Devices with critical credentials should be protected by TPM. | Medium | XSPM |
+| [MT.1089](./MT.1089.md) | Devices with critical credentials should be protected by Credential Guard. | Medium | XSPM |
+| [MT.1090](./MT.1090.md) | Global administrator role should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
+| [MT.1091](./MT.1091.md) | Registering user should not be added as local administrator on the device during Microsoft Entra join | Medium | Entra |
+| [MT.1092](./MT.1092.md) | Intune APNS certificate should be valid for more than 30 days | High | Intune |
+| [MT.1093](./MT.1093.md) | Apple Automated Device Enrollment Tokens should be valid for more than 30 days | High | Intune |
+| [MT.1094](./MT.1094.md) | Apple Volume Purchase Program Tokens should be valid for more than 30 days | High | Intune |
+| [MT.1095](./MT.1095.md) | Android Enterprise Account Connection should be healthy | High | Intune |
+| [MT.1096](./MT.1096.md) | Intune Multi Admin approval should be configured | Medium | Intune |
+| [MT.1097](./MT.1097.md) | Certificate Connectors should be healthy and running supported versions | High | Intune |
+| [MT.1098](./MT.1098.md) | Mobile Threat Defense Connectors should be healthy | Critical | Intune |
+| [MT.1099](./MT.1099.md) | Windows Diagnostic Data Processing should be enabled | Low | Intune |
+| [MT.1100](./MT.1100.md) | Intune Audit Logs should be retained | High | Intune |
+| [MT.1101](./MT.1101.md) | Default Branding Profile should be customized | Low | Intune |
+| [MT.1102](./MT.1102.md) | Windows Feature Update Policy Settings should not reference end of support builds | High | Intune |
+| [MT.1103](./MT.1103.md) | Intune RBAC groups should be protected by Restricted Management Administrative Units or Role Assignable groups | High | Intune |
+| [MT.1105](./MT.1105.md) | MDM Authority should be set to Microsoft Intune | Low | Intune |
+| [MT.1106](./MT.1106.md) | Catalog resources must have valid roles (no stale app roles or deleted SPNs) | Medium | Governance |
+| [MT.1107](./MT.1107.md) | Access packages and catalogs should not reference deleted groups | Medium | Governance |
+| [MT.1108](./MT.1108.md) | Access packages should not have inactive or orphaned assignment policies | Medium | Governance |
+| [MT.1109](./MT.1109.md) | Access package approval workflows must have valid approvers | Medium | Governance |
+| [MT.1110](./MT.1110.md) | No catalog should contain resources without any associated access packages | Medium | Governance |
+| [MT.1111](./MT.1111.md) | High privileged user should be linked to an identity | Low | Privileged |
+| [MT.1112](./MT.1112.md) | Privileged user accounts should not remain enabled when the linked primary account is disabled | Medium | Privileged |
+| [MT.1113](./MT.1113.md) | AI agents should not be shared with broad access control policies | High | AIAgent |
+| [MT.1114](./MT.1114.md) | AI agents should require user authentication | High | AIAgent |
+| [MT.1115](./MT.1115.md) | AI agents should not have risky HTTP configurations | Medium | AIAgent |
+| [MT.1116](./MT.1116.md) | AI agents should not send email with AI-controlled inputs | High | AIAgent |
+| [MT.1117](./MT.1117.md) | Published AI agents should not be dormant | Low | AIAgent |
+| [MT.1118](./MT.1118.md) | AI agents should avoid using author (maker) authentication for tools | Medium | AIAgent |
+| [MT.1119](./MT.1119.md) | AI agents should not have hard-coded credentials in topics | High | AIAgent |
+| [MT.1120](./MT.1120.md) | AI agents should not use MCP server tools without review | Medium | AIAgent |
+| [MT.1121](./MT.1121.md) | AI agents with generative orchestration should have custom instructions | Medium | AIAgent |
+| [MT.1122](./MT.1122.md) | AI agents should not have orphaned ownership | Medium | AIAgent |
+| [MT.1123](./MT.1123.md) | Ensure BitLocker full disk encryption is configured via Intune | High | Intune |
+| [MT.1147](./MT.1147.md) | Do not sync krbtgt_AzureAD to Entra ID | High | Entra |
+| [MT.1148](./MT.1148.md) | Archive Scanning should be enabled | High | Defender |
+| [MT.1149](./MT.1149.md) | Behavior Monitoring should be enabled | High | Defender |
+| [MT.1150](./MT.1150.md) | Cloud Protection should be enabled | High | Defender |
+| [MT.1151](./MT.1151.md) | Email Scanning should be enabled | High | Defender |
+| [MT.1152](./MT.1152.md) | Script Scanning should be enabled | High | Defender |
+| [MT.1153](./MT.1153.md) | Real-time Monitoring should be enabled | High | Defender |
+| [MT.1154](./MT.1154.md) | Full Scan Removable Drives should be enabled | High | Defender |
+| [MT.1155](./MT.1155.md) | Full Scan Mapped Drives should be disabled for performance | High | Defender |
+| [MT.1156](./MT.1156.md) | Scanning Network Files should be enabled | High | Defender |
+| [MT.1157](./MT.1157.md) | CPU Load Factor should be optimized (20-30%) | High | Defender |
+| [MT.1158](./MT.1158.md) | Scan should be scheduled | High | Defender |
+| [MT.1159](./MT.1159.md) | Quick Scan Time configuration is not required | High | Defender |
+| [MT.1160](./MT.1160.md) | Signatures should be checked before scan | High | Defender |
+| [MT.1161](./MT.1161.md) | Cloud Block Level should be High or higher | High | Defender |
+| [MT.1162](./MT.1162.md) | Cloud Extended Timeout should be 30-50 seconds | High | Defender |
+| [MT.1163](./MT.1163.md) | Signature Update Interval should be 1-4 hours | High | Defender |
+| [MT.1164](./MT.1164.md) | PUA Protection should be enabled | High | Defender |
+| [MT.1165](./MT.1165.md) | Network Protection should be enabled | High | Defender |
+| [MT.1166](./MT.1166.md) | Local Admin Merge should be disabled | High | Defender |
+| [MT.1167](./MT.1167.md) | Real-Time Scan Direction should cover both directions | High | Defender |
+| [MT.1168](./MT.1168.md) | Cleaned Malware should be retained for at least 30 days | High | Defender |
+| [MT.1169](./MT.1169.md) | Catch-up Full Scan should be disabled | High | Defender |
+| [MT.1170](./MT.1170.md) | Catch-up Quick Scan should be disabled | High | Defender |
+| [MT.1171](./MT.1171.md) | Sample Submission should send safe samples automatically | High | Defender |

--- a/website/versioned_docs/version-2.1.0/tests/orca/readme.md
+++ b/website/versioned_docs/version-2.1.0/tests/orca/readme.md
@@ -18,70 +18,70 @@ These tests validate Exchange Online security configuration checks from ORCA.
 
 | Test ID | Title | Severity | Category |
 | --- | --- | --- | --- |
-| [ORCA.100](../ORCA.100) | Bulk Complaint Level threshold is between 4 and 6. | Medium | EXO |
-| [ORCA.101](../ORCA.101) | Bulk is marked as spam. | Medium | EXO |
-| [ORCA.102](../ORCA.102) | Advanced Spam filter options are turned off. | Medium | EXO |
-| [ORCA.103](../ORCA.103) | Outbound spam filter policy settings configured. | Medium | EXO |
-| [ORCA.104](../ORCA.104) | High Confidence Phish action set to Quarantine message. | High | EXO |
-| [ORCA.105](../ORCA.105) | Safe Links Synchronous URL detonation is enabled. | Medium | EXO |
-| [ORCA.106](../ORCA.106) | Quarantine retention period is 30 days. | Medium | EXO |
-| [ORCA.107](../ORCA.107) | End-user spam notification is enabled. | Low | EXO |
-| [ORCA.108](../ORCA.108) | DKIM signing is set up for all your custom domains. | Medium | EXO |
-| [ORCA.108.1](../ORCA.108.1) | DNS Records have been set up to support DKIM. | Medium | EXO |
-| [ORCA.109](../ORCA.109) | Senders are not being allow listed in an unsafe manner. | Medium | EXO |
-| [ORCA.110](../ORCA.110) | Internal Sender notifications are disabled. | Medium | EXO |
-| [ORCA.111](../ORCA.111) | Anti-phishing policy exists and EnableUnauthenticatedSender is true. | High | EXO |
-| [ORCA.112](../ORCA.112) | Anti-spoofing protection action is configured to Move message to the recipients' Junk Email folders in Anti-phishing policy. | Medium | EXO |
-| [ORCA.113](../ORCA.113) | AllowClickThrough is disabled in Safe Links policies. | Medium | EXO |
-| [ORCA.114](../ORCA.114) | No IP Allow Lists have been configured. | High | EXO |
-| [ORCA.115](../ORCA.115) | Mailbox intelligence based impersonation protection is enabled in anti-phishing policies. | Medium | EXO |
-| [ORCA.116](../ORCA.116) | Mailbox intelligence based impersonation protection action set to move message to junk mail folder. | Medium | EXO |
-| [ORCA.118.1](../ORCA.118.1) | Domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | High | EXO |
-| [ORCA.118.2](../ORCA.118.2) | Domains are not being allow listed in an unsafe manner in Transport Rules. | High | EXO |
-| [ORCA.118.3](../ORCA.118.3) | Your own domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | Medium | EXO |
-| [ORCA.118.4](../ORCA.118.4) | Your own domains are not being allow listed in an unsafe manner in Transport Rules. | Medium | EXO |
-| [ORCA.119](../ORCA.119) | Similar Domains Safety Tips is enabled. | Info | EXO |
-| [ORCA.120.1](../ORCA.120.1) | Zero Hour Autopurge Enabled for Phish. | Medium | EXO |
-| [ORCA.120.2](../ORCA.120.2) | Zero Hour Autopurge Enabled for Malware. | Medium | EXO |
-| [ORCA.120.3](../ORCA.120.3) | Zero Hour Autopurge Enabled for Spam. | Medium | EXO |
-| [ORCA.121](../ORCA.121) | Supported filter policy action used. | Low | EXO |
-| [ORCA.123](../ORCA.123) | Unusual Characters Safety Tips is enabled. | Info | EXO |
-| [ORCA.124](../ORCA.124) | Safe attachments unknown malware response set to block messages. | High | EXO |
-| [ORCA.139](../ORCA.139) | Spam action set to move message to junk mail folder or quarantine. | Low | EXO |
-| [ORCA.140](../ORCA.140) | High Confidence Spam action set to Quarantine message. | High | EXO |
-| [ORCA.141](../ORCA.141) | Bulk action set to Move message to Junk Email Folder. | Medium | EXO |
-| [ORCA.142](../ORCA.142) | Phish action set to Quarantine message. | Medium | EXO |
-| [ORCA.143](../ORCA.143) | Safety Tips are enabled. | Info | EXO |
-| [ORCA.156](../ORCA.156) | Safe Links Policies are tracking when user clicks on safe links. | Medium | EXO |
-| [ORCA.158](../ORCA.158) | Safe Attachments is enabled for SharePoint and Teams. | Medium | EXO |
-| [ORCA.179](../ORCA.179) | Safe Links is enabled intra-organization. | Medium | EXO |
-| [ORCA.180](../ORCA.180) | Anti-phishing policy exists and EnableSpoofIntelligence is true. | Medium | EXO |
-| [ORCA.189](../ORCA.189) | Safe Attachments is not bypassed. | Medium | EXO |
-| [ORCA.189.2](../ORCA.189.2) | Safe Links is not bypassed. | High | EXO |
-| [ORCA.205](../ORCA.205) | Common attachment type filter is enabled. | Medium | EXO |
-| [ORCA.220](../ORCA.220) | Advanced Phish filter Threshold level is adequate. | Medium | EXO |
-| [ORCA.221](../ORCA.221) | Mailbox intelligence is enabled in anti-phishing policies. | Medium | EXO |
-| [ORCA.222](../ORCA.222) | Domain Impersonation action is set to move to Quarantine. | Medium | EXO |
-| [ORCA.223](../ORCA.223) | User impersonation action is set to move to Quarantine. | High | EXO |
-| [ORCA.224](../ORCA.224) | Similar Users Safety Tips is enabled. | Info | EXO |
-| [ORCA.225](../ORCA.225) | Safe Documents is enabled for Office clients. | Medium | EXO |
-| [ORCA.226](../ORCA.226) | Each domain has a Safe Link policy applied to it. | Medium | EXO |
-| [ORCA.227](../ORCA.227) | Each domain has a Safe Attachments policy applied to it. | Medium | EXO |
-| [ORCA.228](../ORCA.228) | No trusted senders in Anti-phishing policy. | High | EXO |
-| [ORCA.229](../ORCA.229) | No trusted domains in Anti-phishing policy. | Medium | EXO |
-| [ORCA.230](../ORCA.230) | Each domain has a Anti-phishing policy applied to it, or the default policy is being used. | Medium | EXO |
-| [ORCA.231](../ORCA.231) | Each domain has a anti-spam policy applied to it, or the default policy is being used. | Medium | EXO |
-| [ORCA.232](../ORCA.232) | Each domain has a malware filter policy applied to it, or the default policy is being used. | High | EXO |
-| [ORCA.233](../ORCA.233) | Domains are pointed directly at EOP or enhanced filtering is used. | Medium | EXO |
-| [ORCA.233.1](../ORCA.233.1) | Domains are pointed directly at EOP or enhanced filtering is configured on all default connectors. | Medium | EXO |
-| [ORCA.234](../ORCA.234) | Click through is disabled for Safe Documents. | Medium | EXO |
-| [ORCA.235](../ORCA.235) | SPF records is set up for all your custom domains. | Medium | EXO |
-| [ORCA.236](../ORCA.236) | Safe Links is enabled for emails. | Medium | EXO |
-| [ORCA.237](../ORCA.237) | Safe Links is enabled for teams messages. | Medium | EXO |
-| [ORCA.238](../ORCA.238) | Safe Links is enabled for office documents. | Medium | EXO |
-| [ORCA.239](../ORCA.239) | No exclusions for the built-in protection policies. | High | EXO |
-| [ORCA.240](../ORCA.240) | Outlook is configured to display external tags for external emails. | Medium | EXO |
-| [ORCA.241](../ORCA.241) | Anti-phishing policy exists and EnableFirstContactSafetyTips is true. | Medium | EXO |
-| [ORCA.242](../ORCA.242) | Important protection alerts responsible for AIR activities are enabled. | High | EXO |
-| [ORCA.243](../ORCA.243) | Authenticated Receive Chain is set up for domains not pointing to EOP/MDO, or all domains point to EOP/MDO. | Medium | EXO |
-| [ORCA.244](../ORCA.244) | Policies are configured to honor sending domains DMARC. | Medium | EXO |
+| [ORCA.100](./ORCA.100.md) | Bulk Complaint Level threshold is between 4 and 6. | Medium | EXO |
+| [ORCA.101](./ORCA.101.md) | Bulk is marked as spam. | Medium | EXO |
+| [ORCA.102](./ORCA.102.md) | Advanced Spam filter options are turned off. | Medium | EXO |
+| [ORCA.103](./ORCA.103.md) | Outbound spam filter policy settings configured. | Medium | EXO |
+| [ORCA.104](./ORCA.104.md) | High Confidence Phish action set to Quarantine message. | High | EXO |
+| [ORCA.105](./ORCA.105.md) | Safe Links Synchronous URL detonation is enabled. | Medium | EXO |
+| [ORCA.106](./ORCA.106.md) | Quarantine retention period is 30 days. | Medium | EXO |
+| [ORCA.107](./ORCA.107.md) | End-user spam notification is enabled. | Low | EXO |
+| [ORCA.108](./ORCA.108.md) | DKIM signing is set up for all your custom domains. | Medium | EXO |
+| [ORCA.108.1](./ORCA.108.1.md) | DNS Records have been set up to support DKIM. | Medium | EXO |
+| [ORCA.109](./ORCA.109.md) | Senders are not being allow listed in an unsafe manner. | Medium | EXO |
+| [ORCA.110](./ORCA.110.md) | Internal Sender notifications are disabled. | Medium | EXO |
+| [ORCA.111](./ORCA.111.md) | Anti-phishing policy exists and EnableUnauthenticatedSender is true. | High | EXO |
+| [ORCA.112](./ORCA.112.md) | Anti-spoofing protection action is configured to Move message to the recipients' Junk Email folders in Anti-phishing policy. | Medium | EXO |
+| [ORCA.113](./ORCA.113.md) | AllowClickThrough is disabled in Safe Links policies. | Medium | EXO |
+| [ORCA.114](./ORCA.114.md) | No IP Allow Lists have been configured. | High | EXO |
+| [ORCA.115](./ORCA.115.md) | Mailbox intelligence based impersonation protection is enabled in anti-phishing policies. | Medium | EXO |
+| [ORCA.116](./ORCA.116.md) | Mailbox intelligence based impersonation protection action set to move message to junk mail folder. | Medium | EXO |
+| [ORCA.118.1](./ORCA.118.1.md) | Domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | High | EXO |
+| [ORCA.118.2](./ORCA.118.2.md) | Domains are not being allow listed in an unsafe manner in Transport Rules. | High | EXO |
+| [ORCA.118.3](./ORCA.118.3.md) | Your own domains are not being allow listed in an unsafe manner in Anti-Spam Policies. | Medium | EXO |
+| [ORCA.118.4](./ORCA.118.4.md) | Your own domains are not being allow listed in an unsafe manner in Transport Rules. | Medium | EXO |
+| [ORCA.119](./ORCA.119.md) | Similar Domains Safety Tips is enabled. | Info | EXO |
+| [ORCA.120.1](./ORCA.120.1.md) | Zero Hour Autopurge Enabled for Phish. | Medium | EXO |
+| [ORCA.120.2](./ORCA.120.2.md) | Zero Hour Autopurge Enabled for Malware. | Medium | EXO |
+| [ORCA.120.3](./ORCA.120.3.md) | Zero Hour Autopurge Enabled for Spam. | Medium | EXO |
+| [ORCA.121](./ORCA.121.md) | Supported filter policy action used. | Low | EXO |
+| [ORCA.123](./ORCA.123.md) | Unusual Characters Safety Tips is enabled. | Info | EXO |
+| [ORCA.124](./ORCA.124.md) | Safe attachments unknown malware response set to block messages. | High | EXO |
+| [ORCA.139](./ORCA.139.md) | Spam action set to move message to junk mail folder or quarantine. | Low | EXO |
+| [ORCA.140](./ORCA.140.md) | High Confidence Spam action set to Quarantine message. | High | EXO |
+| [ORCA.141](./ORCA.141.md) | Bulk action set to Move message to Junk Email Folder. | Medium | EXO |
+| [ORCA.142](./ORCA.142.md) | Phish action set to Quarantine message. | Medium | EXO |
+| [ORCA.143](./ORCA.143.md) | Safety Tips are enabled. | Info | EXO |
+| [ORCA.156](./ORCA.156.md) | Safe Links Policies are tracking when user clicks on safe links. | Medium | EXO |
+| [ORCA.158](./ORCA.158.md) | Safe Attachments is enabled for SharePoint and Teams. | Medium | EXO |
+| [ORCA.179](./ORCA.179.md) | Safe Links is enabled intra-organization. | Medium | EXO |
+| [ORCA.180](./ORCA.180.md) | Anti-phishing policy exists and EnableSpoofIntelligence is true. | Medium | EXO |
+| [ORCA.189](./ORCA.189.md) | Safe Attachments is not bypassed. | Medium | EXO |
+| [ORCA.189.2](./ORCA.189.2.md) | Safe Links is not bypassed. | High | EXO |
+| [ORCA.205](./ORCA.205.md) | Common attachment type filter is enabled. | Medium | EXO |
+| [ORCA.220](./ORCA.220.md) | Advanced Phish filter Threshold level is adequate. | Medium | EXO |
+| [ORCA.221](./ORCA.221.md) | Mailbox intelligence is enabled in anti-phishing policies. | Medium | EXO |
+| [ORCA.222](./ORCA.222.md) | Domain Impersonation action is set to move to Quarantine. | Medium | EXO |
+| [ORCA.223](./ORCA.223.md) | User impersonation action is set to move to Quarantine. | High | EXO |
+| [ORCA.224](./ORCA.224.md) | Similar Users Safety Tips is enabled. | Info | EXO |
+| [ORCA.225](./ORCA.225.md) | Safe Documents is enabled for Office clients. | Medium | EXO |
+| [ORCA.226](./ORCA.226.md) | Each domain has a Safe Link policy applied to it. | Medium | EXO |
+| [ORCA.227](./ORCA.227.md) | Each domain has a Safe Attachments policy applied to it. | Medium | EXO |
+| [ORCA.228](./ORCA.228.md) | No trusted senders in Anti-phishing policy. | High | EXO |
+| [ORCA.229](./ORCA.229.md) | No trusted domains in Anti-phishing policy. | Medium | EXO |
+| [ORCA.230](./ORCA.230.md) | Each domain has a Anti-phishing policy applied to it, or the default policy is being used. | Medium | EXO |
+| [ORCA.231](./ORCA.231.md) | Each domain has a anti-spam policy applied to it, or the default policy is being used. | Medium | EXO |
+| [ORCA.232](./ORCA.232.md) | Each domain has a malware filter policy applied to it, or the default policy is being used. | High | EXO |
+| [ORCA.233](./ORCA.233.md) | Domains are pointed directly at EOP or enhanced filtering is used. | Medium | EXO |
+| [ORCA.233.1](./ORCA.233.1.md) | Domains are pointed directly at EOP or enhanced filtering is configured on all default connectors. | Medium | EXO |
+| [ORCA.234](./ORCA.234.md) | Click through is disabled for Safe Documents. | Medium | EXO |
+| [ORCA.235](./ORCA.235.md) | SPF records is set up for all your custom domains. | Medium | EXO |
+| [ORCA.236](./ORCA.236.md) | Safe Links is enabled for emails. | Medium | EXO |
+| [ORCA.237](./ORCA.237.md) | Safe Links is enabled for teams messages. | Medium | EXO |
+| [ORCA.238](./ORCA.238.md) | Safe Links is enabled for office documents. | Medium | EXO |
+| [ORCA.239](./ORCA.239.md) | No exclusions for the built-in protection policies. | High | EXO |
+| [ORCA.240](./ORCA.240.md) | Outlook is configured to display external tags for external emails. | Medium | EXO |
+| [ORCA.241](./ORCA.241.md) | Anti-phishing policy exists and EnableFirstContactSafetyTips is true. | Medium | EXO |
+| [ORCA.242](./ORCA.242.md) | Important protection alerts responsible for AIR activities are enabled. | High | EXO |
+| [ORCA.243](./ORCA.243.md) | Authenticated Receive Chain is set up for domains not pointing to EOP/MDO, or all domains point to EOP/MDO. | Medium | EXO |
+| [ORCA.244](./ORCA.244.md) | Policies are configured to honor sending domains DMARC. | Medium | EXO |


### PR DESCRIPTION
## What changed

- Generate suite index links using their actual Markdown source paths (`./<test-id>.md`).
- Update the current and v2.1.0 suite indexes for Maester, EIDSCA, CISA, CIS, and ORCA.

## Why

Suite index links were emitted as extensionless parent-relative URLs such as `../EIDSCA.AF01`. When a suite page was reached through client-side navigation without a trailing slash, the browser resolved those links one directory too high (for example, `/docs/EIDSCA.AF01` instead of `/docs/tests/EIDSCA.AF01`), resulting in a 404.

Including the Markdown extension lets Docusaurus resolve each source document to the correct absolute, version-aware permalink during compilation, independent of trailing-slash behavior.

## Impact

Individual test links from all generated suite overview pages now open the correct test documentation. This fixes the reported EIDSCA and ORCA failures and prevents the same issue in the other suites.

## Validation

- Reproduced the production failures for EIDSCA.AF01 and ORCA.100 before the change.
- Verified end-to-end local navigation from `/docs/tests/eidsca` to `/docs/tests/EIDSCA.AF01`.
- Verified end-to-end local navigation from `/docs/tests/orca` to `/docs/tests/ORCA.100`.
- Verified all 748 current and v2.1.0 suite-index link targets exist.
- Verified the generator parses successfully with `node --check`.
- Docusaurus client and server compilation completed successfully. Full static generation still encounters the existing unrelated command-overview `useDocsSidebar` context error on `/docs/commands/` and `/docs/next/commands/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed test index links across current and versioned documentation.
  * Test entries now correctly open their corresponding Markdown detail pages.
  * Updated links for CIS, CISA, EIDSCA, Maester, and ORCA test suites.
  * Preserved existing test IDs, titles, severities, and categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->