### PR TITLE
Handle missing hunting tables in MT.1084

### DIFF
--- a/powershell/public/maester/entra/Test-MtEntraIDConnectSsso.ps1
+++ b/powershell/public/maester/entra/Test-MtEntraIDConnectSsso.ps1
@@ -60,8 +60,26 @@
         $DeviceInfoAvailable = ((Invoke-MtGraphRequest @params).results.ColumnName -contains "DeviceId")
         $UnifiedMdiInfoAvailable = $IdentityLogonEventsAvailable -and $DeviceInfoAvailable
     } catch {
-        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
-        return $null
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($null -eq $statusCode) {
+            $statusCode = $_.Exception.StatusCode.value__
+        }
+        $errorText = @(
+            $_.Exception.Message
+            $_.ErrorDetails.Message
+            $_.ToString()
+        ) -join "`n"
+        $isMissingHuntingTable = (
+            ($statusCode -eq 400 -or $errorText -match '\b400 Bad Request\b') -and
+            $errorText -match "Failed to resolve table or column expression named '(IdentityLogonEvents|DeviceInfo)'"
+        )
+
+        if ($isMissingHuntingTable) {
+            $UnifiedMdiInfoAvailable = $false
+        } else {
+            Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+            return $null
+        }
     }
 
     if ( $UnifiedMdiInfoAvailable -eq $false) {

--- a/powershell/tests/functions/Test-MtEntraIDConnectSsso.Tests.ps1
+++ b/powershell/tests/functions/Test-MtEntraIDConnectSsso.Tests.ps1
@@ -1,0 +1,56 @@
+﻿Describe 'Test-MtEntraIDConnectSsso' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../Maester.psd1 -Force
+    }
+
+    BeforeEach {
+        $script:SkippedBecause = $null
+        $script:SkippedCustomReason = $null
+
+        Mock -ModuleName Maester Test-MtConnection { return $true }
+        Mock -ModuleName Maester Add-MtTestResultDetail {
+            param($SkippedBecause, $SkippedCustomReason)
+            $script:SkippedBecause = $SkippedBecause
+            $script:SkippedCustomReason = $SkippedCustomReason
+        }
+    }
+
+    It 'skips when the DeviceInfo hunting table is unavailable' {
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri, $Body)
+
+            if ($RelativeUri -eq 'organization') {
+                return [PSCustomObject]@{ onPremisesSyncEnabled = $true }
+            }
+            if ($Body -match 'IdentityLogonEvents') {
+                return [PSCustomObject]@{
+                    results = @([PSCustomObject]@{ ColumnName = 'LogonType' })
+                }
+            }
+            if ($Body -match 'DeviceInfo') {
+                throw "POST https://graph.microsoft.com/beta/security/runHuntingQuery HTTP/1.1 400 Bad Request: 'getschema' operator: Failed to resolve table or column expression named 'DeviceInfo'."
+            }
+        }
+
+        Test-MtEntraIDConnectSsso | Should -BeNull
+        $script:SkippedBecause | Should -Be 'Custom'
+        $script:SkippedCustomReason | Should -BeLike '*IdentityLogonEvents and DeviceInfo*'
+    }
+
+    It 'keeps unrelated bad requests classified as errors' {
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri, $Body)
+
+            if ($RelativeUri -eq 'organization') {
+                return [PSCustomObject]@{ onPremisesSyncEnabled = $true }
+            }
+            if ($Body -match 'IdentityLogonEvents') {
+                throw 'POST https://graph.microsoft.com/beta/security/runHuntingQuery HTTP/1.1 400 Bad Request: The query is invalid for another reason.'
+            }
+        }
+
+        Test-MtEntraIDConnectSsso | Should -BeNull
+        $script:SkippedBecause | Should -Be 'Error'
+        $script:SkippedCustomReason | Should -BeNull
+    }
+}


### PR DESCRIPTION
## What changed

- Treat the Defender XDR HTTP 400 response for an unavailable `IdentityLogonEvents` or `DeviceInfo` hunting table as a missing prerequisite.
- Reuse MT.1084's existing custom skip result when those tables are unavailable.
- Keep unrelated HTTP 400 responses classified as test errors.
- Add regression tests covering both outcomes.

## Why

MT.1084 probes the Defender XDR Advanced Hunting schema before running its Seamless SSO query. When `DeviceInfo` is not available, Graph returns a semantic-query HTTP 400 instead of an empty schema response. The existing generic catch classified that expected missing prerequisite as an error, so the intended skip path was never reached.

## Impact

Tenants without the required Defender for Identity or Defender for Endpoint hunting data will now see MT.1084 skipped with its prerequisite explanation. Authentication, permission, service, and unrelated query failures continue to surface as errors.

## Validation

- Focused Pester tests: 2 passed
- PSScriptAnalyzer: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable Microsoft Defender XDR hunting data sources.
  * Tests now skip with a clear explanation when required tables or columns are unavailable, while unrelated query failures continue to be reported as errors.

* **Tests**
  * Added coverage for missing hunting tables and unrelated schema query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->