### PR TITLE
Open PRs for versioned docs updates

### DIFF
--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -31,9 +31,20 @@ jobs:
       actions: read
 
     steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Download updated report template
         if: needs.build-report.outputs.report-updated == 'true'
@@ -86,11 +97,18 @@ jobs:
       - name: Update website release version
         run: node ./build/Update-WebsiteReleaseVersion.mjs ${{ steps.moduleversion.outputs.tag }}
 
-      - name: Commit website release version
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v5
+      - name: Create website release version pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit_message: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
-          file_pattern: >-
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
+          branch: 'automation/versioned-docs-${{ steps.moduleversion.outputs.tag }}'
+          base: main
+          delete-branch: true
+          title: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
+          body: |
+            Automated versioned documentation update for Maester ${{ steps.moduleversion.outputs.tag }}.
+          add-paths: |
             website/docusaurus.config.js
             website/version-config.js
             website/versions.json

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -31,9 +31,20 @@ jobs:
       actions: read
 
     steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Download updated report template
         if: needs.build-report.outputs.report-updated == 'true'
@@ -86,11 +97,18 @@ jobs:
       - name: Update website release version
         run: node ./build/Update-WebsiteReleaseVersion.mjs ${{ steps.moduleversion.outputs.tag }}
 
-      - name: Commit website release version
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v5
+      - name: Create website release version pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit_message: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
-          file_pattern: >-
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
+          branch: 'automation/versioned-docs-${{ steps.moduleversion.outputs.tag }}'
+          base: main
+          delete-branch: true
+          title: 'ci(docs): update website release version ${{ steps.moduleversion.outputs.tag }}'
+          body: |
+            Automated versioned documentation update for Maester ${{ steps.moduleversion.outputs.tag }}.
+          add-paths: |
             website/docusaurus.config.js
             website/version-config.js
             website/versions.json

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -22,11 +22,22 @@ jobs:
       actions: read
 
     steps:
+      - name: Generate maester-bot app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MAESTER_BOT_APP_ID }}
+          private-key: ${{ secrets.MAESTER_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: ⬇️ Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         # Important: Fetch all history, as the versioning command often needs it.
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -42,11 +53,18 @@ jobs:
       - name: Update website release version
         run: node ./build/Update-WebsiteReleaseVersion.mjs ${{ inputs.version }}
 
-      - name: ✍️ Commit Version Files to Main Branch
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v5
+      - name: ✍️ Create Version Files Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit_message: 'ci(docs): update website release version ${{ inputs.version }}'
-          file_pattern: >-
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: 'ci(docs): update website release version ${{ inputs.version }}'
+          branch: 'automation/versioned-docs-${{ inputs.version }}'
+          base: main
+          delete-branch: true
+          title: 'ci(docs): update website release version ${{ inputs.version }}'
+          body: |
+            Automated versioned documentation update for Maester ${{ inputs.version }}.
+          add-paths: |
             website/docusaurus.config.js
             website/version-config.js
             website/versions.json


### PR DESCRIPTION
## Summary

- Replace direct versioned-docs pushes to `main` with automated pull requests.
- Use the existing `maester-bot` GitHub App token pattern.
- Apply the protected-branch flow to the standard release, manual-version release, and standalone versioned-docs workflows.
- Restrict automated commits to the generated Docusaurus version files.

## Why

The 2.2.0 documentation run successfully generated and committed the new snapshot, but GitHub rejected its direct push to `main` with `GH013`. Repository rules require changes to arrive through a pull request and pass three status checks.

## Impact

After this change, a release or standalone docs-versioning run will open or update an `automation/versioned-docs-<version>` pull request against `main`. The generated documentation can then pass the required checks and be merged normally.

## Validation

- Parsed all three workflow files successfully.
- Confirmed each workflow requests the required Maester bot permissions.
- Confirmed checkout and pull-request creation use the generated app token.
- Confirmed the PR base is explicitly `main` and `add-paths` contains only the generated documentation paths.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release workflows now propose website version and documentation updates through pull requests instead of committing changes directly.
  * Pull requests include version details and are automatically cleaned up after merging.
* **Security**
  * Automated release actions now use short-lived GitHub App authentication tokens.
  * Repository checkout no longer retains authentication credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->