### PR TITLE
Fix Maester action smoke test isolation

### DIFF
--- a/.github/workflows/maester-action-smoke-test.md
+++ b/.github/workflows/maester-action-smoke-test.md
@@ -6,8 +6,8 @@ Microsoft 365 demo tenant. The same workflow supports two run types:
 
 - **Quick** runs only the fast, platform-neutral Graph check `MT.1068` for an
   approved pull request that changes a PowerShell file.
-- **Full** runs all public Graph checks. Exchange, Teams, private, preview, and
-  long-running tests remain disabled.
+- **Full** runs all public Microsoft 365 Graph checks. Exchange, Teams,
+  GitHub, private, preview, and long-running tests remain disabled.
 
 Each operating system's self-contained HTML report is written directly to the
 private `maester365/maester-smoke-reports` repository for core-maintainer
@@ -196,7 +196,10 @@ receives `contents: read` and `id-token: write`.
 The action is pinned to the immutable commit for `maester-action` v1.2.0. The
 action's public result details, public artifacts, and telemetry remain disabled;
 the public run summary contains only links protected by the private report
-repository's access controls. After Maester produces a result, the workflow
+repository's access controls. The action runs before the repository checkout so
+`include_private_tests: false` sees a clean workspace containing only the
+installed public tests. After Maester produces a result, the workflow checks out
+the trusted default-branch report publisher into a separate directory and
 transfers only the HTML report directly to the core-only private release
 repository. The matrix uses `fail-fast: false` so a failure on one operating
 system does not hide the other platform results.

--- a/.github/workflows/maester-action-smoke-test.yaml
+++ b/.github/workflows/maester-action-smoke-test.yaml
@@ -304,14 +304,6 @@ jobs:
               throw 'MAESTER_SMOKE_CLIENT_ID must be an environment secret containing the app registration Application (client) ID.'
           }
 
-      - name: Check out private report publisher
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # All credentialed jobs run from the trusted default branch. Never
-          # check out or execute pull-request code in this workflow.
-          ref: ${{ github.sha }}
-          persist-credentials: false
-
       - name: Create private report uploader token
         id: reports-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -335,6 +327,7 @@ jobs:
           include_longrunning_tests: false
           include_preview_tests: false
           include_tags: ${{ needs.context.outputs.include_tags }}
+          exclude_tags: GitHub
           maester_version: ${{ env.SMOKE_MAESTER_VERSION }}
           pester_verbosity: None
           step_summary: false
@@ -412,6 +405,18 @@ jobs:
 
           Write-Host "Published Maester action completed the $($env:RUN_TYPE) Graph smoke test on $($env:EXPECTED_OS)."
 
+      - name: Check out private report publisher
+        if: always() && steps.maester.outputs.results_json != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Run Maester before checkout so include_private_tests: false sees a
+          # clean workspace containing only the installed public tests. Check
+          # out trusted default-branch code afterward, in its own directory,
+          # without deleting the generated test-results directory.
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          path: smoke-source
+
       - name: Publish private HTML report
         if: always() && steps.maester.outputs.results_json != ''
         shell: pwsh
@@ -432,7 +437,7 @@ jobs:
           Maester version: ``$env:SMOKE_MAESTER_VERSION``
           "@
 
-          ./.github/scripts/Publish-MaesterSmokeReport.ps1 `
+          ./smoke-source/.github/scripts/Publish-MaesterSmokeReport.ps1 `
             -Repository 'maester365/maester-smoke-reports' `
             -Tag $tag `
             -ReleaseName "Maester $env:SMOKE_RUN_TYPE smoke run $env:GITHUB_RUN_ID (attempt $env:GITHUB_RUN_ATTEMPT)" `


### PR DESCRIPTION
## Summary

- run the published Maester action before checking out repository source, leaving the workspace limited to installed public tests
- check out the trusted report publisher afterward under `smoke-source` so generated results are preserved
- exclude tests tagged `GitHub` from the Microsoft 365 Graph smoke run
- document the workspace isolation and excluded test scope

## Root cause

`maester-action` passes the entire GitHub workspace to `Invoke-Maester`. The smoke job checked out this repository before invoking the action, so the run discovered Maester's internal `powershell/tests` in addition to the installed public tenant checks. Those tests can replace or remove the active Maester module, which caused the post-Pester `Write-MtProgress` command-not-found failure on Ubuntu, Windows, and macOS.

The full run also discovered GitHub-tagged checks, which attempted interactive device authentication and added a roughly 15-minute timeout.

## Impact

The smoke workflow now exercises only the intended public Microsoft 365 checks while retaining private HTML report publication. GitHub-specific checks no longer run in this Graph-only smoke test.

## Validation

- parsed `.github/workflows/maester-action-smoke-test.yaml` successfully
- asserted that checkout occurs after Maester, uses the isolated `smoke-source` path, retains the v7.0.1 checkout pin, and the publisher path is updated
- asserted that `exclude_tags` is set to `GitHub`
- ran `git diff --check`

The live demo-tenant workflow has not yet been rerun with this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified smoke-test coverage, including disabled GitHub checks and other excluded test categories.
  - Documented the updated test and report-publishing sequence.

- **Chores**
  - Improved smoke-test workflow isolation by running validation before retrieving report-publishing resources.
  - Updated report handling to use the trusted publishing source only when test results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->