### PR TITLE
Fix BitLocker fixed drive encryption setting ID

### DIFF
--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -61,7 +61,7 @@
         $osEncryptionTypeId = 'device_vendor_msft_bitlocker_systemdrivesencryptiontype'
         $osEncryptionTypeDropdownId = 'device_vendor_msft_bitlocker_systemdrivesencryptiontype_osencryptiontypedropdown_name'
         $fixedEncryptionTypeId = 'device_vendor_msft_bitlocker_fixeddrivesencryptiontype'
-        $fixedEncryptionTypeDropdownId = 'device_vendor_msft_bitlocker_fixeddrivesencryptiontype_fdeencryptiontypedropdown_name'
+        $fixedEncryptionTypeDropdownId = 'device_vendor_msft_bitlocker_fixeddrivesencryptiontype_fdvencryptiontypedropdown_name'
         $requireEncryptionId = 'device_vendor_msft_bitlocker_requiredeviceencryption'
         $encryptionMethodId = 'device_vendor_msft_bitlocker_encryptionmethodbydrivetype'
         $osEncryptionMethodDropdownId = 'device_vendor_msft_bitlocker_encryptionmethodbydrivetype_encryptionmethodwithxtsosdropdown_name'


### PR DESCRIPTION
## Summary
- Correct the fixed drive encryption settingDefinitionId used by MT.1123
- Replace the invalid fde identifier segment with fdv

## Testing
- Parsed Test-MtBitLockerFullDiskEncryption.ps1 successfully with the PowerShell parser

Fixes #2015