### PR TITLE
Fix docs version auto-commit paths

### DIFF
--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -90,8 +90,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v5
         with:
           commit_message: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
-          file_pattern: |
-            build/Update-WebsiteReleaseVersion.mjs
+          file_pattern: >-
             website/docusaurus.config.js
             website/version-config.js
             website/versions.json

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -90,8 +90,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v5
         with:
           commit_message: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
-          file_pattern: |
-            build/Update-WebsiteReleaseVersion.mjs
+          file_pattern: >-
             website/docusaurus.config.js
             website/version-config.js
             website/versions.json

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -46,8 +46,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v5
         with:
           commit_message: 'ci(docs): update website release version ${{ inputs.version }}'
-          file_pattern: |
-            build/Update-WebsiteReleaseVersion.mjs
+          file_pattern: >-
             website/docusaurus.config.js
             website/version-config.js
             website/versions.json


### PR DESCRIPTION
## Summary

- Fold the generated documentation path list into a single space-separated `file_pattern` value.
- Apply the fix to the standard module release, manual-version release, and standalone versioned-docs workflows.
- Remove the unchanged version-update script from the auto-commit path list.

## Why

The Maester 2.2.0 release successfully generated a Docusaurus 2.2.0 snapshot, but the pinned auto-commit action only read the first line of the literal YAML block. Because that first path was an unchanged script, it reported a clean working tree and committed none of the generated documentation.

## Impact

The standalone versioned-docs workflow can now commit the 2.2.0 snapshot, and future module releases will publish their versioned documentation automatically.

## Validation

- Parsed all three workflow files and confirmed `file_pattern` resolves to a single line with no embedded newline.
- Simulated the pinned auto-commit action's path expansion against generated 2.2.0 documentation and confirmed it detects the generated changes.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated website release commits to reliably include all updated version files and versioned documentation assets.
  * Ensured release workflows consistently track configuration, version metadata, versioned documentation, and navigation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->