### PR TITLE
Fix Entra recommendation portal links

### DIFF
--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -13,6 +13,7 @@ Describe "Maester/Entra" -Tag "Maester", "Entra",  "Recommendation" -ForEach $En
     # Define the test name and Id for each Entra recommendation.
     $RecommendationId = $_.id
     It "MT.1024.$($RecommendationId -replace '^[^_]+_', ''): $($_.displayName). See https://maester.dev/docs/tests/MT.1024" -Tag "MT.1024", "$($_.recommendationType)" {
+        $RecommendationId = $_.id
 
         $EntraPremiumRecommendations = @(
             "insiderRiskPolicy",


### PR DESCRIPTION
## Summary
- Restore the recommendation ID when MT.1024 tests enter the Pester run phase
- Ensure Entra recommendation portal links include the correct recommendation ID

## Testing
- Reproduced the discovery/run scope behavior with Pester 5.7.1
- Verified the corrected scope behavior with Pester 5.7.1
- Parsed Test-EntraRecommendations.Tests.ps1 successfully
- Ran git diff --check successfully

Fixes #2044


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Entra recommendation test setup to use the currently evaluated recommendation identifier, improving test accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->