### PR TITLE
fix(exchange): handle missing DKIM signing configurations

### DIFF
--- a/powershell/public/cis/Test-MtCisDkim.ps1
+++ b/powershell/public/cis/Test-MtCisDkim.ps1
@@ -1,4 +1,4 @@
-function Test-MtCisDkim {
+﻿function Test-MtCisDkim {
     <#
     .SYNOPSIS
     Checks state of DKIM for all EXO domains
@@ -45,8 +45,8 @@ function Test-MtCisDkim {
             if (-not $dkimSigningConfig) {
                 $dkimRecord = [PSCustomObject]@{
                     domain     = $domain.DomainName
-                    pass       = if ($domain.SendingFromDomainDisabled) { 'Skipped' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Passed' } else { 'Failed' }
-                    reason     = if ($domain.SendingFromDomainDisabled) { 'Parked domain' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Microsoft auto-signs DKIM for onmicrosoft.com domains' } else { 'No DkimSigningConfig found for domain' }
+                    pass       = if ($domain.SendingFromDomainDisabled) { 'Skipped' } elseif ($domain.InitialDomain -eq $true) { 'Passed' } else { 'Failed' }
+                    reason     = if ($domain.SendingFromDomainDisabled) { 'Parked domain' } elseif ($domain.InitialDomain -eq $true) { 'Microsoft auto-signs DKIM for the initial onmicrosoft.com domain' } else { 'No DkimSigningConfig found for domain' }
                     dkimRecord = $null
                 }
                 $dkimRecords += $dkimRecord

--- a/powershell/public/cis/Test-MtCisDkim.ps1
+++ b/powershell/public/cis/Test-MtCisDkim.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtCisDkim {
+function Test-MtCisDkim {
     <#
     .SYNOPSIS
     Checks state of DKIM for all EXO domains
@@ -40,6 +40,17 @@
         foreach ($domain in $acceptedDomains) {
             $dkimSigningConfig = $dkimSigningConfigs | Where-Object {
                 $_.domain -eq $domain.domainname
+            }
+
+            if (-not $dkimSigningConfig) {
+                $dkimRecord = [PSCustomObject]@{
+                    domain     = $domain.DomainName
+                    pass       = if ($domain.SendingFromDomainDisabled) { 'Skipped' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Passed' } else { 'Failed' }
+                    reason     = if ($domain.SendingFromDomainDisabled) { 'Parked domain' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Microsoft auto-signs DKIM for onmicrosoft.com domains' } else { 'No DkimSigningConfig found for domain' }
+                    dkimRecord = $null
+                }
+                $dkimRecords += $dkimRecord
+                continue
             }
 
             if ((Get-Date) -gt $dkimSigningConfig.RotateOnDate) {

--- a/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtCisaDkim {
+function Test-MtCisaDkim {
     <#
     .SYNOPSIS
     Checks state of DKIM for all EXO domains
@@ -39,6 +39,17 @@
         foreach ($domain in $acceptedDomains) {
             $dkimSigningConfig = $dkimSigningConfigs | Where-Object {`
                     $_.domain -eq $domain.domainname
+            }
+
+            if (-not $dkimSigningConfig) {
+                $dkimRecord = [PSCustomObject]@{
+                    domain     = $domain.DomainName
+                    pass       = if ($domain.SendingFromDomainDisabled) { 'Skipped' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Passed' } else { 'Failed' }
+                    reason     = if ($domain.SendingFromDomainDisabled) { 'Parked domain' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Microsoft auto-signs DKIM for onmicrosoft.com domains' } else { 'No DkimSigningConfig found for domain' }
+                    dkimRecord = $null
+                }
+                $dkimRecords += $dkimRecord
+                continue
             }
             if ((Get-Date) -gt $dkimSigningConfig.RotateOnDate) {
                 if ($Selector -ne $dkimSigningConfig.SelectorAfterRotateOnDate) {

--- a/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
+++ b/powershell/public/cisa/exchange/Test-MtCisaDkim.ps1
@@ -1,4 +1,4 @@
-function Test-MtCisaDkim {
+﻿function Test-MtCisaDkim {
     <#
     .SYNOPSIS
     Checks state of DKIM for all EXO domains
@@ -44,8 +44,8 @@ function Test-MtCisaDkim {
             if (-not $dkimSigningConfig) {
                 $dkimRecord = [PSCustomObject]@{
                     domain     = $domain.DomainName
-                    pass       = if ($domain.SendingFromDomainDisabled) { 'Skipped' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Passed' } else { 'Failed' }
-                    reason     = if ($domain.SendingFromDomainDisabled) { 'Parked domain' } elseif ($domain.DomainName -like '*.onmicrosoft.com') { 'Microsoft auto-signs DKIM for onmicrosoft.com domains' } else { 'No DkimSigningConfig found for domain' }
+                    pass       = if ($domain.SendingFromDomainDisabled) { 'Skipped' } elseif ($domain.InitialDomain -eq $true) { 'Passed' } else { 'Failed' }
+                    reason     = if ($domain.SendingFromDomainDisabled) { 'Parked domain' } elseif ($domain.InitialDomain -eq $true) { 'Microsoft auto-signs DKIM for the initial onmicrosoft.com domain' } else { 'No DkimSigningConfig found for domain' }
                     dkimRecord = $null
                 }
                 $dkimRecords += $dkimRecord

--- a/powershell/tests/functions/Test-MtDkim.Tests.ps1
+++ b/powershell/tests/functions/Test-MtDkim.Tests.ps1
@@ -14,37 +14,75 @@ Describe 'DKIM checks with no signing configuration' -ForEach @(
         }
     }
 
-    It '<CommandName> passes the initial onmicrosoft.com domain' {
+    It '<CommandName> returns <ExpectedOutcome> for <DomainName>' -ForEach @(
+        @{
+            DomainName                = 'contoso.onmicrosoft.com'
+            InitialDomain             = $true
+            IsCoexistenceDomain       = $false
+            SendingFromDomainDisabled = $false
+            ExpectedOutcome           = 'passed'
+            ExpectedResult            = $true
+        }
+        @{
+            DomainName                = 'secondary.onmicrosoft.com'
+            InitialDomain             = $false
+            IsCoexistenceDomain       = $false
+            SendingFromDomainDisabled = $false
+            ExpectedOutcome           = 'failed'
+            ExpectedResult            = $false
+        }
+        @{
+            DomainName                = 'parked.example'
+            InitialDomain             = $false
+            IsCoexistenceDomain       = $false
+            SendingFromDomainDisabled = $true
+            ExpectedOutcome           = 'skipped'
+            ExpectedResult            = $null
+        }
+        @{
+            DomainName                = 'contoso.mail.onmicrosoft.com'
+            InitialDomain             = $false
+            IsCoexistenceDomain       = $true
+            SendingFromDomainDisabled = $false
+            ExpectedOutcome           = 'failed'
+            ExpectedResult            = $false
+        }
+        @{
+            DomainName                = 'contoso.mail.onmicrosoft.com'
+            InitialDomain             = $false
+            IsCoexistenceDomain       = $true
+            SendingFromDomainDisabled = $true
+            ExpectedOutcome           = 'skipped'
+            ExpectedResult            = $null
+        }
+        @{
+            DomainName                = 'contoso.com'
+            InitialDomain             = $false
+            IsCoexistenceDomain       = $false
+            SendingFromDomainDisabled = $false
+            ExpectedOutcome           = 'failed'
+            ExpectedResult            = $false
+        }
+    ) {
         Mock -ModuleName Maester Get-MtExo {
             if ($Request -eq 'AcceptedDomain') {
                 return [PSCustomObject]@{
-                    DomainName               = 'contoso.onmicrosoft.com'
-                    InitialDomain            = $true
-                    SendingFromDomainDisabled = $false
+                    DomainName                = $DomainName
+                    InitialDomain             = $InitialDomain
+                    IsCoexistenceDomain       = $IsCoexistenceDomain
+                    SendingFromDomainDisabled = $SendingFromDomainDisabled
                 }
             }
 
             return @()
         }
 
-        & $CommandName | Should -BeTrue
-        Should -Invoke Get-MailAuthenticationRecord -ModuleName Maester -Exactly 0
-    }
-
-    It '<CommandName> fails a secondary onmicrosoft.com domain' {
-        Mock -ModuleName Maester Get-MtExo {
-            if ($Request -eq 'AcceptedDomain') {
-                return [PSCustomObject]@{
-                    DomainName               = 'secondary.onmicrosoft.com'
-                    InitialDomain            = $false
-                    SendingFromDomainDisabled = $false
-                }
-            }
-
-            return @()
+        $result = & $CommandName
+        if ($null -eq $ExpectedResult) {
+            $result | Should -BeNullOrEmpty
+        } else {
+            $result | Should -Be $ExpectedResult
         }
-
-        & $CommandName | Should -BeFalse
         Should -Invoke Get-MailAuthenticationRecord -ModuleName Maester -Exactly 0
     }
 }

--- a/powershell/tests/functions/Test-MtDkim.Tests.ps1
+++ b/powershell/tests/functions/Test-MtDkim.Tests.ps1
@@ -1,0 +1,50 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../../Maester.psd1" -Force
+}
+
+Describe 'DKIM checks with no signing configuration' -ForEach @(
+    @{ CommandName = 'Test-MtCisDkim' }
+    @{ CommandName = 'Test-MtCisaDkim' }
+) {
+    BeforeEach {
+        Mock -ModuleName Maester Test-MtConnection { return $true }
+        Mock -ModuleName Maester Add-MtTestResultDetail { }
+        Mock -ModuleName Maester Get-MailAuthenticationRecord {
+            throw 'DNS lookup should not be attempted without a DKIM signing configuration'
+        }
+    }
+
+    It '<CommandName> passes the initial onmicrosoft.com domain' {
+        Mock -ModuleName Maester Get-MtExo {
+            if ($Request -eq 'AcceptedDomain') {
+                return [PSCustomObject]@{
+                    DomainName               = 'contoso.onmicrosoft.com'
+                    InitialDomain            = $true
+                    SendingFromDomainDisabled = $false
+                }
+            }
+
+            return @()
+        }
+
+        & $CommandName | Should -BeTrue
+        Should -Invoke Get-MailAuthenticationRecord -ModuleName Maester -Exactly 0
+    }
+
+    It '<CommandName> fails a secondary onmicrosoft.com domain' {
+        Mock -ModuleName Maester Get-MtExo {
+            if ($Request -eq 'AcceptedDomain') {
+                return [PSCustomObject]@{
+                    DomainName               = 'secondary.onmicrosoft.com'
+                    InitialDomain            = $false
+                    SendingFromDomainDisabled = $false
+                }
+            }
+
+            return @()
+        }
+
+        & $CommandName | Should -BeFalse
+        Should -Invoke Get-MailAuthenticationRecord -ModuleName Maester -Exactly 0
+    }
+}

--- a/website/contributors/contributors.yml
+++ b/website/contributors/contributors.yml
@@ -30,6 +30,12 @@ alexandair:
   name: Aleksandar Nikolić
   title: Microsoft MVP
 
+amlhive-tech:
+  name: Haris Habib
+  company: AMLHIVE
+  emails:
+    - tech@amlhive.com.au
+
 amandaw33:
 
 andremieth:


### PR DESCRIPTION
## Description

Closes #1783.

`Test-MtCisDkim` and `Test-MtCisaDkim` previously continued into selector and DNS processing when an accepted domain had no matching `DkimSigningConfig`. This caused an exception and left the Maester result without a useful domain-level outcome.

This update:

- skips domains where outbound sending is disabled;
- passes the tenant's `InitialDomain`, which Microsoft automatically DKIM-signs;
- fails active secondary `onmicrosoft.com`, hybrid, and custom domains when their DKIM configuration is missing;
- avoids selector rotation and DNS lookups when no signing configuration exists;
- adds focused regression coverage for every outcome in both DKIM checks; and
- adds Haris Habib (AMLHIVE) to the contributor registry.

## Impact

Tenants with an unlisted initial `onmicrosoft.com` domain no longer receive an ignored result caused by an exception. Other active domains are not incorrectly reported as DKIM compliant merely because their names end in `onmicrosoft.com`.

## Checks

- [x] Pester: 12 focused DKIM tests passed
- [x] PSScriptAnalyzer passed for the changed files
- [x] `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DKIM validation for accepted domains without matching signing configurations.
  * Reports parked domains as skipped, Microsoft-managed domains as passed, and other unmatched domains as failed with clear reasons.
  * Avoids unnecessary selector rotation and DNS checks when no signing configuration exists.
  * Provides consistent handling across CIS and CISA DKIM checks.

* **Tests**
  * Added coverage for DKIM outcomes across supported domain states.

* **Chores**
  * Added a new contributor to the project registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->