### PR TITLE
Automate generated contributor updates

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -162,14 +162,6 @@ jobs:
         working-directory: ${{ inputs.working_directory || 'website' }}
         run: npm ci
 
-      - name: Check generated test docs and contributor attribution
-        working-directory: ${{ inputs.working_directory || 'website' }}
-        env:
-          # Contributor attribution is history-derived, so stale generated
-          # docs would otherwise leave shallow-clone deployments on the old snapshot.
-          GH_TOKEN: ${{ github.token }}
-        run: npm run check-test-docs
-
       - name: "\U0001F3D7️ Build website"
         working-directory: ${{ inputs.working_directory || 'website' }}
         env:

--- a/.github/workflows/update-test-docs.yaml
+++ b/.github/workflows/update-test-docs.yaml
@@ -1,0 +1,78 @@
+# Regenerates test documentation and contributor attribution after source changes.
+name: Update generated test docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - "powershell/**"
+      - "tests/**"
+      - "website/contributors/attribution-overrides.yml"
+      - "website/contributors/contributors.yml"
+      - "website/scripts/contributors.mjs"
+      - "website/scripts/generate-test-docs.mjs"
+      - ".github/workflows/update-test-docs.yaml"
+
+permissions: {}
+
+concurrency:
+  group: update-generated-test-docs
+  cancel-in-progress: false
+
+jobs:
+  update-generated-test-docs:
+    name: Update generated test docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: "npm"
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Generate test docs and contributor attribution
+        working-directory: website
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: npm run generate-test-docs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: automation/update-test-docs
+          delete-branch: true
+          commit-message: Update generated test docs
+          title: Update generated test docs and contributor attribution
+          body: |
+            Automated refresh of generated test documentation and contributor attribution.
+
+            Source changes are derived from the full git history by `website/scripts/generate-test-docs.mjs`.
+          add-paths: |
+            website/contributors/email-aliases.json
+            website/docs/tests
+            website/src/data/contributors.json


### PR DESCRIPTION
## Summary

- stop requiring contributor PR authors to regenerate and commit derived website files
- add a post-merge workflow that regenerates test docs and contributor attribution from full git history
- open a focused `maester-bot` PR containing only the generated outputs

## Root cause

PRs #2005 and #2006 updated `website/contributors/contributors.yml`, but the committed `website/src/data/contributors.json` snapshot did not change. Their Website workflow runs failed at `npm run check-test-docs` because that check required each contributor PR to commit the derived snapshot.

The PRs were merged despite that non-required failure. The production builder then continued using the unchanged snapshot, so neither profile enrichment appeared on the site.

## Behavior after this change

Changes to contributor metadata, attribution inputs, test sources, or the generator trigger the new workflow after merge to `main`. It:

1. checks out full history;
2. runs `npm run generate-test-docs`;
3. opens or updates `automation/update-test-docs` with only generated test docs, the contributor snapshot, and any generated email aliases.

The workflow includes its own path, so merging this PR triggers the first refresh for #2005 and #2006 without committing generated site files here.

## Validation

- parsed both workflow YAML files
- `git diff --check`
- reproduced the workflow generation in a clean temporary clone of current `main`
- confirmed generation changes only `website/src/data/contributors.json` and includes both Mynster and Christopher Brumm profile enrichment

This PR changes GitHub workflows only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflows to regenerate test documentation and contributor attribution after relevant changes.
  * The workflow can run manually or automatically after updates to source, tests, or documentation-related files.
  * Generated updates are submitted as a pull request for review.
  * Simplified website builds by removing the test documentation verification step from the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->