### PR TITLE
Fix Azure DevOps unavailable app skip status

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaAzureDevOps.ps1
+++ b/powershell/public/maester/entra/Test-MtCaAzureDevOps.ps1
@@ -33,10 +33,17 @@
 
     try {
         $azureDevOpsServicePrincipal = Invoke-MtGraphRequest -RelativeUri 'servicePrincipals' -ApiVersion v1.0 -Filter "appId eq '$azureDevOpsAppId'" -Select id
-        if (-not $azureDevOpsServicePrincipal) {
-            Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Azure DevOps app (App ID: $azureDevOpsAppId) is not available in this tenant."
-            return $null
-        }
+    } catch {
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        return $null
+    }
+
+    if (-not $azureDevOpsServicePrincipal) {
+        Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason "Azure DevOps app (App ID: $azureDevOpsAppId) is not available in this tenant."
+        return $null
+    }
+
+    try {
 
         $policies = Get-MtConditionalAccessPolicy | Where-Object { $_.state -eq 'enabled' }
         $policiesResult = New-Object System.Collections.ArrayList

--- a/powershell/tests/functions/Test-MtCaAzureDevOps.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaAzureDevOps.Tests.ps1
@@ -44,6 +44,23 @@
         }
     }
 
+    Context 'Azure DevOps app skip propagation' {
+        It 'Should not convert the custom skip into an error' {
+            Mock -ModuleName Maester Test-MtConnection { return $true }
+            Mock -ModuleName Maester Get-MtLicenseInformation { return 'P1' }
+            Mock -ModuleName Maester Invoke-MtGraphRequest { return @() }
+            Mock -ModuleName Maester Add-MtTestResultDetail {
+                param($SkippedBecause)
+                if ($SkippedBecause -eq 'Custom') {
+                    throw 'Pester skip signal'
+                }
+            }
+
+            { Test-MtCaAzureDevOps } | Should -Throw 'Pester skip signal'
+            Should -Invoke -ModuleName Maester Add-MtTestResultDetail -ParameterFilter { $SkippedBecause -eq 'Error' } -Times 0 -Exactly
+        }
+    }
+
     Context 'Azure DevOps app is available in tenant' {
         BeforeEach {
             Mock -ModuleName Maester Test-MtConnection { return $true }


### PR DESCRIPTION
## Summary
- Preserve the custom skipped status when the Azure DevOps service principal is unavailable
- Limit Graph request error handling so Pester skip control flow is not converted into an error
- Add regression coverage for skip propagation

## Testing
- Reproduced the skip conversion behavior with Pester 5.7.1
- Verified the regression test failed before the fix and passed afterward
- Passed all 4 Test-MtCaAzureDevOps tests with Pester 5.7.1
- Parsed both modified PowerShell files successfully
- Ran git diff --check successfully

Fixes #2051


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure DevOps service-principal lookup error handling.
  * Missing service principals are now correctly reported as skipped before policy evaluation.
  * Custom skip results now remain skips instead of being incorrectly recorded as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->