### PR TITLE
Add verbose logging to GSA checks

### DIFF
--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaBaselineThreatIntelligenceEnforced.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaBaselineThreatIntelligenceEnforced.ps1
@@ -22,6 +22,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaBaselineThreatIntelligenceEnforced..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaCompliantNetworkBreakGlassExcluded.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaCompliantNetworkBreakGlassExcluded.ps1
@@ -24,6 +24,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaCompliantNetworkBreakGlassExcluded..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaForwardingProfileAssignmentNotNested.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaForwardingProfileAssignmentNotNested.ps1
@@ -25,6 +25,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaForwardingProfileAssignmentNotNested..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaM365ProfileEnabled.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaM365ProfileEnabled.ps1
@@ -25,6 +25,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaM365ProfileEnabled..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppAssignmentNotNested.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppAssignmentNotNested.ps1
@@ -25,6 +25,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaPrivateAccessAppAssignmentNotNested..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppCompliantDevice.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppCompliantDevice.ps1
@@ -25,6 +25,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaPrivateAccessAppCompliantDevice..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppNotOnDefaultConnectorGroup.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppNotOnDefaultConnectorGroup.ps1
@@ -22,6 +22,8 @@
     [OutputType([bool])]
     param ()
 
+    Write-Verbose "Running Test-MtGsaPrivateAccessAppNotOnDefaultConnectorGroup..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppSegmentHygiene.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaPrivateAccessAppSegmentHygiene.ps1
@@ -36,6 +36,8 @@
         [int] $BroadIPv4MaskThreshold = 16
     )
 
+    Write-Verbose "Running Test-MtGsaPrivateAccessAppSegmentHygiene..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null

--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaQuickAccessNoSignInFrequency.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaQuickAccessNoSignInFrequency.ps1
@@ -43,6 +43,8 @@ function Test-MtGsaQuickAccessNoSignInFrequency {
         [string[]] $AllowedPolicies
     )
 
+    Write-Verbose "Running Test-MtGsaQuickAccessNoSignInFrequency..."
+
     if (!(Test-MtConnection Graph)) {
         Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
         return $null


### PR DESCRIPTION
## What changed

Added standard entry-point `Write-Verbose` diagnostics to nine Global Secure Access check functions.

## Why

The functions did not contain any verbose logging, causing the common public-function quality test to fail for each function. The added messages also make it clear which GSA check is running during troubleshooting.

## Impact

No check evaluation logic or output changes. The functions now satisfy the public-function logging convention and emit a diagnostic when invoked with `-Verbose`.

## Validation

- `git diff --check`
- `pwsh -NoProfile -File ./powershell/tests/pester.ps1 -TestGeneral:$false -TestFunctions:$true -Include Common.Tests.ps1 -Output Detailed`
  - 4,266 tests executed
  - 3,475 passed
  - 791 skipped
  - 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added startup verbose messages to Global Secure Access compliance checks.
  * Users can now better track when each check begins during execution.

* **Unchanged Behavior**
  * Existing connectivity, licensing, policy, assignment, and configuration validations continue to operate as before.
  * Results, error handling, and skip behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->