### PR TITLE
Remove redundant headings from entitlement test descriptions

### DIFF
--- a/powershell/public/maester/entra/Test-MtEntitlementManagementDeletedGroups.md
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementDeletedGroups.md
@@ -1,5 +1,3 @@
-## Description
-
 This test identifies Microsoft Entra ID Governance access packages and catalogs that contain references to deleted Entra ID groups. Deleted group references can cause access provisioning failures, broken approval workflows, and compliance violations.
 
 The test validates:

--- a/powershell/public/maester/entra/Test-MtEntitlementManagementInactivePolicies.md
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementInactivePolicies.md
@@ -1,5 +1,3 @@
-## Description
-
 This test identifies Microsoft Entra ID Governance access packages that contain assignment policies which are disabled, misconfigured, or orphaned. Inactive or misconfigured policies prevent users from successfully requesting access and can break automated provisioning workflows.
 
 The test validates:

--- a/powershell/public/maester/entra/Test-MtEntitlementManagementOrphanedResources.md
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementOrphanedResources.md
@@ -1,5 +1,3 @@
-## Description
-
 This test identifies Microsoft Entra ID Governance access package catalogs that contain resources (groups, applications, SharePoint sites) that are not used in any access package within that catalog. Orphaned resources indicate incomplete configuration or drift.
 
 The test validates:

--- a/powershell/public/maester/entra/Test-MtEntitlementManagementValidApprovers.md
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementValidApprovers.md
@@ -1,5 +1,3 @@
-## Description
-
 This test identifies Microsoft Entra ID Governance access package assignment policies with approval workflows that reference invalid approvers. Invalid approvers cause approval workflow failures, access request timeouts, and create significant operational overhead.
 
 The test validates:

--- a/powershell/public/maester/entra/Test-MtEntitlementManagementValidResourceRoles.md
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementValidResourceRoles.md
@@ -1,5 +1,3 @@
-## Description
-
 This test identifies Microsoft Entra ID Governance access package catalog resources that reference stale or invalid roles, deleted service principals, or non-existent SharePoint sites. When applications or sites are reconfigured or deleted, catalogs often retain "ghost roles" that cause provisioning failures.
 
 The test validates:


### PR DESCRIPTION
## 📑 Description

Remove the redundant `## Description` heading from the companion Markdown for MT.1106–MT.1110. Maester loads each companion Markdown file verbatim into the test result description, so the heading was rendered prominently above the actual description in every result card.

The description, remediation, and reference content remain unchanged. Generated website documentation is left to the docs pipeline.

Closes #2053

## ✅ Checks

- [x] My pull request adheres to the code style of this project.
- [x] The module builds successfully with `./build/Build-MaesterModule.ps1`.
- [x] Built module validation passes with `./build/Test-MaesterModuleOutput.ps1`.
- [x] The five generated `Maester.TestMetadata.json` descriptions are non-empty and no longer start with `## Description`.
- [x] `git diff --check` passes.

## ℹ️ Additional Information

This is a presentation-only fix; no test evaluation logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined entitlement management test documentation by removing redundant description headings.
  * Preserved existing descriptive content and relevant Microsoft Graph API links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->