### PR TITLE
Fix Pester test names for exported functions

### DIFF
--- a/powershell/tests/functions/Common.Tests.ps1
+++ b/powershell/tests/functions/Common.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Common function tests' -Tags 'Acceptance' -ForEach @{ exportedFunction
             $functionPath = $_.ScriptBlock.File
         }
 
-        It "<function>.ps1 should exist in public folder" {
+        It "<function.Name>.ps1 should exist in public folder" {
             # Normalize path in test to work cross-platform
             $functionPath -replace '\\','/' | Should -BeLike "*/public/*$($function.Name).ps1"
             $functionPath | Should -Exist
@@ -35,7 +35,7 @@ Describe 'Common function tests' -Tags 'Acceptance' -ForEach @{ exportedFunction
         }
 
         # Not really necessary as we test exported commands meaning they were able to load
-        It "<function>.ps1 is valid PowerShell code" {
+        It "<function.Name>.ps1 is valid PowerShell code" {
             $psFile = Get-Content -Path $functionPath -ErrorAction Stop
             $errors = $null
             $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
@@ -43,7 +43,7 @@ Describe 'Common function tests' -Tags 'Acceptance' -ForEach @{ exportedFunction
         }
 
         # Same comment as above, but doesn't hurt to double check
-        It '<function>.ps1 should run without exceptions' {
+        It '<function.Name>.ps1 should run without exceptions' {
             $scriptBlock = [scriptblock]::Create((Get-Content $functionPath -Raw))
             { & $scriptBlock } | Should -Not -Throw
         }


### PR DESCRIPTION
## Summary
- Update parametrized Pester test names to use function.Name instead of function
- Prevent Pester 6 from recursively formatting the full CommandInfo object

## Testing
- Ran Invoke-Pester against powershell/tests/functions/Common.Tests.ps1
- 3475 tests passed, 0 failed

Fixes #1975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test descriptions by dynamically including the relevant function name for clearer validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->