### PR TITLE
Use default GitHub smoke test behavior

### DIFF
--- a/.github/workflows/maester-action-smoke-test.md
+++ b/.github/workflows/maester-action-smoke-test.md
@@ -6,8 +6,8 @@ Microsoft 365 demo tenant. The same workflow supports two run types:
 
 - **Quick** runs only the fast, platform-neutral Graph check `MT.1068` for an
   approved pull request that changes a PowerShell file.
-- **Full** runs all public Microsoft 365 Graph checks. Exchange, Teams,
-  GitHub, private, preview, and long-running tests remain disabled.
+- **Full** runs all public Graph checks. Exchange, Teams, private, preview, and
+  long-running tests remain disabled.
 
 Each operating system's self-contained HTML report is written directly to the
 private `maester365/maester-smoke-reports` repository for core-maintainer

--- a/.github/workflows/maester-action-smoke-test.yaml
+++ b/.github/workflows/maester-action-smoke-test.yaml
@@ -327,7 +327,6 @@ jobs:
           include_longrunning_tests: false
           include_preview_tests: false
           include_tags: ${{ needs.context.outputs.include_tags }}
-          exclude_tags: GitHub
           maester_version: ${{ env.SMOKE_MAESTER_VERSION }}
           pester_verbosity: None
           step_summary: false


### PR DESCRIPTION
## Summary

- remove the explicit `exclude_tags: GitHub` override from the published-action smoke workflow
- restore the documented scope to public Graph checks
- retain the workspace-isolation fix from #2062, which runs Maester before checking out repository source

## Root cause

The roughly 15-minute delay in run 30672076581 was not caused by the public GitHub-tagged checks. The action passed the pre-populated GitHub workspace to `Invoke-Maester`, which discovered this repository's untagged internal PowerShell unit tests.

The internal `Connect-MtGitHub` no-token test then escaped its expected mock while published and source Maester module instances were being imported and replaced. That started a real GitHub device flow, whose expiry window is 900 seconds. The later `Write-MtProgress` failure was another symptom of those internal tests replacing or removing the active Maester module.

Because the offending internal tests are not tagged `GitHub`, an `exclude_tags: GitHub` override cannot prevent that failure. Public GitHub checks already remain opt-in and skip when `Connect-MtGitHub` has not established a connection.

## Impact

The smoke workflow continues to avoid repository-test contamination by checking out the trusted report publisher only after Maester completes. It now preserves Maester's normal out-of-box GitHub behavior instead of applying a redundant tag filter.

## Validation

- parsed `.github/workflows/maester-action-smoke-test.yaml`
- asserted that checkout occurs after the Maester action and uses `smoke-source`
- asserted that the private report publisher uses the isolated checkout path
- asserted that the workflow has no `exclude_tags` override
- ran `git diff --check`

The live demo-tenant workflow has not been rerun by this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Maester smoke-test runs so GitHub checks are no longer excluded.
  * Full runs now execute all public Graph checks as expected.

* **Documentation**
  * Clarified the definition of Full runs and removed outdated information about disabled GitHub checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->