### PR TITLE
fix: bound telemetry request timeout

### DIFF
--- a/powershell/internal/Write-Telemetry.ps1
+++ b/powershell/internal/Write-Telemetry.ps1
@@ -27,7 +27,7 @@
 
     # Send the POST request
     try {
-        Invoke-RestMethod -Uri $url -Method Post -ContentType "application/json" -Body $jsonBody | Out-Null
+        Invoke-RestMethod -Uri $url -Method Post -ContentType "application/json" -Body $jsonBody -TimeoutSec 5 -ErrorAction Stop | Out-Null
     }
     catch {
         Write-Verbose $_

--- a/powershell/tests/functions/Write-Telemetry.Tests.ps1
+++ b/powershell/tests/functions/Write-Telemetry.Tests.ps1
@@ -1,0 +1,27 @@
+Describe 'Write-Telemetry' {
+    BeforeAll {
+        . "$PSScriptRoot/../../internal/Write-Telemetry.ps1"
+    }
+
+    BeforeEach {
+        Mock Get-MgContext {
+            [PSCustomObject]@{ TenantId = '00000000-0000-0000-0000-000000000000' }
+        }
+    }
+
+    It 'uses a bounded timeout for the telemetry request' {
+        Mock Invoke-RestMethod {}
+
+        Write-Telemetry -EventName InvokeMaester
+
+        Should -Invoke Invoke-RestMethod -Exactly 1 -ParameterFilter {
+            $TimeoutSec -eq 5 -and $ErrorAction -eq 'Stop'
+        }
+    }
+
+    It 'does not fail when the telemetry request throws' {
+        Mock Invoke-RestMethod { throw 'Network failure' }
+
+        { Write-Telemetry -EventName InvokeMaester } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
## Summary

- bound the best-effort PostHog telemetry request to five seconds
- make the request error terminating so the existing catch reliably handles request failures
- add focused coverage for the timeout and non-fatal failure behavior

## Why

`Write-Telemetry` runs synchronously during `Invoke-Maester`. When the PostHog endpoint is blocked or unreachable, the request previously relied on the operating system or HTTP stack's default timeout and could materially delay an assessment. Telemetry is optional and should not hold up assessment execution.

Closes #2047.

## Validation

- PowerShell 7 / Pester 5.7.1: 2 passed, 0 failed
- Windows PowerShell / Pester 5.9.0: 2 passed, 0 failed
- `Build-MaesterModule.ps1`: passed
- `Test-MaesterModuleOutput.ps1`: passed
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a five-second timeout for telemetry requests.
  * Improved handling of telemetry network failures so they do not disrupt the application.

* **Tests**
  * Added automated coverage for request timeouts, error handling, and network failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->