### PR TITLE
Fix MT.1020 role ID parameter binding

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
+++ b/powershell/public/maester/entra/Test-MtCaExclusionForDirectorySyncAccount.ps1
@@ -32,13 +32,17 @@
         $OnPremisesDirectorySyncAccountRole = Get-MtRoleInfo -RoleName 'OnPremisesDirectorySyncAccount'
 
         $Members = @()
+        $DirectorySynchronizationAccountsRoleId = $null
+        $OnPremisesDirectorySyncAccountRoleId = $null
         # Guard: Get-MtRoleInfo returns $null when $script:MtRoles is uninitialised (module reload issue).
         # Skip the Get-MtRoleMember call in that case to avoid a mandatory-parameter binding error.
         if ($null -ne $DirectorySynchronizationAccountsRole) {
-            $Members += Get-MtRoleMember -RoleId $DirectorySynchronizationAccountsRole
+            $DirectorySynchronizationAccountsRoleId = $DirectorySynchronizationAccountsRole.Id
+            $Members += Get-MtRoleMember -RoleId $DirectorySynchronizationAccountsRoleId
         }
         if ($null -ne $OnPremisesDirectorySyncAccountRole) {
-            $Members += Get-MtRoleMember -RoleId $OnPremisesDirectorySyncAccountRole
+            $OnPremisesDirectorySyncAccountRoleId = $OnPremisesDirectorySyncAccountRole.Id
+            $Members += Get-MtRoleMember -RoleId $OnPremisesDirectorySyncAccountRoleId
         }
         $Members = @($Members | Where-Object { $null -ne $_ })
 
@@ -104,7 +108,7 @@
                 }
             }
 
-            if ( $DirectorySynchronizationAccountsRole -in $policy.conditions.users.includeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.includeRoles ) {
+            if ( $DirectorySynchronizationAccountsRoleId -in $policy.conditions.users.includeRoles -or $OnPremisesDirectorySyncAccountRoleId -in $policy.conditions.users.includeRoles ) {
                 $PolicyIncludesRole = $true
             }
 
@@ -120,7 +124,7 @@
                 continue
             } else {
                 # Check if excluded by role
-                $excludedByRole = $DirectorySynchronizationAccountsRole -in $policy.conditions.users.excludeRoles -or $OnPremisesDirectorySyncAccountRole -in $policy.conditions.users.excludeRoles
+                $excludedByRole = $DirectorySynchronizationAccountsRoleId -in $policy.conditions.users.excludeRoles -or $OnPremisesDirectorySyncAccountRoleId -in $policy.conditions.users.excludeRoles
 
                 # Check if all user members are individually excluded
                 $excludedByMember = $memberIds.Count -gt 0 -and @($memberIds | Where-Object { $_ -notin $policy.conditions.users.excludeUsers }).Count -eq 0

--- a/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaExclusionForDirectorySyncAccount.Tests.ps1
@@ -64,12 +64,16 @@
             }
         }
 
-        # Default mock: Get-MtRoleInfo returns the correct GUIDs by role name
+        # Default mock: Get-MtRoleInfo returns role-definition objects, matching the real command.
         Mock -ModuleName Maester Get-MtRoleInfo {
             param($RoleName)
             switch ($RoleName) {
-                'DirectorySynchronizationAccounts' { return $script:DirSyncRoleId }
-                'OnPremisesDirectorySyncAccount' { return $script:OnPremRoleId }
+                'DirectorySynchronizationAccounts' {
+                    return [PSCustomObject]@{ Id = $script:DirSyncRoleId; IsPrivileged = $false }
+                }
+                'OnPremisesDirectorySyncAccount' {
+                    return [PSCustomObject]@{ Id = $script:OnPremRoleId; IsPrivileged = $false }
+                }
             }
         }
     }
@@ -84,6 +88,19 @@
             Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return @() }
 
             Test-MtCaExclusionForDirectorySyncAccount | Should -BeTrue
+        }
+
+        It 'Should pass role GUIDs rather than role-definition objects to Get-MtRoleMember' {
+            Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return @() }
+
+            Test-MtCaExclusionForDirectorySyncAccount
+
+            Should -Invoke Get-MtRoleMember -ModuleName Maester -Times 1 -Exactly -ParameterFilter {
+                "$RoleId" -eq 'd29b2b05-8046-44ba-8758-1e26182fcf32'
+            }
+            Should -Invoke Get-MtRoleMember -ModuleName Maester -Times 1 -Exactly -ParameterFilter {
+                "$RoleId" -eq 'a92aed5d-d78a-4d16-b381-09adb37eb3b0'
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- pass role template GUIDs to `Get-MtRoleMember -RoleId` in MT.1020
- use the extracted GUIDs when checking Conditional Access included and excluded roles
- update the MT.1020 mocks to match the real `MtRoleDefinition` return type
- add regression assertions that both synchronization role GUIDs are passed to `Get-MtRoleMember`

## Root cause

`Get-MtRoleInfo` returns an `MtRoleDefinition` object, but MT.1020 passed the entire object to the `[guid[]]` `RoleId` parameter. PowerShell could not transform the object into a GUID, so the test was skipped with an argument-transformation error instead of evaluating Conditional Access policies.

## Impact

MT.1020 can resolve Directory Synchronization Accounts and On-Premises Directory Sync Account role members again, and its role include/exclude comparisons now use the actual template IDs.

## Validation

- Full PowerShell test suite: 10,225 passed, 0 failed
- Focused MT.1020 suite: 19 passed, 0 failed
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional access policy validation for directory synchronization accounts.
  * Ensured directory synchronization role identifiers are correctly used when checking role membership and policy exclusions.

* **Tests**
  * Added coverage confirming role membership checks use the expected role identifiers.
  * Updated test scenarios to better reflect real-world role information responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->