### PR TITLE
Add multi-forest AD targeting and merged reporting

### DIFF
--- a/build/activeDirectory/README-ADTestRunner.md
+++ b/build/activeDirectory/README-ADTestRunner.md
@@ -4,6 +4,16 @@ This folder contains scripts for running Maester Active Directory tests on a dom
 
 ## Quick Start
 
+### Recommended First Step (Pin the Local Module)
+
+Run this once in each new terminal session before connecting to AD:
+
+```powershell
+.\build\activeDirectory\Use-LocalMaesterModule.ps1
+```
+
+This ensures `Connect-Maester` is loaded from this workspace and includes `-ActiveDirectoryServer`.
+
 ### Option 1: Run All AD Tests (Recommended)
 
 From the repository root on a domain controller:
@@ -14,6 +24,9 @@ From the repository root on a domain controller:
 
 # With verbose output
 .\build\activeDirectory\Run-ADTests-And-CopyReports.ps1 -ConnectActiveDirectory -Verbose
+
+# Run against multiple forests from one machine
+.\build\activeDirectory\Run-ADTests-And-CopyReports.ps1 -ConnectActiveDirectory -ActiveDirectoryServer dc01.corp.contoso.com,dc01.fabrikam.net
 ```
 
 ### Option 2: Run Specific AD Test Categories
@@ -53,38 +66,39 @@ $latestReports | Copy-Item -Destination ".\build\activeDirectory\" -Force
 
 The AD tests are organized into the following categories:
 
-| Category | Path | Description |
-|----------|------|-------------|
-| GPO State | `tests/ad/gpostate` | GPO configuration and state tests |
-| Domain | `tests/ad/domain` | Domain configuration tests |
-| Security | `tests/ad/security` | Security-related AD tests |
-| User | `tests/ad/user` | User account tests |
-| Group | `tests/ad/group` | Group configuration tests |
-| Computer | `tests/ad/computer` | Computer account tests |
-| GPO | `tests/ad/gpo` | Group Policy Object tests |
-| Password Policy | `tests/ad/passwordpolicy` | Password policy tests |
-| Replication | `tests/ad/replication` | AD replication tests |
-| DACL | `tests/ad/dacl` | Discretionary Access Control List tests |
-| Domain Controller | `tests/ad/domaincontroller` | DC-specific tests |
-| DNS | `tests/ad/dns` | DNS-related tests |
-| OU | `tests/ad/ou` | Organizational Unit tests |
-| Site | `tests/ad/site` | AD site topology tests |
-| Schema | `tests/ad/schema` | AD schema tests |
-| SPN | `tests/ad/spn` | Service Principal Name tests |
-| Trust | `tests/ad/trust` | Domain trust tests |
-| Config | `tests/ad/config` | General configuration tests |
+| Category          | Path                        | Description                             |
+| ----------------- | --------------------------- | --------------------------------------- |
+| GPO State         | `tests/ad/gpostate`         | GPO configuration and state tests       |
+| Domain            | `tests/ad/domain`           | Domain configuration tests              |
+| Security          | `tests/ad/security`         | Security-related AD tests               |
+| User              | `tests/ad/user`             | User account tests                      |
+| Group             | `tests/ad/group`            | Group configuration tests               |
+| Computer          | `tests/ad/computer`         | Computer account tests                  |
+| GPO               | `tests/ad/gpo`              | Group Policy Object tests               |
+| Password Policy   | `tests/ad/passwordpolicy`   | Password policy tests                   |
+| Replication       | `tests/ad/replication`      | AD replication tests                    |
+| DACL              | `tests/ad/dacl`             | Discretionary Access Control List tests |
+| Domain Controller | `tests/ad/domaincontroller` | DC-specific tests                       |
+| DNS               | `tests/ad/dns`              | DNS-related tests                       |
+| OU                | `tests/ad/ou`               | Organizational Unit tests               |
+| Site              | `tests/ad/site`             | AD site topology tests                  |
+| Schema            | `tests/ad/schema`           | AD schema tests                         |
+| SPN               | `tests/ad/spn`              | Service Principal Name tests            |
+| Trust             | `tests/ad/trust`            | Domain trust tests                      |
+| Config            | `tests/ad/config`           | General configuration tests             |
 
 ## Script Parameters
 
 ### Run-ADTests-And-CopyReports.ps1
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `ConnectActiveDirectory` | Required | Explicitly authorize AD connection validation and test execution |
-| `MaesterModulePath` | `..\..\powershell` | Path to Maester PowerShell module |
-| `TestPath` | `..\..\tests` | Path to test files |
-| `OutputFolder` | `..\..\test-results` | Temporary output folder |
-| `TargetFolder` | Current folder | Where to copy final reports |
+| Parameter                | Default              | Description                                                                                   |
+| ------------------------ | -------------------- | --------------------------------------------------------------------------------------------- |
+| `ConnectActiveDirectory` | Required             | Explicitly authorize AD connection validation and test execution                              |
+| `MaesterModulePath`      | `..\..\powershell`   | Path to Maester PowerShell module                                                             |
+| `TestPath`               | `..\..\tests`        | Path to test files                                                                            |
+| `OutputFolder`           | `..\..\test-results` | Temporary output folder                                                                       |
+| `TargetFolder`           | Current folder       | Where to copy final reports                                                                   |
+| `ActiveDirectoryServer`  | *(not set)*          | One or more AD servers/DCs to target. Provide multiple values to run across multiple forests. |
 
 ## Report Files
 
@@ -130,6 +144,11 @@ After running tests, the following files are generated:
 ### Example 1: Full AD Test Suite
 ```powershell
 .\build\activeDirectory\Run-ADTests-And-CopyReports.ps1 -ConnectActiveDirectory -Verbose
+```
+
+### Example 1b: Multi-forest run from a single host
+```powershell
+.\build\activeDirectory\Run-ADTests-And-CopyReports.ps1 -ConnectActiveDirectory -ActiveDirectoryServer dc01.corp.contoso.com,dc01.fabrikam.net
 ```
 
 ### Example 2: Quick GPO Validation Only

--- a/build/activeDirectory/Run-ADTests-And-CopyReports.ps1
+++ b/build/activeDirectory/Run-ADTests-And-CopyReports.ps1
@@ -25,6 +25,10 @@
 .PARAMETER TargetFolder
     Target folder where reports will be copied. Defaults to build/activeDirectory.
 
+.PARAMETER ActiveDirectoryServer
+    One or more domain controllers or AD DS servers to target. Provide multiple
+    values to run the AD suite against multiple forests from the same machine.
+
 .EXAMPLE
     .\Run-ADTests-And-CopyReports.ps1 -ConnectActiveDirectory
 
@@ -55,7 +59,10 @@ param (
     [string]$OutputFolder = (Join-Path $PSScriptRoot "..\..\test-results"),
 
     [Parameter()]
-    [string]$TargetFolder = $PSScriptRoot
+    [string]$TargetFolder = $PSScriptRoot,
+
+    [Parameter()]
+    [string[]]$ActiveDirectoryServer
 )
 
 if (-not $ConnectActiveDirectory.IsPresent) {
@@ -132,18 +139,6 @@ foreach ($moduleName in $requiredModules) {
     }
 }
 
-# Validate the explicit Active Directory connection before any tests run.
-try {
-    Connect-Maester -Service ActiveDirectory
-    if (-not (Test-MtConnection -Service ActiveDirectory)) {
-        throw "Connect-Maester did not establish an Active Directory connection."
-    }
-    Write-Host "  ✓ Active Directory connection validated" -ForegroundColor Green
-} catch {
-    Write-Error "Failed to connect to Active Directory: $_"
-    exit 1
-}
-
 # Verify AD test paths
 $adTestPaths = @(
     (Join-Path $TestPath "Maester\ad"),
@@ -166,6 +161,14 @@ if ($validTestPaths.Count -eq 0) {
 }
 
 Write-Host "  Found $($validTestPaths.Count) AD test location(s)" -ForegroundColor Gray
+
+$targets = if ($ActiveDirectoryServer -and $ActiveDirectoryServer.Count -gt 0) {
+    $ActiveDirectoryServer
+} else {
+    @($null)
+}
+
+Write-Host "  Forest targets to test: $($targets.Count)" -ForegroundColor Gray
 #endregion
 
 #region Run AD Tests
@@ -179,50 +182,74 @@ try {
         New-Item -Path $OutputFolder -ItemType Directory -Force | Out-Null
     }
 
-    # Generate timestamped filename
-    $timestamp = Get-Date -Format 'yyyy-MM-dd-HHmmss'
-    $fileName = "AD-TestResults-$timestamp"
+    $allGeneratedFiles = @()
 
-    # Run Invoke-Maester for AD tests
-    $invokeParams = @{
-        Path = $validTestPaths[0]
-        Tag = 'AD'
-        OutputFolder = $OutputFolder
-        OutputFolderFileName = $fileName
-        NonInteractive = $true
-        SkipGraphConnect = $true  # AD tests don't need Graph connection
-        Verbosity = 'Normal'
-    }
+    foreach ($target in $targets) {
+        $targetLabel = if ($target) { $target } else { 'default-domain' }
+        $targetLabelSafe = ($targetLabel -replace '[^A-Za-z0-9._-]', '_')
+        Write-Host "  Target: $targetLabel" -ForegroundColor Cyan
 
-    Write-Host "  Running: Invoke-Maester with parameters:" -ForegroundColor Gray
-    $invokeParams.GetEnumerator() | ForEach-Object {
-        Write-Host "    - $($_.Key): $($_.Value)" -ForegroundColor Gray
-    }
-    Write-Host ""
-
-    $results = Invoke-Maester @invokeParams -PassThru
-
-    if ($results) {
-        Write-Host "`n  ✓ Tests completed" -ForegroundColor Green
-        Write-Host "    - Total Tests: $($results.TotalCount)" -ForegroundColor Gray
-        Write-Host "    - Passed: $($results.PassedCount)" -ForegroundColor Green
-        Write-Host "    - Failed: $($results.FailedCount)" -ForegroundColor $(if($results.FailedCount -gt 0){'Red'}else{'Gray'})
-        Write-Host "    - Skipped: $($results.SkippedCount)" -ForegroundColor Gray
-
-        # Get the generated files
-        $generatedFiles = @(
-            (Join-Path $OutputFolder "$fileName.html"),
-            (Join-Path $OutputFolder "$fileName.md"),
-            (Join-Path $OutputFolder "$fileName.json")
-        ) | Where-Object { Test-Path $_ }
-
-        Write-Host "`n  Generated files:" -ForegroundColor Gray
-        $generatedFiles | ForEach-Object {
-            $size = (Get-Item $_).Length
-            Write-Host "    - $(Split-Path $_ -Leaf) ($([math]::Round($size/1KB, 2)) KB)" -ForegroundColor Gray
+        try {
+            if ($target) {
+                Connect-Maester -Service ActiveDirectory -ActiveDirectoryServer $target
+            } else {
+                Connect-Maester -Service ActiveDirectory
+            }
+            if (-not (Test-MtConnection -Service ActiveDirectory)) {
+                throw "Connect-Maester did not establish an Active Directory connection for target '$targetLabel'."
+            }
+            Write-Host "    ✓ Active Directory connection validated" -ForegroundColor Green
+        } catch {
+            Write-Error "Failed to connect to Active Directory target '$targetLabel': $_"
+            exit 1
         }
-    } else {
-        Write-Warning "No test results returned"
+
+        # Ensure each target uses fresh AD data.
+        Clear-MtADCache
+
+        $timestamp = Get-Date -Format 'yyyy-MM-dd-HHmmss'
+        $fileName = "AD-TestResults-$targetLabelSafe-$timestamp"
+
+        $invokeParams = @{
+            Path = $validTestPaths[0]
+            Tag = 'AD'
+            OutputFolder = $OutputFolder
+            OutputFolderFileName = $fileName
+            NonInteractive = $true
+            SkipGraphConnect = $true  # AD tests don't need Graph connection
+            Verbosity = 'Normal'
+        }
+
+        Write-Host "    Running: Invoke-Maester with parameters:" -ForegroundColor Gray
+        $invokeParams.GetEnumerator() | ForEach-Object {
+            Write-Host "      - $($_.Key): $($_.Value)" -ForegroundColor Gray
+        }
+        Write-Host ""
+
+        $results = Invoke-Maester @invokeParams -PassThru
+
+        if ($results) {
+            Write-Host "`n    ✓ Tests completed" -ForegroundColor Green
+            Write-Host "      - Total Tests: $($results.TotalCount)" -ForegroundColor Gray
+            Write-Host "      - Passed: $($results.PassedCount)" -ForegroundColor Green
+            Write-Host "      - Failed: $($results.FailedCount)" -ForegroundColor $(if($results.FailedCount -gt 0){'Red'}else{'Gray'})
+            Write-Host "      - Skipped: $($results.SkippedCount)" -ForegroundColor Gray
+
+            $generatedFiles = @(
+                (Join-Path $OutputFolder "$fileName.html"),
+                (Join-Path $OutputFolder "$fileName.md"),
+                (Join-Path $OutputFolder "$fileName.json")
+            ) | Where-Object { Test-Path $_ }
+            $allGeneratedFiles += $generatedFiles
+
+            Write-Host "`n    Generated files:" -ForegroundColor Gray
+            $generatedFiles | ForEach-Object {
+                $size = (Get-Item $_).Length
+                Write-Host "      - $(Split-Path $_ -Leaf) ($([math]::Round($size/1KB, 2)) KB)" -ForegroundColor Gray
+            }
+        } else {
+            Write-Warning "No test results returned for target '$targetLabel'"
+        }
     }
 } catch {
     Write-Error "Failed to run AD tests: $_"
@@ -235,16 +262,17 @@ Write-Host "`n[Step 4] Copying report files to target folder..." -ForegroundColo
 
 try {
     $copiedFiles = @()
-    $fileTypes = @("*.html", "*.md", "*.json", "*.csv", "*.xlsx")
 
-    foreach ($fileType in $fileTypes) {
-        $files = Get-ChildItem -Path $OutputFolder -Filter "$fileName$fileType" -ErrorAction SilentlyContinue
-        foreach ($file in $files) {
-            $targetPath = Join-Path $TargetFolder $file.Name
-            Copy-Item -Path $file.FullName -Destination $targetPath -Force
-            $copiedFiles += $targetPath
-            Write-Host "  ✓ Copied: $($file.Name)" -ForegroundColor Green
+    foreach ($filePath in $allGeneratedFiles | Select-Object -Unique) {
+        $file = Get-Item -Path $filePath -ErrorAction SilentlyContinue
+        if ($null -eq $file) {
+            continue
         }
+
+        $targetPath = Join-Path $TargetFolder $file.Name
+        Copy-Item -Path $file.FullName -Destination $targetPath -Force
+        $copiedFiles += $targetPath
+        Write-Host "  ✓ Copied: $($file.Name)" -ForegroundColor Green
     }
 
     if ($copiedFiles.Count -eq 0) {

--- a/build/activeDirectory/Run-ADTests-And-CopyReports.ps1
+++ b/build/activeDirectory/Run-ADTests-And-CopyReports.ps1
@@ -211,7 +211,7 @@ try {
         $fileName = "AD-TestResults-$targetLabelSafe-$timestamp"
 
         $invokeParams = @{
-            Path = $validTestPaths[0]
+            Path = $validTestPaths
             Tag = 'AD'
             OutputFolder = $OutputFolder
             OutputFolderFileName = $fileName

--- a/build/activeDirectory/Use-LocalMaesterModule.ps1
+++ b/build/activeDirectory/Use-LocalMaesterModule.ps1
@@ -1,0 +1,53 @@
+﻿<#
+.SYNOPSIS
+    Loads the local workspace Maester module for AD test sessions.
+
+.DESCRIPTION
+    Removes any already-loaded Maester modules and force-loads the module from
+    this repository (powershell/Maester.psd1). This avoids parameter drift when
+    an installed module version is auto-loaded from PSModulePath.
+
+.PARAMETER Quiet
+    Suppress informational host output.
+
+.EXAMPLE
+    .\build\activeDirectory\Use-LocalMaesterModule.ps1
+
+    Loads the local workspace module and verifies Connect-Maester supports
+    -ActiveDirectoryServer.
+
+.EXAMPLE
+    .\build\activeDirectory\Use-LocalMaesterModule.ps1 -Quiet
+
+    Loads the local workspace module silently.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$localManifest = Join-Path $repoRoot 'powershell\Maester.psd1'
+
+if (-not (Test-Path -LiteralPath $localManifest -PathType Leaf)) {
+    throw "Local module manifest was not found at '$localManifest'."
+}
+
+Get-Module -Name Maester -All | Remove-Module -Force -ErrorAction SilentlyContinue
+$imported = Import-Module -Name $localManifest -Force -PassThru -Global
+
+$command = Get-Command -Name Connect-Maester -Module Maester -ErrorAction Stop
+$hasAdServerParam = $command.Parameters.ContainsKey('ActiveDirectoryServer')
+
+if (-not $hasAdServerParam) {
+    throw 'Connect-Maester was loaded but does not expose ActiveDirectoryServer. Ensure the workspace module is up to date.'
+}
+
+if (-not $Quiet.IsPresent) {
+    Write-Host "Loaded Maester module from: $($imported.Path)" -ForegroundColor Green
+    Write-Host "Connect-Maester supports -ActiveDirectoryServer: $hasAdServerParam" -ForegroundColor Green
+}

--- a/powershell/Maester.psd1
+++ b/powershell/Maester.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'Maester.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '2.0.0'
+    ModuleVersion        = '2.2.0'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Core', 'Desktop'

--- a/powershell/Maester.psm1
+++ b/powershell/Maester.psm1
@@ -30,6 +30,7 @@ $__MtSession = @{
 	GitHubCache            = @{}                 # Per-session REST response cache; cleared each Invoke-Maester run
 	ADCache                = @{}                 # Active Directory data cache
 	ADConnection           = $null               # Active Directory connection state
+	ADRunContext           = $null               # Active Directory run context for current Invoke-Maester execution
 	ADCollectionTime       = $null               # Timestamp of last AD data collection
 }
 New-Variable -Name __MtSession -Value $__MtSession -Scope Script -Force

--- a/powershell/internal/Clear-ModuleVariable.ps1
+++ b/powershell/internal/Clear-ModuleVariable.ps1
@@ -20,6 +20,7 @@ function Clear-ModuleVariable {
     Clear-MtDnsCache
     Clear-MtExoCache
     Clear-MtADCache
+    $__MtSession.ADRunContext = $null
     $__MtSession.AIAgentInfo = $null
     $__MtSession.AzureDevOpsConnectionCache = $null
     # Invoke-Maester resets the per-run cache but preserves the existing GitHub session.

--- a/powershell/internal/ConvertTo-MtMaesterResult.ps1
+++ b/powershell/internal/ConvertTo-MtMaesterResult.ps1
@@ -35,6 +35,15 @@
         } elseif (Test-MtConnection Teams) {
             $tenant = Get-CsTenant
             return $tenant.DisplayName
+        } elseif (Test-MtConnection ActiveDirectory) {
+            $adContext = GetActiveDirectoryContext
+            if ($adContext -and $adContext.ForestName) {
+                return "Active Directory Forest: $($adContext.ForestName)"
+            }
+            if ($adContext -and $adContext.DomainName) {
+                return "Active Directory Domain: $($adContext.DomainName)"
+            }
+            return 'Active Directory (connected)'
         } else {
             return 'TenantName (not connected to Graph)'
         }
@@ -47,9 +56,47 @@
         } elseif (Test-MtConnection Teams) {
             $tenant = Get-CsTenant
             return $tenant.TenantId
+        } elseif (Test-MtConnection ActiveDirectory) {
+            $adContext = GetActiveDirectoryContext
+            if ($adContext -and $adContext.ForestRootDomain) {
+                return $adContext.ForestRootDomain
+            }
+            if ($adContext -and $adContext.DomainName) {
+                return $adContext.DomainName
+            }
+            if ($adContext -and $adContext.TargetServer) {
+                return $adContext.TargetServer
+            }
+            return 'ActiveDirectory'
         } else {
             return 'TenantId (not connected to Graph)'
         }
+    }
+
+    function GetActiveDirectoryContext() {
+        if (-not (Test-MtConnection ActiveDirectory)) {
+            return $null
+        }
+
+        $context = [ordered]@{
+            ForestName       = $null
+            ForestRootDomain = $null
+            DomainName       = $null
+            TargetServer     = $null
+        }
+
+        if ($__MtSession -and $null -ne $__MtSession.ADRunContext) {
+            $context.ForestName = [string]$__MtSession.ADRunContext.ForestName
+            $context.ForestRootDomain = [string]$__MtSession.ADRunContext.ForestRootDomain
+            $context.DomainName = [string]$__MtSession.ADRunContext.DomainName
+            $context.TargetServer = [string]$__MtSession.ADRunContext.TargetServer
+        }
+
+        if (-not $context.TargetServer -and $__MtSession -and $null -ne $__MtSession.ADConnection) {
+            $context.TargetServer = [string]$__MtSession.ADConnection.TargetServer
+        }
+
+        return [PSCustomObject]$context
     }
 
     function GetAccount() {
@@ -444,6 +491,7 @@
         LoadedModules     = GetLoadedModules
         InvokeCommand     = $InvokeMaesterCommand
         MgContext         = GetMgContextInfo
+        ActiveDirectoryContext = GetActiveDirectoryContext
         PesterConfig      = GetPesterConfigInfo $PesterConfiguration
         MaesterConfig     = $__MtSession.MaesterConfig
         Tests             = $mtTests

--- a/powershell/internal/Reset-MtProgressView.ps1
+++ b/powershell/internal/Reset-MtProgressView.ps1
@@ -8,7 +8,7 @@
     param ()
 
     try {
-        if ($IsWindows -and $IsCoreCLR) {
+        if ($IsWindows -and $IsCoreCLR -and $null -ne $Script:ProgressView) {
             $PSStyle.Progress.View = $Script:ProgressView
         }
     } catch {

--- a/powershell/internal/Set-MtProgressView.ps1
+++ b/powershell/internal/Set-MtProgressView.ps1
@@ -8,12 +8,13 @@
     param ()
 
     try {
-        if($IsWindows -and $IsCoreCLR) {
+        if ($IsWindows -and $IsCoreCLR -and [string]::IsNullOrWhiteSpace($env:VSCODE_PID)) {
             $Script:ProgressView = $PSStyle.Progress.View
             $PSStyle.Progress.View = 'Classic'
+        } else {
+            $Script:ProgressView = $null
         }
-    }
-    catch {
+    } catch {
         Write-Verbose $_
     }
 }

--- a/powershell/public/Connect-Maester.ps1
+++ b/powershell/public/Connect-Maester.ps1
@@ -35,6 +35,16 @@
    Validates connectivity to the current Active Directory domain. Active Directory must be explicitly selected and is not included in -Service All.
 
 .EXAMPLE
+   Connect-Maester -Service ActiveDirectory -ActiveDirectoryServer dc01.corp.contoso.com
+
+   Validates connectivity to Active Directory by targeting the specified domain controller or AD DS server.
+
+.EXAMPLE
+   Connect-Maester -Service ActiveDirectory -ActiveDirectoryServer dc01.corp.contoso.com,dc01.fabrikam.net
+
+   Validates connectivity to Active Directory for each provided domain controller or AD DS server.
+
+.EXAMPLE
    Connect-Maester -Service Azure,Graph
 
    Connects to Microsoft Graph and Azure.
@@ -155,7 +165,11 @@
       [string]$SharePointCertificateThumbprint,
 
       # The GitHub organization login name to connect to when Service includes GitHub.
-      [string]$GitHubOrganization
+      [string]$GitHubOrganization,
+
+      # One or more Active Directory domain controllers or AD DS servers to target when Service includes ActiveDirectory.
+      # When omitted, Active Directory cmdlets use default serverless/domain-joined resolution.
+      [string[]]$ActiveDirectoryServer
    )
 
    $__MtSession.Connections = $Service
@@ -469,15 +483,60 @@
    if ($Service -contains 'ActiveDirectory') {
       Write-Verbose 'Validating Active Directory connectivity'
       try {
-         $adRootDSE = Get-ADRootDSE -ErrorAction Stop
+         $requestedTargets = @(
+            @($ActiveDirectoryServer) |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object { $_.Trim() } |
+            Select-Object -Unique
+         )
+
+         $successfulTargets = @()
+         $failedTargets = @()
+         $firstSuccessfulRootDse = $null
+
+         if ($requestedTargets.Count -eq 0) {
+            Write-Verbose 'Probing AD target using default domain resolution'
+            $adRootDSE = Get-ADRootDSE -ErrorAction Stop
+            $firstSuccessfulRootDse = $adRootDSE
+            $successfulTargets += $adRootDSE.dnsHostName
+            Write-Verbose "Connected to AD target: $($adRootDSE.dnsHostName)"
+         } else {
+            foreach ($target in $requestedTargets) {
+               $adRootDSEParams = @{ Server = $target }
+               Write-Verbose "Probing AD target '$target'"
+
+               try {
+                  $adRootDSE = Get-ADRootDSE @adRootDSEParams -ErrorAction Stop
+                  if ($null -eq $firstSuccessfulRootDse) {
+                     $firstSuccessfulRootDse = $adRootDSE
+                  }
+                  $successfulTargets += $target
+                  Write-Verbose "Connected to AD target: $($adRootDSE.dnsHostName)"
+               } catch {
+                  $failedTargets += [PSCustomObject]@{
+                     Target = $target
+                     Error  = $_.Exception.Message
+                  }
+                  Write-Warning "Failed to validate AD target '$target': $($_.Exception.Message)"
+               }
+            }
+         }
+
+         if ($successfulTargets.Count -eq 0 -or $null -eq $firstSuccessfulRootDse) {
+            $failureMessages = @($failedTargets | ForEach-Object { "[$($_.Target)] $($_.Error)" })
+            throw "Failed to connect to requested Active Directory targets. $($failureMessages -join '; ')"
+         }
+
          $__MtSession.ADConnection = @{
             Connected                  = $true
-            DefaultNamingContext       = $adRootDSE.defaultNamingContext
-            ConfigurationNamingContext = $adRootDSE.configurationNamingContext
-            SchemaNamingContext        = $adRootDSE.schemaNamingContext
-            DomainController           = $adRootDSE.dnsHostName
+            DefaultNamingContext       = $firstSuccessfulRootDse.defaultNamingContext
+            ConfigurationNamingContext = $firstSuccessfulRootDse.configurationNamingContext
+            SchemaNamingContext        = $firstSuccessfulRootDse.schemaNamingContext
+            DomainController           = $firstSuccessfulRootDse.dnsHostName
+            TargetServer               = $successfulTargets[0]
+            TargetServers              = $successfulTargets
+            FailedTargets              = $failedTargets
          }
-         Write-Verbose "Connected to AD: $($adRootDSE.dnsHostName)"
       } catch [Management.Automation.CommandNotFoundException] {
          $__MtSession.ADConnection = @{
             Connected = $false

--- a/powershell/public/Get-MtADDomainState.ps1
+++ b/powershell/public/Get-MtADDomainState.ps1
@@ -17,8 +17,10 @@ function Get-MtADDomainState {
     data collection. When provided, Active Directory queries and the LDAP searcher
     are directed to this server. DNS collection also targets this host when it
     supports the required DNS management access. If not specified, commands use
-    the implicit serverless behavior of the Active Directory module and the DNS
-    root from the collected domain object is used for DNS queries.
+        the server selected by Connect-Maester -Service ActiveDirectory -ActiveDirectoryServer
+        when present; otherwise commands use the implicit serverless behavior of the
+        Active Directory module and the DNS root from the collected domain object is
+        used for DNS queries.
 
     .EXAMPLE
     Get-MtADDomainState
@@ -50,15 +52,17 @@ function Get-MtADDomainState {
         return $null
     }
 
-    $cacheKey = if ($ComputerName) { "DomainState:$ComputerName" } else { 'DomainState' }
+    $effectiveComputerName = if ($ComputerName) { $ComputerName } elseif ($__MtSession.ADConnection.TargetServer) { $__MtSession.ADConnection.TargetServer } else { $null }
+
+    $cacheKey = if ($effectiveComputerName) { "DomainState:$effectiveComputerName" } else { 'DomainState' }
 
     if ($Refresh -or -not $__MtSession.ADCache.ContainsKey($cacheKey)) {
         Write-Verbose 'Collecting AD Domain State data from Active Directory'
 
         try {
             $adServerParameters = @{}
-            if ($ComputerName) {
-                $adServerParameters['Server'] = $ComputerName
+            if ($effectiveComputerName) {
+                $adServerParameters['Server'] = $effectiveComputerName
             }
 
             $domainState = @{
@@ -83,7 +87,7 @@ function Get-MtADDomainState {
                 throw "Failed to retrieve RootDSE information from Active Directory. Verify connectivity and that the specified ComputerName is a valid domain controller."
             }
 
-            $resolvedComputerName = if ($ComputerName) { $ComputerName } else { $domainState.Domain.DNSRoot }
+            $resolvedComputerName = if ($effectiveComputerName) { $effectiveComputerName } else { $domainState.Domain.DNSRoot }
 
             # Collect Replication Connection information
             try {
@@ -386,8 +390,8 @@ function Get-MtADDomainState {
 
                 # Use DirectorySearcher to get objects with their security descriptors
                 $searcher = New-Object System.DirectoryServices.DirectorySearcher
-                if ($ComputerName) {
-                    $searcher.SearchRoot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$ComputerName/$domainDN", $null, $null, ([System.DirectoryServices.AuthenticationTypes]::Secure -bor [System.DirectoryServices.AuthenticationTypes]::ServerBind))
+                if ($effectiveComputerName) {
+                    $searcher.SearchRoot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$effectiveComputerName/$domainDN", $null, $null, ([System.DirectoryServices.AuthenticationTypes]::Secure -bor [System.DirectoryServices.AuthenticationTypes]::ServerBind))
                 } else {
                     $searcher.SearchRoot = [ADSI]"LDAP://$domainDN"
                 }

--- a/powershell/public/Get-MtADServerParameters.ps1
+++ b/powershell/public/Get-MtADServerParameters.ps1
@@ -1,0 +1,27 @@
+function Get-MtADServerParameters {
+    <#
+    .SYNOPSIS
+    Builds AD cmdlet server parameters for the active Maester AD target.
+
+    .DESCRIPTION
+    Returns a hashtable that includes -Server when Connect-Maester selected an
+    Active Directory target server. Returns an empty hashtable when no explicit
+    target server is set.
+
+    .EXAMPLE
+    $adServerParameters = Get-MtADServerParameters
+    Get-ADDomain @adServerParameters
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $adServerParameters = @{}
+
+    if ($__MtSession -and $null -ne $__MtSession.ADConnection -and
+        -not [string]::IsNullOrWhiteSpace($__MtSession.ADConnection.TargetServer)) {
+        $adServerParameters['Server'] = $__MtSession.ADConnection.TargetServer
+    }
+
+    return $adServerParameters
+}

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -330,9 +330,18 @@
         )
 
         $invokeCommand = 'Invoke-Maester'
+        $redactedParameters = @('TeamChannelWebhookUri')
         foreach ($param in $BoundParameters.GetEnumerator()) {
             $paramName = $param.Key
             $paramValue = $param.Value
+
+            if ($paramName -in $redactedParameters) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$paramValue)) {
+                    $invokeCommand += " -$paramName '<redacted>'"
+                }
+                continue
+            }
+
             if ($paramValue -is [switch]) {
                 if ($paramValue.IsPresent) {
                     $invokeCommand += " -$paramName"
@@ -841,6 +850,10 @@
                     $targetParams = @{}
                     foreach ($entry in $PSBoundParameters.GetEnumerator()) {
                         $targetParams[$entry.Key] = $entry.Value
+                    }
+
+                    foreach ($notificationParam in @('MailRecipient', 'MailTestResultsUri', 'MailUserId', 'TeamId', 'TeamChannelId', 'TeamChannelWebhookUri')) {
+                        $null = $targetParams.Remove($notificationParam)
                     }
 
                     if (-not [string]::IsNullOrWhiteSpace($OutputFolder) -or -not [string]::IsNullOrWhiteSpace($OutputFolderFileName)) {

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -303,6 +303,270 @@
         return $PesterConfiguration
     }
 
+    function Add-SuffixToPath($FilePath, $Suffix) {
+        if ([string]::IsNullOrEmpty($FilePath)) {
+            return $FilePath
+        }
+
+        $directory = [System.IO.Path]::GetDirectoryName($FilePath)
+        $name = [System.IO.Path]::GetFileNameWithoutExtension($FilePath)
+        $extension = [System.IO.Path]::GetExtension($FilePath)
+        $fileNameWithSuffix = "$name-$Suffix$extension"
+
+        if ([string]::IsNullOrEmpty($directory)) {
+            return $fileNameWithSuffix
+        }
+
+        return (Join-Path $directory $fileNameWithSuffix)
+    }
+
+    function Get-MtInvokeMaesterCommand {
+        param(
+            [Parameter(Mandatory = $true)]
+            [hashtable]$BoundParameters,
+
+            [Parameter(Mandatory = $false)]
+            [string]$Comment
+        )
+
+        $invokeCommand = 'Invoke-Maester'
+        foreach ($param in $BoundParameters.GetEnumerator()) {
+            $paramName = $param.Key
+            $paramValue = $param.Value
+            if ($paramValue -is [switch]) {
+                if ($paramValue.IsPresent) {
+                    $invokeCommand += " -$paramName"
+                }
+            } elseif ($paramValue -is [array]) {
+                $invokeCommand += " -$paramName @('$($paramValue -join "', '")')"
+            } elseif ($paramValue -is [string]) {
+                $invokeCommand += " -$paramName '$paramValue'"
+            } elseif ($null -ne $paramValue) {
+                $invokeCommand += " -$paramName $paramValue"
+            }
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($Comment)) {
+            $invokeCommand += " # $Comment"
+        }
+
+        return $invokeCommand
+    }
+
+    function New-MtMergedAdForestResult {
+        param(
+            [Parameter(Mandatory = $true)]
+            [psobject[]]$ForestResults,
+
+            [Parameter(Mandatory = $false)]
+            [string]$InvokeCommand
+        )
+
+        if (-not $ForestResults -or $ForestResults.Count -eq 0) {
+            return $null
+        }
+
+        $mergedResult = Merge-MtMaesterResult -MaesterResults $ForestResults
+        $mergedTenants = $mergedResult.Tenants
+        $firstResult = @($ForestResults)[0]
+
+        $combinedTests = foreach ($forestResult in $ForestResults) {
+            foreach ($test in @($forestResult.Tests)) {
+                $testCopy = $test | Select-Object *
+                if ($forestResult.PSObject.Properties.Name -contains 'ADTargetServer') {
+                    $testCopy | Add-Member -NotePropertyName 'ADTargetServer' -NotePropertyValue $forestResult.ADTargetServer -Force
+                }
+                if ($forestResult.PSObject.Properties.Name -contains 'ADForestName') {
+                    $testCopy | Add-Member -NotePropertyName 'ADForestName' -NotePropertyValue $forestResult.ADForestName -Force
+                }
+                if ($forestResult.PSObject.Properties.Name -contains 'ADForestRootDomain') {
+                    $testCopy | Add-Member -NotePropertyName 'ADForestRootDomain' -NotePropertyValue $forestResult.ADForestRootDomain -Force
+                }
+
+                $testCopy
+            }
+        }
+
+        $totalCount = 0
+        $passedCount = 0
+        $failedCount = 0
+        $errorCount = 0
+        $skippedCount = 0
+        $investigateCount = 0
+        $notRunCount = 0
+
+        foreach ($forestResult in $ForestResults) {
+            $totalCount += [int]$forestResult.TotalCount
+            $passedCount += [int]$forestResult.PassedCount
+            $failedCount += [int]$forestResult.FailedCount
+            $errorCount += [int]$forestResult.ErrorCount
+            $skippedCount += [int]$forestResult.SkippedCount
+            $investigateCount += [int]$forestResult.InvestigateCount
+            $notRunCount += [int]$forestResult.NotRunCount
+        }
+
+        $resultState = if ($failedCount -gt 0 -or $errorCount -gt 0) {
+            'Failed'
+        } elseif ($investigateCount -gt 0) {
+            'Investigate'
+        } elseif ($notRunCount -gt 0 -and $passedCount -eq 0 -and $failedCount -eq 0 -and $errorCount -eq 0) {
+            'NotRun'
+        } elseif ($skippedCount -gt 0 -and $passedCount -eq 0 -and $failedCount -eq 0 -and $errorCount -eq 0) {
+            'Skipped'
+        } else {
+            'Passed'
+        }
+
+        $mergedResult = $firstResult | Select-Object *
+        $mergedResult | Add-Member -NotePropertyName 'TenantId' -NotePropertyValue 'ActiveDirectoryMultiForest' -Force
+        $mergedResult | Add-Member -NotePropertyName 'TenantName' -NotePropertyValue 'Active Directory Forests' -Force
+        $mergedResult | Add-Member -NotePropertyName 'Result' -NotePropertyValue $resultState -Force
+        $mergedResult | Add-Member -NotePropertyName 'TotalCount' -NotePropertyValue $totalCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'PassedCount' -NotePropertyValue $passedCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'FailedCount' -NotePropertyValue $failedCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'ErrorCount' -NotePropertyValue $errorCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'SkippedCount' -NotePropertyValue $skippedCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'InvestigateCount' -NotePropertyValue $investigateCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'NotRunCount' -NotePropertyValue $notRunCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'Tests' -NotePropertyValue @($combinedTests) -Force
+        $mergedResult | Add-Member -NotePropertyName 'Tenants' -NotePropertyValue @($mergedTenants) -Force
+        $mergedResult | Add-Member -NotePropertyName 'InvokeCommand' -NotePropertyValue $InvokeCommand -Force
+        $mergedResult | Add-Member -NotePropertyName 'EndOfJson' -NotePropertyValue $mergedResult.EndOfJson -Force
+
+        return $mergedResult
+    }
+
+    function Write-MtMaesterOutputs {
+        param(
+            [Parameter(Mandatory = $true)]
+            [psobject]$MaesterResults,
+
+            [Parameter(Mandatory = $false)]
+            [int]$TestCount = 0
+        )
+
+        $jsonDepth = if ($MaesterResults.PSObject.Properties.Name -contains 'Tenants') { 7 } else { 5 }
+        $jsonSerializableResult = $MaesterResults | Select-Object *
+
+        if ($jsonSerializableResult.PSObject.Properties.Name -contains 'OutputFiles') {
+            $jsonSerializableResult.PSObject.Properties.Remove('OutputFiles')
+        }
+
+        if ($jsonSerializableResult.PSObject.Properties.Name -contains 'Tenants') {
+            foreach ($tenantResult in @($jsonSerializableResult.Tenants)) {
+                if ($tenantResult -and $tenantResult.PSObject.Properties.Name -contains 'OutputFiles') {
+                    $tenantResult.PSObject.Properties.Remove('OutputFiles')
+                }
+            }
+        }
+
+        Write-MtProgress -Activity 'Processing test results' -Status "$TestCount test(s)" -Force
+
+        if (![string]::IsNullOrEmpty($out.OutputJsonFile)) {
+            $jsonSerializableResult | ConvertTo-Json -Depth $jsonDepth -WarningAction SilentlyContinue | Out-File -FilePath $out.OutputJsonFile -Encoding UTF8
+        }
+
+        if (![string]::IsNullOrEmpty($out.OutputMarkdownFile)) {
+            Write-MtProgress -Activity 'Creating markdown report'
+            $output = Get-MtMarkdownReport -MaesterResults $MaesterResults
+            $output | Out-File -FilePath $out.OutputMarkdownFile -Encoding UTF8
+        }
+
+        if (![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)) {
+            Write-MtProgress -Activity 'Creating markdown summary report'
+            $output = Get-MtMarkdownSummaryReport -MaesterResults $MaesterResults
+            $output | Out-File -FilePath $out.OutputMarkdownSummaryFile -Encoding UTF8
+        }
+
+        if (![string]::IsNullOrEmpty($out.OutputCsvFile)) {
+            Write-MtProgress -Activity 'Creating CSV'
+            Convert-MtResultsToFlatObject -InputObject $MaesterResults -CsvFilePath $out.OutputCsvFile
+        }
+
+        if (![string]::IsNullOrEmpty($out.OutputExcelFile)) {
+            Write-MtProgress -Activity 'Creating Excel workbook'
+            Convert-MtResultsToFlatObject -InputObject $MaesterResults -ExcelFilePath $out.OutputExcelFile
+        }
+
+        if (![string]::IsNullOrEmpty($out.OutputHtmlFile)) {
+            Write-MtProgress -Activity 'Creating html report'
+            $output = Get-MtHtmlReport -MaesterResults $MaesterResults
+            $output | Out-File -FilePath $out.OutputHtmlFile -Encoding UTF8
+            if (-not $NonInteractive.IsPresent) {
+                Write-Host "🔥 Maester test report generated at $($out.OutputHtmlFile)" -ForegroundColor Green
+            }
+
+            if ( ( Get-MtUserInteractive ) -and ( -not $NonInteractive ) ) {
+                # Open test results in the default browser.
+                Invoke-Item $out.OutputHtmlFile | Out-Null
+            }
+        }
+
+        if ($MailRecipient) {
+            Write-MtProgress -Activity 'Sending mail'
+            Send-MtMail -MaesterResults $MaesterResults -Recipient $MailRecipient -TestResultsUri $MailTestResultsUri -UserId $MailUserId
+        }
+
+        if ($TeamId -and $TeamChannelId) {
+            Write-MtProgress -Activity 'Sending Teams message'
+            Send-MtTeamsMessage -MaesterResults $MaesterResults -TeamId $TeamId -TeamChannelId $TeamChannelId -TestResultsUri $MailTestResultsUri
+        }
+
+        if ($TeamChannelWebhookUri) {
+            Write-MtProgress -Activity 'Sending Teams message'
+            Send-MtTeamsMessage -MaesterResults $MaesterResults -TeamChannelWebhookUri $TeamChannelWebhookUri -TestResultsUri $MailTestResultsUri
+        }
+    }
+
+    function Test-IsAdOnlyRun($InputPath, $InputTags) {
+        if ($InputTags -and @($InputTags).Count -gt 0) {
+            return @($InputTags | Where-Object { $_ -notmatch '^AD($|[.-])' }).Count -eq 0
+        }
+
+        if ([string]::IsNullOrWhiteSpace($InputPath)) {
+            return $false
+        }
+
+        return ($InputPath -match '(?i)(^|[\\/])tests([\\/])(ad|Maester[\\/]ad)([\\/]|$)')
+    }
+
+    function Get-MtAdRunContext {
+        [CmdletBinding()]
+        param(
+            [string]$TargetServer,
+            [switch]$RefreshAdState
+        )
+
+        $context = [ordered]@{
+            TargetServer     = $TargetServer
+            ForestName       = $null
+            ForestRootDomain = $null
+            DomainName       = $null
+        }
+
+        try {
+            $adStateParams = @{}
+            if ($RefreshAdState.IsPresent) {
+                $adStateParams['Refresh'] = $true
+            }
+
+            $adState = Get-MtADDomainState @adStateParams -ErrorAction SilentlyContinue
+            if ($adState) {
+                if ([string]::IsNullOrWhiteSpace($context.TargetServer)) {
+                    $context.TargetServer = [string]$adState.RootDSE.dnsHostName
+                }
+
+                $context.ForestName = [string]$adState.Forest.Name
+                $context.ForestRootDomain = [string]$adState.Forest.RootDomain
+                $context.DomainName = [string]$adState.Domain.DNSRoot
+            }
+        } catch {
+            Write-Verbose "Failed to resolve Active Directory run context: $($_.Exception.Message)"
+        }
+
+        return [PSCustomObject]$context
+    }
+
     $version = Get-MtModuleVersion
 
     if ( $NonInteractive.IsPresent -or $NoLogo.IsPresent ) {
@@ -452,6 +716,118 @@
         return
     }
 
+    $adTargets = @()
+    if (Test-MtConnection -Service ActiveDirectory) {
+        $adTargets = @(
+            @($__MtSession.ADConnection.TargetServers) |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+        )
+
+        $isAdExcluded = 'AD' -in @($pesterConfig.Filter.ExcludeTag.Value)
+        $isAdOnlyRun = Test-IsAdOnlyRun -InputPath $Path -InputTags $Tag
+
+        if ($adTargets.Count -eq 1 -and -not $isAdExcluded -and $isAdOnlyRun) {
+            $__MtSession.ADRunContext = Get-MtAdRunContext -TargetServer $__MtSession.ADConnection.TargetServer
+            if ($__MtSession.ADRunContext.ForestName) {
+                Write-Verbose "Running AD tests for forest '$($__MtSession.ADRunContext.ForestName)' via target '$($__MtSession.ADRunContext.TargetServer)'."
+                Write-MtProgress -Activity 'Starting Maester' -Status "Forest: $__MtSession.ADRunContext.ForestName" -Force
+            }
+        }
+
+        if ($adTargets.Count -gt 1 -and -not $isAdExcluded -and $isAdOnlyRun) {
+            Write-Verbose "Running AD tests across $($adTargets.Count) targets from a single host."
+
+            $originalTargetServer = $__MtSession.ADConnection.TargetServer
+            $originalTargetServers = @($__MtSession.ADConnection.TargetServers)
+            $originalAdRunContext = $__MtSession.ADRunContext
+            $multiForestResults = @()
+            $baseFileName = if ([string]::IsNullOrWhiteSpace($OutputFolderFileName)) { "TestResults-$(Get-Date -Format 'yyyy-MM-dd-HHmmss')" } else { $OutputFolderFileName }
+
+            foreach ($adTarget in $adTargets) {
+                $__MtSession.ADConnection.TargetServer = $adTarget
+                $__MtSession.ADConnection.TargetServers = @($adTarget)
+                Clear-MtADCache
+
+                $__MtSession.ADRunContext = Get-MtAdRunContext -TargetServer $adTarget -RefreshAdState
+                $forestName = $__MtSession.ADRunContext.ForestName
+                $targetServer = if ($__MtSession.ADRunContext.TargetServer) { $__MtSession.ADRunContext.TargetServer } else { $adTarget }
+                $contextStatus = if ($forestName) { "Forest: $forestName" } else { "Target: $targetServer" }
+                $contextDescriptor = if ($forestName) { "forest '$forestName' via target '$targetServer'" } else { "target '$targetServer'" }
+                Write-Verbose "Running AD tests for $contextDescriptor"
+                Write-MtProgress -Activity 'Starting Maester' -Status "Preparing Active Directory context - $contextStatus" -Force
+
+                $contextSuffixSource = if ($forestName) {
+                    if ($targetServer -and $targetServer -ne $forestName) {
+                        "$forestName-$targetServer"
+                    } else {
+                        $forestName
+                    }
+                } else {
+                    $targetServer
+                }
+
+                $targetSuffix = ($contextSuffixSource -replace '[^A-Za-z0-9._-]', '_')
+
+                $targetParams = @{}
+                foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+                    $targetParams[$entry.Key] = $entry.Value
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($OutputFolder) -or -not [string]::IsNullOrWhiteSpace($OutputFolderFileName)) {
+                    $targetParams['OutputFolderFileName'] = "$baseFileName-$targetSuffix"
+                } else {
+                    if (-not [string]::IsNullOrWhiteSpace($OutputHtmlFile)) {
+                        $targetParams['OutputHtmlFile'] = Add-SuffixToPath -FilePath $OutputHtmlFile -Suffix $targetSuffix
+                    }
+                    if (-not [string]::IsNullOrWhiteSpace($OutputMarkdownFile)) {
+                        $targetParams['OutputMarkdownFile'] = Add-SuffixToPath -FilePath $OutputMarkdownFile -Suffix $targetSuffix
+                    }
+                    if (-not [string]::IsNullOrWhiteSpace($OutputMarkdownSummaryFile)) {
+                        $targetParams['OutputMarkdownSummaryFile'] = Add-SuffixToPath -FilePath $OutputMarkdownSummaryFile -Suffix $targetSuffix
+                    }
+                    if (-not [string]::IsNullOrWhiteSpace($OutputJsonFile)) {
+                        $targetParams['OutputJsonFile'] = Add-SuffixToPath -FilePath $OutputJsonFile -Suffix $targetSuffix
+                    }
+                }
+
+                $targetParams['PassThru'] = $true
+
+                $targetResult = Invoke-Maester @targetParams
+                if ($targetResult) {
+                    foreach ($result in @($targetResult)) {
+                        $result | Add-Member -NotePropertyName 'ADTargetServer' -NotePropertyValue $targetServer -Force
+                        $result | Add-Member -NotePropertyName 'ADForestName' -NotePropertyValue $forestName -Force
+                        $result | Add-Member -NotePropertyName 'ADForestRootDomain' -NotePropertyValue $__MtSession.ADRunContext.ForestRootDomain -Force
+                    }
+                    $multiForestResults += @($targetResult)
+                }
+            }
+
+            $__MtSession.ADConnection.TargetServer = $originalTargetServer
+            $__MtSession.ADConnection.TargetServers = $originalTargetServers
+            $__MtSession.ADRunContext = $originalAdRunContext
+
+            $combinedInvokeCommand = Get-MtInvokeMaesterCommand -BoundParameters $PSBoundParameters -Comment 'Merged multi-forest AD report'
+            $mergedResults = New-MtMergedAdForestResult -ForestResults $multiForestResults -InvokeCommand $combinedInvokeCommand
+            if ($mergedResults -and (
+                    -not [string]::IsNullOrEmpty($out.OutputJsonFile) -or
+                    -not [string]::IsNullOrEmpty($out.OutputMarkdownFile) -or
+                    -not [string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile) -or
+                    -not [string]::IsNullOrEmpty($out.OutputCsvFile) -or
+                    -not [string]::IsNullOrEmpty($out.OutputExcelFile) -or
+                    -not [string]::IsNullOrEmpty($out.OutputHtmlFile))) {
+                Write-MtMaesterOutputs -MaesterResults $mergedResults -TestCount @($mergedResults.Tests).Count
+            }
+
+            if ($PassThru) {
+                return $multiForestResults
+            }
+
+            return
+        }
+    }
+
     # If DriftRoot is specified, set the environment variable for drift tests.
     if ($DriftRoot) {
         $DriftRoot = (Resolve-Path -Path $DriftRoot -ErrorAction SilentlyContinue).Path
@@ -487,80 +863,28 @@
 
         Write-MtProgress -Activity 'Processing test results' -Status "$($pesterResults.TotalCount) test(s)" -Force
 
-        # Build the Invoke-Maester command string from bound parameters
-        $invokeMaesterCommand = "Invoke-Maester"
-        foreach ($param in $PSBoundParameters.GetEnumerator()) {
-            $paramName = $param.Key
-            $paramValue = $param.Value
-            if ($paramValue -is [switch]) {
-                if ($paramValue.IsPresent) {
-                    $invokeMaesterCommand += " -$paramName"
-                }
-            } elseif ($paramValue -is [array]) {
-                $invokeMaesterCommand += " -$paramName @('$($paramValue -join "', '")')"
-            } elseif ($paramValue -is [string]) {
-                $invokeMaesterCommand += " -$paramName '$paramValue'"
-            } elseif ($null -ne $paramValue) {
-                $invokeMaesterCommand += " -$paramName $paramValue"
+        $invokeMaesterCommand = Get-MtInvokeMaesterCommand -BoundParameters $PSBoundParameters
+
+        if ($__MtSession.ADRunContext) {
+            $adContextParts = @()
+            if (-not [string]::IsNullOrWhiteSpace($__MtSession.ADRunContext.ForestName)) {
+                $adContextParts += "ADForest='$($__MtSession.ADRunContext.ForestName)'"
+            }
+            if (-not [string]::IsNullOrWhiteSpace($__MtSession.ADRunContext.ForestRootDomain)) {
+                $adContextParts += "ADForestRoot='$($__MtSession.ADRunContext.ForestRootDomain)'"
+            }
+            if (-not [string]::IsNullOrWhiteSpace($__MtSession.ADRunContext.TargetServer)) {
+                $adContextParts += "ADTarget='$($__MtSession.ADRunContext.TargetServer)'"
+            }
+
+            if ($adContextParts.Count -gt 0) {
+                $invokeMaesterCommand += " # " + ($adContextParts -join '; ')
             }
         }
 
         $maesterResults = ConvertTo-MtMaesterResult -PesterResults $PesterResults -OutputFiles $out -InvokeMaesterCommand $invokeMaesterCommand -PesterConfiguration $pesterConfig -SkipVersionCheck:$SkipVersionCheck
 
-        if (![string]::IsNullOrEmpty($out.OutputJsonFile)) {
-            $maesterResults | ConvertTo-Json -Depth 5 -WarningAction SilentlyContinue | Out-File -FilePath $out.OutputJsonFile -Encoding UTF8
-        }
-
-        if (![string]::IsNullOrEmpty($out.OutputMarkdownFile)) {
-            Write-MtProgress -Activity 'Creating markdown report'
-            $output = Get-MtMarkdownReport -MaesterResults $maesterResults
-            $output | Out-File -FilePath $out.OutputMarkdownFile -Encoding UTF8
-        }
-
-        if (![string]::IsNullOrEmpty($out.OutputMarkdownSummaryFile)) {
-            Write-MtProgress -Activity 'Creating markdown summary report'
-            $output = Get-MtMarkdownSummaryReport -MaesterResults $maesterResults
-            $output | Out-File -FilePath $out.OutputMarkdownSummaryFile -Encoding UTF8
-        }
-
-        if (![string]::IsNullOrEmpty($out.OutputCsvFile)) {
-            Write-MtProgress -Activity 'Creating CSV'
-            Convert-MtResultsToFlatObject -InputObject $maesterResults -CsvFilePath $out.OutputCsvFile
-        }
-
-        if (![string]::IsNullOrEmpty($out.OutputExcelFile)) {
-            Write-MtProgress -Activity 'Creating Excel workbook'
-            Convert-MtResultsToFlatObject -InputObject $maesterResults -ExcelFilePath $out.OutputExcelFile
-        }
-
-        if (![string]::IsNullOrEmpty($out.OutputHtmlFile)) {
-            Write-MtProgress -Activity 'Creating html report'
-            $output = Get-MtHtmlReport -MaesterResults $maesterResults
-            $output | Out-File -FilePath $out.OutputHtmlFile -Encoding UTF8
-            if (-not $NonInteractive.IsPresent) {
-                Write-Host "🔥 Maester test report generated at $($out.OutputHtmlFile)" -ForegroundColor Green
-            }
-
-            if ( ( Get-MtUserInteractive ) -and ( -not $NonInteractive ) ) {
-                # Open test results in the default browser.
-                Invoke-Item $out.OutputHtmlFile | Out-Null
-            }
-        }
-
-        if ($MailRecipient) {
-            Write-MtProgress -Activity 'Sending mail'
-            Send-MtMail -MaesterResults $maesterResults -Recipient $MailRecipient -TestResultsUri $MailTestResultsUri -UserId $MailUserId
-        }
-
-        if ($TeamId -and $TeamChannelId) {
-            Write-MtProgress -Activity 'Sending Teams message'
-            Send-MtTeamsMessage -MaesterResults $maesterResults -TeamId $TeamId -TeamChannelId $TeamChannelId -TestResultsUri $MailTestResultsUri
-        }
-
-        if ($TeamChannelWebhookUri) {
-            Write-MtProgress -Activity 'Sending Teams message'
-            Send-MtTeamsMessage -MaesterResults $maesterResults -TeamChannelWebhookUri $TeamChannelWebhookUri -TestResultsUri $MailTestResultsUri
-        }
+        Write-MtMaesterOutputs -MaesterResults $maesterResults -TestCount $PesterResults.TotalCount
 
         if ($Verbosity -eq 'None' -and -not $NonInteractive.IsPresent) {
             # Show final summary.

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -366,6 +366,50 @@
             return $null
         }
 
+        function ConvertTo-MtTimeSpan {
+            param(
+                [Parameter(Mandatory = $false)]
+                $Value
+            )
+
+            if ($null -eq $Value) {
+                return [TimeSpan]::Zero
+            }
+
+            if ($Value -is [TimeSpan]) {
+                return $Value
+            }
+
+            $parsedTimeSpan = [TimeSpan]::Zero
+            if ([TimeSpan]::TryParse([string]$Value, [ref]$parsedTimeSpan)) {
+                return $parsedTimeSpan
+            }
+
+            return [TimeSpan]::Zero
+        }
+
+        function ConvertTo-MtDateTime {
+            param(
+                [Parameter(Mandatory = $false)]
+                $Value
+            )
+
+            if ($null -eq $Value) {
+                return $null
+            }
+
+            if ($Value -is [DateTime]) {
+                return $Value
+            }
+
+            $parsedDateTime = [DateTime]::MinValue
+            if ([DateTime]::TryParse([string]$Value, [ref]$parsedDateTime)) {
+                return $parsedDateTime
+            }
+
+            return $null
+        }
+
         $mergedResult = Merge-MtMaesterResult -MaesterResults $ForestResults
         $mergedTenants = $mergedResult.Tenants
         $firstResult = @($ForestResults)[0]
@@ -394,6 +438,11 @@
         $skippedCount = 0
         $investigateCount = 0
         $notRunCount = 0
+        $totalDuration = [TimeSpan]::Zero
+        $userDuration = [TimeSpan]::Zero
+        $discoveryDuration = [TimeSpan]::Zero
+        $frameworkDuration = [TimeSpan]::Zero
+        $earliestExecutedAt = $null
 
         foreach ($forestResult in $ForestResults) {
             $totalCount += [int]$forestResult.TotalCount
@@ -403,6 +452,16 @@
             $skippedCount += [int]$forestResult.SkippedCount
             $investigateCount += [int]$forestResult.InvestigateCount
             $notRunCount += [int]$forestResult.NotRunCount
+
+            $totalDuration += ConvertTo-MtTimeSpan -Value $forestResult.TotalDuration
+            $userDuration += ConvertTo-MtTimeSpan -Value $forestResult.UserDuration
+            $discoveryDuration += ConvertTo-MtTimeSpan -Value $forestResult.DiscoveryDuration
+            $frameworkDuration += ConvertTo-MtTimeSpan -Value $forestResult.FrameworkDuration
+
+            $executedAt = ConvertTo-MtDateTime -Value $forestResult.ExecutedAt
+            if ($executedAt -and (($null -eq $earliestExecutedAt) -or ($executedAt -lt $earliestExecutedAt))) {
+                $earliestExecutedAt = $executedAt
+            }
         }
 
         $resultState = if ($failedCount -gt 0 -or $errorCount -gt 0) {
@@ -428,6 +487,14 @@
         $mergedResult | Add-Member -NotePropertyName 'SkippedCount' -NotePropertyValue $skippedCount -Force
         $mergedResult | Add-Member -NotePropertyName 'InvestigateCount' -NotePropertyValue $investigateCount -Force
         $mergedResult | Add-Member -NotePropertyName 'NotRunCount' -NotePropertyValue $notRunCount -Force
+        $mergedResult | Add-Member -NotePropertyName 'TotalDuration' -NotePropertyValue $totalDuration -Force
+        $mergedResult | Add-Member -NotePropertyName 'UserDuration' -NotePropertyValue $userDuration -Force
+        $mergedResult | Add-Member -NotePropertyName 'DiscoveryDuration' -NotePropertyValue $discoveryDuration -Force
+        $mergedResult | Add-Member -NotePropertyName 'FrameworkDuration' -NotePropertyValue $frameworkDuration -Force
+        if ($earliestExecutedAt) {
+            $mergedResult | Add-Member -NotePropertyName 'ExecutedAt' -NotePropertyValue $earliestExecutedAt -Force
+        }
+        $mergedResult | Add-Member -NotePropertyName 'ActiveDirectoryContext' -NotePropertyValue $null -Force
         $mergedResult | Add-Member -NotePropertyName 'Tests' -NotePropertyValue @($combinedTests) -Force
         $mergedResult | Add-Member -NotePropertyName 'Tenants' -NotePropertyValue @($mergedTenants) -Force
         $mergedResult | Add-Member -NotePropertyName 'InvokeCommand' -NotePropertyValue $InvokeCommand -Force
@@ -731,7 +798,7 @@
             $__MtSession.ADRunContext = Get-MtAdRunContext -TargetServer $__MtSession.ADConnection.TargetServer
             if ($__MtSession.ADRunContext.ForestName) {
                 Write-Verbose "Running AD tests for forest '$($__MtSession.ADRunContext.ForestName)' via target '$($__MtSession.ADRunContext.TargetServer)'."
-                Write-MtProgress -Activity 'Starting Maester' -Status "Forest: $__MtSession.ADRunContext.ForestName" -Force
+                Write-MtProgress -Activity 'Starting Maester' -Status "Forest: $($__MtSession.ADRunContext.ForestName)" -Force
             }
         }
 
@@ -742,74 +809,94 @@
             $originalTargetServers = @($__MtSession.ADConnection.TargetServers)
             $originalAdRunContext = $__MtSession.ADRunContext
             $multiForestResults = @()
+            $multiForestFailures = @()
             $baseFileName = if ([string]::IsNullOrWhiteSpace($OutputFolderFileName)) { "TestResults-$(Get-Date -Format 'yyyy-MM-dd-HHmmss')" } else { $OutputFolderFileName }
 
-            foreach ($adTarget in $adTargets) {
-                $__MtSession.ADConnection.TargetServer = $adTarget
-                $__MtSession.ADConnection.TargetServers = @($adTarget)
-                Clear-MtADCache
+            try {
+                foreach ($adTarget in $adTargets) {
+                    $__MtSession.ADConnection.TargetServer = $adTarget
+                    $__MtSession.ADConnection.TargetServers = @($adTarget)
+                    Clear-MtADCache
 
-                $__MtSession.ADRunContext = Get-MtAdRunContext -TargetServer $adTarget -RefreshAdState
-                $forestName = $__MtSession.ADRunContext.ForestName
-                $targetServer = if ($__MtSession.ADRunContext.TargetServer) { $__MtSession.ADRunContext.TargetServer } else { $adTarget }
-                $contextStatus = if ($forestName) { "Forest: $forestName" } else { "Target: $targetServer" }
-                $contextDescriptor = if ($forestName) { "forest '$forestName' via target '$targetServer'" } else { "target '$targetServer'" }
-                Write-Verbose "Running AD tests for $contextDescriptor"
-                Write-MtProgress -Activity 'Starting Maester' -Status "Preparing Active Directory context - $contextStatus" -Force
+                    $__MtSession.ADRunContext = Get-MtAdRunContext -TargetServer $adTarget -RefreshAdState
+                    $forestName = $__MtSession.ADRunContext.ForestName
+                    $targetServer = if ($__MtSession.ADRunContext.TargetServer) { $__MtSession.ADRunContext.TargetServer } else { $adTarget }
+                    $contextStatus = if ($forestName) { "Forest: $forestName" } else { "Target: $targetServer" }
+                    $contextDescriptor = if ($forestName) { "forest '$forestName' via target '$targetServer'" } else { "target '$targetServer'" }
+                    Write-Verbose "Running AD tests for $contextDescriptor"
+                    Write-MtProgress -Activity 'Starting Maester' -Status "Preparing Active Directory context - $contextStatus" -Force
 
-                $contextSuffixSource = if ($forestName) {
-                    if ($targetServer -and $targetServer -ne $forestName) {
-                        "$forestName-$targetServer"
+                    $contextSuffixSource = if ($forestName) {
+                        if ($targetServer -and $targetServer -ne $forestName) {
+                            "$forestName-$targetServer"
+                        } else {
+                            $forestName
+                        }
                     } else {
-                        $forestName
+                        $targetServer
                     }
-                } else {
-                    $targetServer
+
+                    $targetSuffix = ($contextSuffixSource -replace '[^A-Za-z0-9._-]', '_')
+
+                    $targetParams = @{}
+                    foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+                        $targetParams[$entry.Key] = $entry.Value
+                    }
+
+                    if (-not [string]::IsNullOrWhiteSpace($OutputFolder) -or -not [string]::IsNullOrWhiteSpace($OutputFolderFileName)) {
+                        $targetParams['OutputFolderFileName'] = "$baseFileName-$targetSuffix"
+                    } else {
+                        if (-not [string]::IsNullOrWhiteSpace($OutputHtmlFile)) {
+                            $targetParams['OutputHtmlFile'] = Add-SuffixToPath -FilePath $OutputHtmlFile -Suffix $targetSuffix
+                        }
+                        if (-not [string]::IsNullOrWhiteSpace($OutputMarkdownFile)) {
+                            $targetParams['OutputMarkdownFile'] = Add-SuffixToPath -FilePath $OutputMarkdownFile -Suffix $targetSuffix
+                        }
+                        if (-not [string]::IsNullOrWhiteSpace($OutputMarkdownSummaryFile)) {
+                            $targetParams['OutputMarkdownSummaryFile'] = Add-SuffixToPath -FilePath $OutputMarkdownSummaryFile -Suffix $targetSuffix
+                        }
+                        if (-not [string]::IsNullOrWhiteSpace($OutputJsonFile)) {
+                            $targetParams['OutputJsonFile'] = Add-SuffixToPath -FilePath $OutputJsonFile -Suffix $targetSuffix
+                        }
+                    }
+
+                    $targetParams['PassThru'] = $true
+
+                    try {
+                        $targetResult = Invoke-Maester @targetParams -ErrorAction Stop
+                        if ($targetResult) {
+                            foreach ($result in @($targetResult)) {
+                                $result | Add-Member -NotePropertyName 'ADTargetServer' -NotePropertyValue $targetServer -Force
+                                $result | Add-Member -NotePropertyName 'ADForestName' -NotePropertyValue $forestName -Force
+                                $result | Add-Member -NotePropertyName 'ADForestRootDomain' -NotePropertyValue $__MtSession.ADRunContext.ForestRootDomain -Force
+                            }
+                            $multiForestResults += @($targetResult)
+                        }
+                    } catch {
+                        $failureRecord = [PSCustomObject]@{
+                            TargetServer = $targetServer
+                            ForestName   = $forestName
+                            Error        = $_.Exception.Message
+                        }
+                        $multiForestFailures += $failureRecord
+                        Write-Warning "Skipping AD target '$targetServer' after failure: $($_.Exception.Message)"
+                    }
                 }
-
-                $targetSuffix = ($contextSuffixSource -replace '[^A-Za-z0-9._-]', '_')
-
-                $targetParams = @{}
-                foreach ($entry in $PSBoundParameters.GetEnumerator()) {
-                    $targetParams[$entry.Key] = $entry.Value
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($OutputFolder) -or -not [string]::IsNullOrWhiteSpace($OutputFolderFileName)) {
-                    $targetParams['OutputFolderFileName'] = "$baseFileName-$targetSuffix"
-                } else {
-                    if (-not [string]::IsNullOrWhiteSpace($OutputHtmlFile)) {
-                        $targetParams['OutputHtmlFile'] = Add-SuffixToPath -FilePath $OutputHtmlFile -Suffix $targetSuffix
-                    }
-                    if (-not [string]::IsNullOrWhiteSpace($OutputMarkdownFile)) {
-                        $targetParams['OutputMarkdownFile'] = Add-SuffixToPath -FilePath $OutputMarkdownFile -Suffix $targetSuffix
-                    }
-                    if (-not [string]::IsNullOrWhiteSpace($OutputMarkdownSummaryFile)) {
-                        $targetParams['OutputMarkdownSummaryFile'] = Add-SuffixToPath -FilePath $OutputMarkdownSummaryFile -Suffix $targetSuffix
-                    }
-                    if (-not [string]::IsNullOrWhiteSpace($OutputJsonFile)) {
-                        $targetParams['OutputJsonFile'] = Add-SuffixToPath -FilePath $OutputJsonFile -Suffix $targetSuffix
-                    }
-                }
-
-                $targetParams['PassThru'] = $true
-
-                $targetResult = Invoke-Maester @targetParams
-                if ($targetResult) {
-                    foreach ($result in @($targetResult)) {
-                        $result | Add-Member -NotePropertyName 'ADTargetServer' -NotePropertyValue $targetServer -Force
-                        $result | Add-Member -NotePropertyName 'ADForestName' -NotePropertyValue $forestName -Force
-                        $result | Add-Member -NotePropertyName 'ADForestRootDomain' -NotePropertyValue $__MtSession.ADRunContext.ForestRootDomain -Force
-                    }
-                    $multiForestResults += @($targetResult)
-                }
+            } finally {
+                $__MtSession.ADConnection.TargetServer = $originalTargetServer
+                $__MtSession.ADConnection.TargetServers = $originalTargetServers
+                $__MtSession.ADRunContext = $originalAdRunContext
             }
 
-            $__MtSession.ADConnection.TargetServer = $originalTargetServer
-            $__MtSession.ADConnection.TargetServers = $originalTargetServers
-            $__MtSession.ADRunContext = $originalAdRunContext
+            if ($multiForestFailures.Count -gt 0) {
+                Write-Warning "Multi-forest AD run skipped $($multiForestFailures.Count) target(s) due to errors."
+            }
 
             $combinedInvokeCommand = Get-MtInvokeMaesterCommand -BoundParameters $PSBoundParameters -Comment 'Merged multi-forest AD report'
             $mergedResults = New-MtMergedAdForestResult -ForestResults $multiForestResults -InvokeCommand $combinedInvokeCommand
+            if ($mergedResults -and $multiForestFailures.Count -gt 0) {
+                $mergedResults | Add-Member -NotePropertyName 'ADTargetFailures' -NotePropertyValue @($multiForestFailures) -Force
+            }
             if ($mergedResults -and (
                     -not [string]::IsNullOrEmpty($out.OutputJsonFile) -or
                     -not [string]::IsNullOrEmpty($out.OutputMarkdownFile) -or

--- a/powershell/public/Invoke-Maester.ps1
+++ b/powershell/public/Invoke-Maester.ps1
@@ -381,7 +381,7 @@
             }
 
             $parsedTimeSpan = [TimeSpan]::Zero
-            if ([TimeSpan]::TryParse([string]$Value, [ref]$parsedTimeSpan)) {
+            if ([TimeSpan]::TryParse([string]$Value, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsedTimeSpan)) {
                 return $parsedTimeSpan
             }
 
@@ -403,7 +403,7 @@
             }
 
             $parsedDateTime = [DateTime]::MinValue
-            if ([DateTime]::TryParse([string]$Value, [ref]$parsedDateTime)) {
+            if ([DateTime]::TryParse([string]$Value, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::None, [ref]$parsedDateTime)) {
                 return $parsedDateTime
             }
 
@@ -845,6 +845,11 @@
 
                     if (-not [string]::IsNullOrWhiteSpace($OutputFolder) -or -not [string]::IsNullOrWhiteSpace($OutputFolderFileName)) {
                         $targetParams['OutputFolderFileName'] = "$baseFileName-$targetSuffix"
+                    } elseif ([string]::IsNullOrWhiteSpace($OutputHtmlFile) -and
+                        [string]::IsNullOrWhiteSpace($OutputMarkdownFile) -and
+                        [string]::IsNullOrWhiteSpace($OutputMarkdownSummaryFile) -and
+                        [string]::IsNullOrWhiteSpace($OutputJsonFile)) {
+                        $targetParams['OutputFolderFileName'] = "$baseFileName-$targetSuffix"
                     } else {
                         if (-not [string]::IsNullOrWhiteSpace($OutputHtmlFile)) {
                             $targetParams['OutputHtmlFile'] = Add-SuffixToPath -FilePath $OutputHtmlFile -Suffix $targetSuffix
@@ -893,7 +898,10 @@
             }
 
             $combinedInvokeCommand = Get-MtInvokeMaesterCommand -BoundParameters $PSBoundParameters -Comment 'Merged multi-forest AD report'
-            $mergedResults = New-MtMergedAdForestResult -ForestResults $multiForestResults -InvokeCommand $combinedInvokeCommand
+            $mergedResults = $null
+            if (@($multiForestResults).Count -gt 0) {
+                $mergedResults = New-MtMergedAdForestResult -ForestResults $multiForestResults -InvokeCommand $combinedInvokeCommand
+            }
             if ($mergedResults -and $multiForestFailures.Count -gt 0) {
                 $mergedResults | Add-Member -NotePropertyName 'ADTargetFailures' -NotePropertyValue @($multiForestFailures) -Force
             }

--- a/powershell/public/ad/domain/Test-MtAdMachineAccountQuota.ps1
+++ b/powershell/public/ad/domain/Test-MtAdMachineAccountQuota.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdMachineAccountQuota {
+function Test-MtAdMachineAccountQuota {
     <#
     .SYNOPSIS
     Retrieves the ms-DS-MachineAccountQuota value for the domain.
@@ -30,12 +30,14 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $domain = $adState.Domain
 
     # Try to get machine account quota from the domain object
     $machineAccountQuota = $null
     try {
-        $domainObject = Get-ADObject -Identity $domain.DistinguishedName -Properties ms-DS-MachineAccountQuota
+        $domainObject = Get-ADObject -Identity $domain.DistinguishedName -Properties ms-DS-MachineAccountQuota @adServerParameters
         $machineAccountQuota = $domainObject.'ms-DS-MachineAccountQuota'
     }
     catch {

--- a/powershell/public/ad/domain/Test-MtAdRidsRemaining.ps1
+++ b/powershell/public/ad/domain/Test-MtAdRidsRemaining.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdRidsRemaining {
+function Test-MtAdRidsRemaining {
     <#
     .SYNOPSIS
     Retrieves the number of remaining RIDs (Relative Identifiers) in the domain.
@@ -30,12 +30,14 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $domain = $adState.Domain
 
     # Try to get RID available pool from the domain object
     $ridsRemaining = $null
     try {
-        $domainObject = Get-ADObject -Identity $domain.DistinguishedName -Properties RIDAvailablePool
+        $domainObject = Get-ADObject -Identity $domain.DistinguishedName -Properties RIDAvailablePool @adServerParameters
         $ridsRemaining = $domainObject.RIDAvailablePool
     }
     catch {

--- a/powershell/public/ad/domain/Test-MtAdTombstoneLifetime.ps1
+++ b/powershell/public/ad/domain/Test-MtAdTombstoneLifetime.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdTombstoneLifetime {
+function Test-MtAdTombstoneLifetime {
     <#
     .SYNOPSIS
     Retrieves the tombstone lifetime in days.
@@ -31,6 +31,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $domain = $adState.Domain
 
     # Try to get tombstone lifetime from the domain object
@@ -38,7 +40,7 @@
     try {
         # Get the tombstone lifetime from the directory configuration
         $configurationNC = $domain.ConfigurationNamingContext
-        $tombstoneObject = Get-ADObject -Identity "CN=Directory Service,CN=Windows NT,CN=Services,$configurationNC" -Properties tombstoneLifetime -ErrorAction SilentlyContinue
+        $tombstoneObject = Get-ADObject -Identity "CN=Directory Service,CN=Windows NT,CN=Services,$configurationNC" -Properties tombstoneLifetime -ErrorAction SilentlyContinue @adServerParameters
         $tombstoneLifetime = $tombstoneObject.tombstoneLifetime
     }
     catch {

--- a/powershell/public/ad/gpo/Test-MtAdGpoBlockedInheritanceCount.ps1
+++ b/powershell/public/ad/gpo/Test-MtAdGpoBlockedInheritanceCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGpoBlockedInheritanceCount {
+function Test-MtAdGpoBlockedInheritanceCount {
     <#
     .SYNOPSIS
     Counts targets blocking GPO inheritance.
@@ -43,9 +43,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $ous = $null
     try {
-        $ous = Get-ADOrganizationalUnit -Filter * -Properties gpOptions -ErrorAction Stop
+        $ous = Get-ADOrganizationalUnit -Filter * -Properties gpOptions -ErrorAction Stop @adServerParameters
     }
     catch {
         Write-Verbose "Unable to retrieve Organizational Units for blocked inheritance check: $($_.Exception.Message)"

--- a/powershell/public/ad/gpo/Test-MtAdGpoLinkedOUCount.ps1
+++ b/powershell/public/ad/gpo/Test-MtAdGpoLinkedOUCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGpoLinkedOUCount {
+function Test-MtAdGpoLinkedOUCount {
     <#
     .SYNOPSIS
     Counts the number of Organizational Units with GPO links in Active Directory.
@@ -30,9 +30,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get all OUs in the domain
     try {
-        $allOUs = Get-ADOrganizationalUnit -Filter * -Properties gPLink
+        $allOUs = Get-ADOrganizationalUnit -Filter * -Properties gPLink @adServerParameters
         $totalOUs = ($allOUs | Measure-Object).Count
 
         # Count OUs with GPO links (gPLink is not null or empty)

--- a/powershell/public/ad/gpo/Test-MtAdGpoUnlinkedTargetCount.ps1
+++ b/powershell/public/ad/gpo/Test-MtAdGpoUnlinkedTargetCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGpoUnlinkedTargetCount {
+function Test-MtAdGpoUnlinkedTargetCount {
     <#
     .SYNOPSIS
     Counts AD targets (OUs, domains, sites) that do not have any GPO links.
@@ -34,6 +34,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     function Test-MtGpoLinkPresent {
         param(
             [Parameter(Mandatory = $false)]
@@ -61,7 +63,7 @@
 
     # OUs
     try {
-        $ous = Get-ADOrganizationalUnit -Filter * -Properties DistinguishedName, gPLink
+        $ous = Get-ADOrganizationalUnit -Filter * -Properties DistinguishedName, gPLink @adServerParameters
         if ($null -ne $ous) {
             foreach ($ou in @($ous)) {
                 $ouLink = $null
@@ -82,8 +84,8 @@
 
     # Domain root
     try {
-        $domain = Get-ADDomain
-        $domainObj = Get-ADObject -Identity $domain.DistinguishedName -Properties DistinguishedName, gPLink
+        $domain = Get-ADDomain @adServerParameters
+        $domainObj = Get-ADObject -Identity $domain.DistinguishedName -Properties DistinguishedName, gPLink @adServerParameters
         $domainLink = $null
         if ($domainObj -and $domainObj.PSObject.Properties.Match('gPLink')) {
             $domainLink = $domainObj.gPLink

--- a/powershell/public/ad/group/Test-MtAdGroupEmptyNonPrivilegedCount.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupEmptyNonPrivilegedCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupEmptyNonPrivilegedCount {
+function Test-MtAdGroupEmptyNonPrivilegedCount {
     <#
     .SYNOPSIS
     Counts empty non-privileged groups in Active Directory.
@@ -26,6 +26,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
     $totalGroups = ($groups | Measure-Object).Count
 
@@ -36,7 +38,7 @@
 
     foreach ($group in $groups) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             $memberCount = ($members | Measure-Object).Count
 
             if ($memberCount -eq 0) {

--- a/powershell/public/ad/group/Test-MtAdGroupEmptyNonPrivilegedDetails.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupEmptyNonPrivilegedDetails.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupEmptyNonPrivilegedDetails {
+function Test-MtAdGroupEmptyNonPrivilegedDetails {
     <#
     .SYNOPSIS
     Details of empty non-privileged groups in Active Directory.
@@ -27,6 +27,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
 
     # Collect empty non-privileged groups
@@ -34,7 +36,7 @@
 
     foreach ($group in $groups) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             $memberCount = ($members | Measure-Object).Count
 
             if ($memberCount -eq 0 -and $group.adminCount -ne 1) {

--- a/powershell/public/ad/group/Test-MtAdGroupMemberAccountTypeCount.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberAccountTypeCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberAccountTypeCount {
+function Test-MtAdGroupMemberAccountTypeCount {
     <#
     .SYNOPSIS
     Counts the distinct account types of members across Active Directory groups.
@@ -31,6 +31,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
 
     # Collect all unique member object classes
@@ -41,7 +43,7 @@
 
     foreach ($group in $groupsToCheck) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             foreach ($member in $members) {
                 # Avoid duplicates by SID
                 if (-not $processedSids.ContainsKey($member.SID.Value)) {

--- a/powershell/public/ad/group/Test-MtAdGroupMemberAccountTypeDetails.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberAccountTypeDetails.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberAccountTypeDetails {
+function Test-MtAdGroupMemberAccountTypeDetails {
     <#
     .SYNOPSIS
     Provides detailed breakdown of member account types across Active Directory groups.
@@ -33,6 +33,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
 
     # Collect all members and their types
@@ -43,7 +45,7 @@
 
     foreach ($group in $groupsToCheck) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             foreach ($member in $members) {
                 # Avoid duplicates by SID
                 if (-not $processedSids.ContainsKey($member.SID.Value)) {

--- a/powershell/public/ad/group/Test-MtAdGroupMemberDistinctGroupCount.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberDistinctGroupCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberDistinctGroupCount {
+function Test-MtAdGroupMemberDistinctGroupCount {
     <#
     .SYNOPSIS
     Counts the distinct groups that have members in Active Directory.
@@ -30,6 +30,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
     $totalGroupCount = ($groups | Measure-Object).Count
 
@@ -40,7 +42,7 @@
 
     foreach ($group in $groupsToCheck) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             if ($members -and ($members | Measure-Object).Count -gt 0) {
                 $groupsWithMembers += $group
             }

--- a/powershell/public/ad/group/Test-MtAdGroupMemberForeignSidCount.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberForeignSidCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberForeignSidCount {
+function Test-MtAdGroupMemberForeignSidCount {
     <#
     .SYNOPSIS
     Counts the foreign SID principals in Active Directory groups.
@@ -32,6 +32,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
     $domain = $adState.Domain
     $domainSid = $domain.DomainSID.Value
@@ -44,7 +46,7 @@
 
     foreach ($group in $groupsToCheck) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             foreach ($member in $members) {
                 # Check if SID is foreign (doesn't start with domain SID)
                 if ($member.SID.Value -and -not $member.SID.Value.StartsWith($domainSid)) {

--- a/powershell/public/ad/group/Test-MtAdGroupMemberForeignSidDetails.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberForeignSidDetails.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberForeignSidDetails {
+function Test-MtAdGroupMemberForeignSidDetails {
     <#
     .SYNOPSIS
     Details of foreign security principals by their domain of origin.
@@ -27,6 +27,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
     $domain = $adState.Domain
     $domainSid = $domain.DomainSID.Value
@@ -38,7 +40,7 @@
     foreach ($group in $groups) {
         try {
             # Get group members
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
 
             foreach ($member in $members) {
                 if ($member.SID -and $member.SID.Value) {

--- a/powershell/public/ad/group/Test-MtAdGroupMemberTrustCount.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberTrustCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberTrustCount {
+function Test-MtAdGroupMemberTrustCount {
     <#
     .SYNOPSIS
     Counts the trust members in Active Directory groups.
@@ -32,6 +32,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
     $domain = $adState.Domain
     $domainSid = $domain.DomainSID.Value
@@ -44,7 +46,7 @@
 
     foreach ($group in $groupsToCheck) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             foreach ($member in $members) {
                 # Check if this is a trust member (foreignSecurityPrincipal or SID doesn't match domain)
                 $isTrustMember = $false

--- a/powershell/public/ad/group/Test-MtAdGroupMemberTrustDetails.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupMemberTrustDetails.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupMemberTrustDetails {
+function Test-MtAdGroupMemberTrustDetails {
     <#
     .SYNOPSIS
     Provides detailed breakdown of trust members by group in Active Directory.
@@ -33,6 +33,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
     $domain = $adState.Domain
     $domainSid = $domain.DomainSID.Value
@@ -45,7 +47,7 @@
 
     foreach ($group in $groupsToCheck) {
         try {
-            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+            $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
             $groupTrustMembers = @()
 
             foreach ($member in $members) {

--- a/powershell/public/ad/group/Test-MtAdGroupPrivilegedWithMembersCount.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupPrivilegedWithMembersCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupPrivilegedWithMembersCount {
+function Test-MtAdGroupPrivilegedWithMembersCount {
     <#
     .SYNOPSIS
     Counts privileged groups that have members in Active Directory.
@@ -35,6 +35,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
 
     # Well-known privileged group RIDs
@@ -66,7 +68,7 @@
             $totalPrivileged++
 
             try {
-                $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+                $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
                 $memberCount = ($members | Measure-Object).Count
 
                 if ($memberCount -gt 0) {

--- a/powershell/public/ad/group/Test-MtAdGroupPrivilegedWithMembersDetails.ps1
+++ b/powershell/public/ad/group/Test-MtAdGroupPrivilegedWithMembersDetails.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdGroupPrivilegedWithMembersDetails {
+function Test-MtAdGroupPrivilegedWithMembersDetails {
     <#
     .SYNOPSIS
     Details of privileged groups with their member counts in Active Directory.
@@ -36,6 +36,8 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     $groups = $adState.Groups
 
     # Well-known privileged group RIDs
@@ -60,7 +62,7 @@
 
         if ($isPrivileged -or $isWellKnown) {
             try {
-                $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue
+                $members = Get-ADGroupMember -Identity $group.DistinguishedName -ErrorAction SilentlyContinue @adServerParameters
                 $memberCount = ($members | Measure-Object).Count
 
                 $privilegedGroups += [PSCustomObject]@{

--- a/powershell/public/ad/passwordpolicy/Test-MtAdAccountLockoutDuration.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdAccountLockoutDuration.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdAccountLockoutDuration {
+function Test-MtAdAccountLockoutDuration {
     <#
     .SYNOPSIS
     Checks the account lockout duration configured in the default domain password policy.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $lockoutDuration = $passwordPolicy.LockoutDuration
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdAccountLockoutThreshold.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdAccountLockoutThreshold.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdAccountLockoutThreshold {
+function Test-MtAdAccountLockoutThreshold {
     <#
     .SYNOPSIS
     Checks the account lockout threshold configured in the default domain password policy.
@@ -32,9 +32,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $lockoutThreshold = $passwordPolicy.LockoutThreshold
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicyAppliesTo.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicyAppliesTo.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdFineGrainedPolicyAppliesTo {
+function Test-MtAdFineGrainedPolicyAppliesTo {
     <#
     .SYNOPSIS
     Shows which users and groups each fine-grained password policy applies to.
@@ -32,9 +32,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get fine-grained password policies
     try {
-        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -Properties AppliesTo -ErrorAction Stop
+        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -Properties AppliesTo -ErrorAction Stop @adServerParameters
         $policyCount = ($fgppPolicies | Measure-Object).Count
     } catch {
         Write-Error "Failed to retrieve fine-grained password policies: $($_.Exception.Message)"
@@ -62,7 +64,7 @@
                     foreach ($target in $appliesTo) {
                         try {
                             # Try to resolve the DN to a friendly name
-                            $object = Get-ADObject -Identity $target -Properties ObjectClass -ErrorAction SilentlyContinue
+                            $object = Get-ADObject -Identity $target -Properties ObjectClass -ErrorAction SilentlyContinue @adServerParameters
                             if ($object) {
                                 $objectClass = $object.ObjectClass
                                 $objectName = $object.Name

--- a/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicyCount.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicyCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdFineGrainedPolicyCount {
+function Test-MtAdFineGrainedPolicyCount {
     <#
     .SYNOPSIS
     Counts the number of fine-grained password policies configured in the domain.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get fine-grained password policies
     try {
-        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -ErrorAction Stop
+        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -ErrorAction Stop @adServerParameters
         $policyCount = ($fgppPolicies | Measure-Object).Count
     } catch {
         Write-Error "Failed to retrieve fine-grained password policies: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicySettingCounts.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicySettingCounts.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdFineGrainedPolicySettingCounts {
+function Test-MtAdFineGrainedPolicySettingCounts {
     <#
     .SYNOPSIS
     Provides a detailed breakdown of settings across all fine-grained password policies.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get fine-grained password policies
     try {
-        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -ErrorAction Stop
+        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -ErrorAction Stop @adServerParameters
         $policyCount = ($fgppPolicies | Measure-Object).Count
     } catch {
         Write-Error "Failed to retrieve fine-grained password policies: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicyValueCount.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdFineGrainedPolicyValueCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdFineGrainedPolicyValueCount {
+function Test-MtAdFineGrainedPolicyValueCount {
     <#
     .SYNOPSIS
     Analyzes distinct values across all fine-grained password policies.
@@ -32,9 +32,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get fine-grained password policies
     try {
-        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -ErrorAction Stop
+        $fgppPolicies = Get-ADFineGrainedPasswordPolicy -Filter * -ErrorAction Stop @adServerParameters
         $policyCount = ($fgppPolicies | Measure-Object).Count
     } catch {
         Write-Error "Failed to retrieve fine-grained password policies: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdPasswordComplexityRequired.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdPasswordComplexityRequired.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdPasswordComplexityRequired {
+function Test-MtAdPasswordComplexityRequired {
     <#
     .SYNOPSIS
     Checks whether password complexity is required in the default domain password policy.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $complexityEnabled = $passwordPolicy.ComplexityEnabled
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdPasswordHistoryCount.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdPasswordHistoryCount.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdPasswordHistoryCount {
+function Test-MtAdPasswordHistoryCount {
     <#
     .SYNOPSIS
     Checks the password history count configured in the default domain password policy.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $passwordHistoryCount = $passwordPolicy.PasswordHistoryCount
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdPasswordMaxAge.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdPasswordMaxAge.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdPasswordMaxAge {
+function Test-MtAdPasswordMaxAge {
     <#
     .SYNOPSIS
     Checks the maximum password age configured in the default domain password policy.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $maxPasswordAge = $passwordPolicy.MaxPasswordAge
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdPasswordMinLength.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdPasswordMinLength.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdPasswordMinLength {
+function Test-MtAdPasswordMinLength {
     <#
     .SYNOPSIS
     Checks the minimum password length configured in the default domain password policy.
@@ -32,9 +32,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $minPasswordLength = $passwordPolicy.MinPasswordLength
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/public/ad/passwordpolicy/Test-MtAdPasswordReversibleEncryption.ps1
+++ b/powershell/public/ad/passwordpolicy/Test-MtAdPasswordReversibleEncryption.ps1
@@ -1,4 +1,4 @@
-﻿function Test-MtAdPasswordReversibleEncryption {
+function Test-MtAdPasswordReversibleEncryption {
     <#
     .SYNOPSIS
     Checks whether reversible encryption is enabled for passwords in the default domain password policy.
@@ -33,9 +33,11 @@
         return $null
     }
 
+    $adServerParameters = Get-MtADServerParameters
+
     # Get the default domain password policy
     try {
-        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop
+        $passwordPolicy = Get-ADDefaultDomainPasswordPolicy -ErrorAction Stop @adServerParameters
         $reversibleEncryption = $passwordPolicy.ReversibleEncryptionEnabled
     } catch {
         Write-Error "Failed to retrieve password policy: $($_.Exception.Message)"

--- a/powershell/tests/functions/ActiveDirectoryOptIn.Tests.ps1
+++ b/powershell/tests/functions/ActiveDirectoryOptIn.Tests.ps1
@@ -66,13 +66,13 @@ Describe 'Active Directory Pester tests remain opt-in' {
         $probeTest = @'
 Describe 'AD opt-in probe' -Tag 'AD' {
     It 'AD-OPT-IN: runs only after an explicit connection' {
-        New-Item -Path '__MARKER_PATH__' -ItemType File | Out-Null
+        New-Item -Path '__MARKER_PATH__' -ItemType File -Force | Out-Null
         $true | Should -BeTrue
     }
 }
 '@
         $probeTest.Replace('__MARKER_PATH__', $script:adMarkerPath) |
-            Set-Content -Path (Join-Path $script:adTestPath 'ActiveDirectory.Tests.ps1')
+        Set-Content -Path (Join-Path $script:adTestPath 'ActiveDirectory.Tests.ps1')
 
         InModuleScope Maester {
             $__MtSession.ADConnection = $null
@@ -102,6 +102,30 @@ Describe 'AD opt-in probe' -Tag 'AD' {
         Invoke-Maester -Path $script:adTestPath -Tag 'AD' -OutputJsonFile $script:adResultPath -SkipGraphConnect -NonInteractive -NoLogo -DisableTelemetry -SkipVersionCheck
 
         Test-Path $script:adMarkerPath | Should -BeTrue
+    }
+
+    It 'Runs AD tests once per connected forest target when multiple targets are configured' {
+        InModuleScope Maester {
+            $__MtSession.ADConnection = [PSCustomObject]@{
+                Connected        = $true
+                DomainController = 'dc01.contoso.com'
+                TargetServer     = 'dc01.contoso.com'
+                TargetServers    = @('dc01.contoso.com', 'dc01.fabrikam.net')
+            }
+        }
+
+        $outputFolder = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+        New-Item -Path $outputFolder -ItemType Directory | Out-Null
+
+        $results = Invoke-Maester -Path $script:adTestPath -Tag 'AD' -OutputFolder $outputFolder -OutputFolderFileName 'ADMultiForest' -SkipGraphConnect -NonInteractive -NoLogo -DisableTelemetry -SkipVersionCheck -PassThru
+
+        @($results).Count | Should -Be 2
+        @($results | Where-Object { $_.ADTargetServer -eq 'dc01.contoso.com' }).Count | Should -Be 1
+        @($results | Where-Object { $_.ADTargetServer -eq 'dc01.fabrikam.net' }).Count | Should -Be 1
+
+        Test-Path (Join-Path $outputFolder 'ADMultiForest.html') | Should -BeTrue
+        (Get-ChildItem -Path $outputFolder -Filter 'ADMultiForest-dc01.contoso.com*.json').Count | Should -BeGreaterThan 0
+        (Get-ChildItem -Path $outputFolder -Filter 'ADMultiForest-dc01.fabrikam.net*.json').Count | Should -BeGreaterThan 0
     }
 }
 
@@ -142,8 +166,8 @@ Describe 'Active Directory test source safety' {
                 }
 
                 $block = $describe.CommandElements |
-                    Where-Object { $_ -is [System.Management.Automation.Language.ScriptBlockExpressionAst] } |
-                    Select-Object -Last 1
+                Where-Object { $_ -is [System.Management.Automation.Language.ScriptBlockExpressionAst] } |
+                Select-Object -Last 1
 
                 foreach ($statement in $block.ScriptBlock.EndBlock.Statements) {
                     $command = $statement.Find({
@@ -181,9 +205,9 @@ Describe 'Active Directory test source safety' {
                     $node -is [System.Management.Automation.Language.CommandAst]
                 }, $true)
             $collector = $commands |
-                Where-Object { $_.GetCommandName() -in 'Get-MtADDomainState', 'Get-MtADDacls', 'Get-MtADGpoState' } |
-                Sort-Object { $_.Extent.StartOffset } |
-                Select-Object -First 1
+            Where-Object { $_.GetCommandName() -in 'Get-MtADDomainState', 'Get-MtADDacls', 'Get-MtADGpoState' } |
+            Sort-Object { $_.Extent.StartOffset } |
+            Select-Object -First 1
 
             if ($null -eq $collector) {
                 $issues += "$($file.FullName): does not call a guarded Active Directory collector."
@@ -191,11 +215,11 @@ Describe 'Active Directory test source safety' {
             }
 
             $earlierAdOperation = $commands |
-                Where-Object {
-                    $_.Extent.StartOffset -lt $collector.Extent.StartOffset -and
-                    ($_.GetCommandName() -match '^(Get-AD|Get-GPO|Get-DnsServer)' -or $_.GetCommandName() -eq 'Invoke-Command')
-                } |
-                Select-Object -First 1
+            Where-Object {
+                $_.Extent.StartOffset -lt $collector.Extent.StartOffset -and
+                ($_.GetCommandName() -match '^(Get-AD|Get-GPO|Get-DnsServer)' -or $_.GetCommandName() -eq 'Invoke-Command')
+            } |
+            Select-Object -First 1
 
             if ($null -ne $earlierAdOperation) {
                 $issues += "$($file.FullName): calls $($earlierAdOperation.GetCommandName()) before checking the explicit AD connection."

--- a/powershell/tests/functions/Connect-Maester.Tests.ps1
+++ b/powershell/tests/functions/Connect-Maester.Tests.ps1
@@ -40,6 +40,14 @@ Describe 'Connect-Maester' {
         (Get-Command Connect-Maester).Parameters.Keys | Should -Contain 'GitHubOrganization'
     }
 
+    It 'Offers ActiveDirectoryServer as a parameter' {
+        (Get-Command Connect-Maester).Parameters.Keys | Should -Contain 'ActiveDirectoryServer'
+    }
+
+    It 'Accepts multiple ActiveDirectoryServer values' {
+        (Get-Command Connect-Maester).Parameters['ActiveDirectoryServer'].ParameterType.FullName | Should -Be 'System.String[]'
+    }
+
     It 'Calls Connect-MtGitHub when -Service GitHub is specified' {
         Mock Connect-MtGitHub -ModuleName Maester {}
 
@@ -69,6 +77,53 @@ Describe 'Connect-Maester' {
         Connect-Maester -Service ActiveDirectory
 
         Should -Invoke Get-ADRootDSE -ModuleName Maester -Times 1 -Exactly
+    }
+
+    It 'Passes ActiveDirectoryServer to the AD connectivity probe and records the target' {
+        Mock Get-ADRootDSE -ModuleName Maester -ParameterFilter { $Server -eq 'dc02.contoso.com' } {
+            [PSCustomObject]@{
+                defaultNamingContext       = 'DC=contoso,DC=com'
+                configurationNamingContext = 'CN=Configuration,DC=contoso,DC=com'
+                schemaNamingContext        = 'CN=Schema,CN=Configuration,DC=contoso,DC=com'
+                dnsHostName                = 'dc02.contoso.com'
+            }
+        }
+
+        Connect-Maester -Service ActiveDirectory -ActiveDirectoryServer 'dc02.contoso.com'
+
+        Should -Invoke Get-ADRootDSE -ModuleName Maester -Times 1 -Exactly -ParameterFilter { $Server -eq 'dc02.contoso.com' }
+        InModuleScope Maester {
+            $__MtSession.ADConnection.TargetServer | Should -Be 'dc02.contoso.com'
+        }
+    }
+
+    It 'Validates and stores multiple ActiveDirectoryServer targets' {
+        Mock Get-ADRootDSE -ModuleName Maester -ParameterFilter { $Server -eq 'dc01.contoso.com' } {
+            [PSCustomObject]@{
+                defaultNamingContext       = 'DC=contoso,DC=com'
+                configurationNamingContext = 'CN=Configuration,DC=contoso,DC=com'
+                schemaNamingContext        = 'CN=Schema,CN=Configuration,DC=contoso,DC=com'
+                dnsHostName                = 'dc01.contoso.com'
+            }
+        }
+
+        Mock Get-ADRootDSE -ModuleName Maester -ParameterFilter { $Server -eq 'dc01.fabrikam.net' } {
+            [PSCustomObject]@{
+                defaultNamingContext       = 'DC=fabrikam,DC=net'
+                configurationNamingContext = 'CN=Configuration,DC=fabrikam,DC=net'
+                schemaNamingContext        = 'CN=Schema,CN=Configuration,DC=fabrikam,DC=net'
+                dnsHostName                = 'dc01.fabrikam.net'
+            }
+        }
+
+        Connect-Maester -Service ActiveDirectory -ActiveDirectoryServer 'dc01.contoso.com', 'dc01.fabrikam.net'
+
+        Should -Invoke Get-ADRootDSE -ModuleName Maester -Times 1 -Exactly -ParameterFilter { $Server -eq 'dc01.contoso.com' }
+        Should -Invoke Get-ADRootDSE -ModuleName Maester -Times 1 -Exactly -ParameterFilter { $Server -eq 'dc01.fabrikam.net' }
+        InModuleScope Maester {
+            $__MtSession.ADConnection.TargetServer | Should -Be 'dc01.contoso.com'
+            $__MtSession.ADConnection.TargetServers | Should -Be @('dc01.contoso.com', 'dc01.fabrikam.net')
+        }
     }
 
     It 'Does not call opt-in services when -Service All is specified' {

--- a/powershell/tests/functions/Get-MtHtmlReport.Tests.ps1
+++ b/powershell/tests/functions/Get-MtHtmlReport.Tests.ps1
@@ -6,30 +6,30 @@ Describe 'Get-MtHtmlReport' {
         $templateAvailable = Test-Path $templatePath
 
         $singleTenant = [PSCustomObject]@{
-            TenantId       = 'single-tenant-id'
-            TenantName     = 'Single Tenant'
-            Result         = 'Passed'
-            TotalCount     = 5
-            PassedCount    = 4
-            FailedCount    = 1
-            ErrorCount     = 0
-            SkippedCount   = 0
-            InvestigateCount = 0
-            NotRunCount    = 0
-            ExecutedAt     = '2026-03-30T10:00:00'
-            TotalDuration  = '00:01:00'
-            UserDuration   = '00:00:50'
+            TenantId          = 'single-tenant-id'
+            TenantName        = 'Single Tenant'
+            Result            = 'Passed'
+            TotalCount        = 5
+            PassedCount       = 4
+            FailedCount       = 1
+            ErrorCount        = 0
+            SkippedCount      = 0
+            InvestigateCount  = 0
+            NotRunCount       = 0
+            ExecutedAt        = '2026-03-30T10:00:00'
+            TotalDuration     = '00:01:00'
+            UserDuration      = '00:00:50'
             DiscoveryDuration = '00:00:08'
             FrameworkDuration = '00:00:01'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
-            Account        = 'test@contoso.com'
-            SystemInfo     = [PSCustomObject]@{ MachineName = 'TEST-01' }
-            PowerShellInfo = [PSCustomObject]@{ Version = '7.4.1' }
-            LoadedModules  = @()
-            InvokeCommand  = 'Invoke-Maester'
-            MgContext      = [PSCustomObject]@{ TenantId = 'single-tenant-id' }
-            MaesterConfig  = [PSCustomObject]@{
+            CurrentVersion    = '2.2.0'
+            LatestVersion     = '2.2.0'
+            Account           = 'test@contoso.com'
+            SystemInfo        = [PSCustomObject]@{ MachineName = 'TEST-01' }
+            PowerShellInfo    = [PSCustomObject]@{ Version = '7.4.1' }
+            LoadedModules     = @()
+            InvokeCommand     = 'Invoke-Maester'
+            MgContext         = [PSCustomObject]@{ TenantId = 'single-tenant-id' }
+            MaesterConfig     = [PSCustomObject]@{
                 GlobalSettings = [PSCustomObject]@{
                     EmergencyAccessAccounts = @(
                         [PSCustomObject]@{
@@ -40,7 +40,7 @@ Describe 'Get-MtHtmlReport' {
                 }
                 TestSettings   = @()
             }
-            Tests          = @(
+            Tests             = @(
                 [PSCustomObject]@{
                     Index = 1; Id = 'MT.1001'; Title = 'Test One'
                     Name = 'MT.1001: Test One'; Result = 'Passed'
@@ -49,56 +49,56 @@ Describe 'Get-MtHtmlReport' {
                     ResultDetail = [PSCustomObject]@{ TestDescription = 'Desc'; TestResult = 'OK' }
                 }
             )
-            Blocks         = @(
+            Blocks            = @(
                 [PSCustomObject]@{ Name = 'Maester'; PassedCount = 4; FailedCount = 1; TotalCount = 5 }
             )
-            EndOfJson      = 'EndOfJson'
+            EndOfJson         = 'EndOfJson'
         }
 
         $tenant1 = [PSCustomObject]@{
-            TenantId       = 'tenant-1-id'
-            TenantName     = 'Tenant One'
-            Result         = 'Passed'
-            TotalCount     = 3
-            PassedCount    = 3
-            FailedCount    = 0
-            ErrorCount     = 0
-            SkippedCount   = 0
+            TenantId         = 'tenant-1-id'
+            TenantName       = 'Tenant One'
+            Result           = 'Passed'
+            TotalCount       = 3
+            PassedCount      = 3
+            FailedCount      = 0
+            ErrorCount       = 0
+            SkippedCount     = 0
             InvestigateCount = 0
-            NotRunCount    = 0
-            ExecutedAt     = '2026-03-30T10:00:00'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
-            Tests          = @(
+            NotRunCount      = 0
+            ExecutedAt       = '2026-03-30T10:00:00'
+            CurrentVersion   = '2.2.0'
+            LatestVersion    = '2.2.0'
+            Tests            = @(
                 [PSCustomObject]@{ Index = 1; Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
             )
-            Blocks         = @(
+            Blocks           = @(
                 [PSCustomObject]@{ Name = 'Maester'; PassedCount = 3; TotalCount = 3 }
             )
-            EndOfJson      = 'EndOfJson'
+            EndOfJson        = 'EndOfJson'
         }
 
         $tenant2 = [PSCustomObject]@{
-            TenantId       = 'tenant-2-id'
-            TenantName     = 'Tenant Two'
-            Result         = 'Failed'
-            TotalCount     = 5
-            PassedCount    = 3
-            FailedCount    = 2
-            ErrorCount     = 0
-            SkippedCount   = 0
+            TenantId         = 'tenant-2-id'
+            TenantName       = 'Tenant Two'
+            Result           = 'Failed'
+            TotalCount       = 5
+            PassedCount      = 3
+            FailedCount      = 2
+            ErrorCount       = 0
+            SkippedCount     = 0
             InvestigateCount = 0
-            NotRunCount    = 0
-            ExecutedAt     = '2026-03-30T11:00:00'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
-            Tests          = @(
+            NotRunCount      = 0
+            ExecutedAt       = '2026-03-30T11:00:00'
+            CurrentVersion   = '2.2.0'
+            LatestVersion    = '2.2.0'
+            Tests            = @(
                 [PSCustomObject]@{ Index = 1; Id = 'MT.1001'; Result = 'Failed'; Block = 'Maester' }
             )
-            Blocks         = @(
+            Blocks           = @(
                 [PSCustomObject]@{ Name = 'Maester'; PassedCount = 3; FailedCount = 2; TotalCount = 5 }
             )
-            EndOfJson      = 'EndOfJson'
+            EndOfJson        = 'EndOfJson'
         }
     }
 

--- a/powershell/tests/functions/Get-MtHtmlReport.Tests.ps1
+++ b/powershell/tests/functions/Get-MtHtmlReport.Tests.ps1
@@ -29,6 +29,11 @@ Describe 'Get-MtHtmlReport' {
             LoadedModules     = @()
             InvokeCommand     = 'Invoke-Maester'
             MgContext         = [PSCustomObject]@{ TenantId = 'single-tenant-id' }
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-single.contoso.com'
+                ForestRootDomain = 'contoso.com'
+                TargetServer = 'dc01.contoso.com'
+            }
             MaesterConfig     = [PSCustomObject]@{
                 GlobalSettings = [PSCustomObject]@{
                     EmergencyAccessAccounts = @(
@@ -69,6 +74,11 @@ Describe 'Get-MtHtmlReport' {
             ExecutedAt       = '2026-03-30T10:00:00'
             CurrentVersion   = '2.2.0'
             LatestVersion    = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-one.contoso.com'
+                ForestRootDomain = 'contoso.com'
+                TargetServer = 'dc01.contoso.com'
+            }
             Tests            = @(
                 [PSCustomObject]@{ Index = 1; Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
             )
@@ -92,6 +102,11 @@ Describe 'Get-MtHtmlReport' {
             ExecutedAt       = '2026-03-30T11:00:00'
             CurrentVersion   = '2.2.0'
             LatestVersion    = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-two.fabrikam.com'
+                ForestRootDomain = 'fabrikam.com'
+                TargetServer = 'dc02.fabrikam.com'
+            }
             Tests            = @(
                 [PSCustomObject]@{ Index = 1; Id = 'MT.1001'; Result = 'Failed'; Block = 'Maester' }
             )
@@ -127,6 +142,14 @@ Describe 'Get-MtHtmlReport' {
             $html = Get-MtHtmlReport -MaesterResults $singleTenant
 
             $html | Should -BeLike '*MT.1001*'
+        }
+
+        It 'Should contain AD context metadata in the output' {
+            $html = Get-MtHtmlReport -MaesterResults $singleTenant
+
+            $html | Should -BeLike '*forest-single.contoso.com*'
+            $html | Should -BeLike '*dc01.contoso.com*'
+            $html | Should -BeLike '*contoso.com*'
         }
 
         It 'Should contain emergency access account config data' {
@@ -166,6 +189,15 @@ Describe 'Get-MtHtmlReport' {
 
             $html | Should -BeLike '*Tenant One*'
             $html | Should -BeLike '*Tenant Two*'
+        }
+
+        It 'Should retain distinct AD context metadata for each tenant' {
+            $html = Get-MtHtmlReport -MaesterResults $merged
+
+            $html | Should -BeLike '*forest-one.contoso.com*'
+            $html | Should -BeLike '*dc01.contoso.com*'
+            $html | Should -BeLike '*forest-two.fabrikam.com*'
+            $html | Should -BeLike '*dc02.fabrikam.com*'
         }
 
         It 'Should not contain sample data from the template' {

--- a/powershell/tests/functions/Import-MtMaesterResult.Tests.ps1
+++ b/powershell/tests/functions/Import-MtMaesterResult.Tests.ps1
@@ -19,6 +19,11 @@ Describe 'Import-MtMaesterResult' {
             ExecutedAt     = '2026-04-01T10:00:00'
             CurrentVersion = '2.2.0'
             LatestVersion  = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-one.contoso.com'
+                ForestRootDomain = 'contoso.com'
+                TargetServer = 'dc01.contoso.com'
+            }
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
                 [PSCustomObject]@{ Id = 'MT.1002'; Result = 'Failed'; Block = 'Maester' }
@@ -43,6 +48,11 @@ Describe 'Import-MtMaesterResult' {
             ExecutedAt     = '2026-04-01T11:00:00'
             CurrentVersion = '2.2.0'
             LatestVersion  = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-two.fabrikam.com'
+                ForestRootDomain = 'fabrikam.com'
+                TargetServer = 'dc02.fabrikam.com'
+            }
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Failed'; Block = 'Maester' }
             )
@@ -121,6 +131,8 @@ Describe 'Import-MtMaesterResult' {
             $results[0].TotalCount | Should -BeExactly 10
             $results[0].ExecutedAt | Should -Not -BeNullOrEmpty
             $results[0].CurrentVersion | Should -BeExactly '2.2.0'
+            $results[0].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-one.contoso.com'
+            $results[0].ActiveDirectoryContext.TargetServer | Should -BeExactly 'dc01.contoso.com'
         }
     }
 
@@ -132,6 +144,8 @@ Describe 'Import-MtMaesterResult' {
             $results.Count | Should -BeExactly 2
             $results[0].TenantId | Should -BeExactly 'tenant-1-id'
             $results[1].TenantId | Should -BeExactly 'tenant-2-id'
+            $results[0].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-one.contoso.com'
+            $results[1].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-two.fabrikam.com'
         }
 
         It 'Should treat expanded tenants as standalone results' {

--- a/powershell/tests/functions/Import-MtMaesterResult.Tests.ps1
+++ b/powershell/tests/functions/Import-MtMaesterResult.Tests.ps1
@@ -17,8 +17,8 @@ Describe 'Import-MtMaesterResult' {
             InvestigateCount = 0
             NotRunCount    = 0
             ExecutedAt     = '2026-04-01T10:00:00'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
                 [PSCustomObject]@{ Id = 'MT.1002'; Result = 'Failed'; Block = 'Maester' }
@@ -41,8 +41,8 @@ Describe 'Import-MtMaesterResult' {
             InvestigateCount = 0
             NotRunCount    = 0
             ExecutedAt     = '2026-04-01T11:00:00'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Failed'; Block = 'Maester' }
             )
@@ -55,8 +55,8 @@ Describe 'Import-MtMaesterResult' {
         # Multi-tenant merged format
         $mergedData = [PSCustomObject]@{
             Tenants        = @($singleTenantData, $singleTenantData2)
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             EndOfJson      = 'EndOfJson'
         }
 
@@ -120,7 +120,7 @@ Describe 'Import-MtMaesterResult' {
             $results[0].Tests.Count | Should -BeExactly 2
             $results[0].TotalCount | Should -BeExactly 10
             $results[0].ExecutedAt | Should -Not -BeNullOrEmpty
-            $results[0].CurrentVersion | Should -BeExactly '2.0.0'
+            $results[0].CurrentVersion | Should -BeExactly '2.2.0'
         }
     }
 

--- a/powershell/tests/functions/Merge-MtMaesterResult.Tests.ps1
+++ b/powershell/tests/functions/Merge-MtMaesterResult.Tests.ps1
@@ -8,8 +8,8 @@ Describe 'Merge-MtMaesterResult' {
             PassedCount    = 8
             FailedCount    = 2
             ExecutedAt     = '2026-04-01T10:00:00'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
                 [PSCustomObject]@{ Id = 'MT.1002'; Result = 'Failed'; Block = 'Maester' }
@@ -28,8 +28,8 @@ Describe 'Merge-MtMaesterResult' {
             PassedCount    = 3
             FailedCount    = 2
             ExecutedAt     = '2026-04-01T11:00:00'
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Failed'; Block = 'Maester' }
                 [PSCustomObject]@{ Id = 'MT.1002'; Result = 'Passed'; Block = 'Maester' }
@@ -82,8 +82,8 @@ Describe 'Merge-MtMaesterResult' {
     It 'Should preserve shared metadata from the first result' {
         $result = Merge-MtMaesterResult -MaesterResults @($tenant1, $tenant2)
 
-        $result.CurrentVersion | Should -BeExactly '2.0.0'
-        $result.LatestVersion | Should -BeExactly '2.0.0'
+        $result.CurrentVersion | Should -BeExactly '2.2.0'
+        $result.LatestVersion | Should -BeExactly '2.2.0'
     }
 
     It 'Should preserve all test data per tenant' {
@@ -115,8 +115,8 @@ Describe 'Merge-MtMaesterResult' {
             TotalCount     = 7
             PassedCount    = 7
             FailedCount    = 0
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
             )
@@ -141,8 +141,8 @@ Describe 'Merge-MtMaesterResult' {
             TotalCount     = 1
             PassedCount    = 1
             FailedCount    = 0
-            CurrentVersion = '2.0.0'
-            LatestVersion  = '2.0.0'
+            CurrentVersion = '2.2.0'
+            LatestVersion  = '2.2.0'
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
             )

--- a/powershell/tests/functions/Merge-MtMaesterResult.Tests.ps1
+++ b/powershell/tests/functions/Merge-MtMaesterResult.Tests.ps1
@@ -10,6 +10,11 @@ Describe 'Merge-MtMaesterResult' {
             ExecutedAt     = '2026-04-01T10:00:00'
             CurrentVersion = '2.2.0'
             LatestVersion  = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-one.contoso.com'
+                ForestRootDomain = 'contoso.com'
+                TargetServer = 'dc01.contoso.com'
+            }
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
                 [PSCustomObject]@{ Id = 'MT.1002'; Result = 'Failed'; Block = 'Maester' }
@@ -30,6 +35,11 @@ Describe 'Merge-MtMaesterResult' {
             ExecutedAt     = '2026-04-01T11:00:00'
             CurrentVersion = '2.2.0'
             LatestVersion  = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-two.fabrikam.com'
+                ForestRootDomain = 'fabrikam.com'
+                TargetServer = 'dc02.fabrikam.com'
+            }
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Failed'; Block = 'Maester' }
                 [PSCustomObject]@{ Id = 'MT.1002'; Result = 'Passed'; Block = 'Maester' }
@@ -95,6 +105,15 @@ Describe 'Merge-MtMaesterResult' {
         $result.Tenants[1].TotalCount | Should -BeExactly 5
     }
 
+    It 'Should preserve AD context metadata per tenant' {
+        $result = Merge-MtMaesterResult -MaesterResults @($tenant1, $tenant2)
+
+        $result.Tenants[0].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-one.contoso.com'
+        $result.Tenants[1].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-two.fabrikam.com'
+        $result.Tenants[0].ActiveDirectoryContext.TargetServer | Should -BeExactly 'dc01.contoso.com'
+        $result.Tenants[1].ActiveDirectoryContext.TargetServer | Should -BeExactly 'dc02.fabrikam.com'
+    }
+
     It 'Should throw when a result is missing the Tests property' {
         $invalid = [PSCustomObject]@{ TenantId = 'bad'; TenantName = 'Bad Tenant' }
 
@@ -131,6 +150,8 @@ Describe 'Merge-MtMaesterResult' {
         $result.Tenants.Count | Should -BeExactly 3
         $result.Tenants[2].TenantName | Should -BeExactly 'Tenant Three'
         $result.Tenants[2].TotalCount | Should -BeExactly 7
+        $result.Tenants[0].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-one.contoso.com'
+        $result.Tenants[1].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-two.fabrikam.com'
     }
 
     It 'Should handle a result with empty TenantName' {
@@ -143,6 +164,11 @@ Describe 'Merge-MtMaesterResult' {
             FailedCount    = 0
             CurrentVersion = '2.2.0'
             LatestVersion  = '2.2.0'
+            ActiveDirectoryContext = [PSCustomObject]@{
+                ForestName = 'forest-empty.contoso.com'
+                ForestRootDomain = ''
+                TargetServer = 'dc99.contoso.com'
+            }
             Tests          = @(
                 [PSCustomObject]@{ Id = 'MT.1001'; Result = 'Passed'; Block = 'Maester' }
             )
@@ -154,6 +180,7 @@ Describe 'Merge-MtMaesterResult' {
 
         $result.Tenants.Count | Should -BeExactly 1
         $result.Tenants[0].TenantName | Should -BeExactly ''
+        $result.Tenants[0].ActiveDirectoryContext.ForestName | Should -BeExactly 'forest-empty.contoso.com'
     }
 
     Context 'FromPath parameter set' {

--- a/tests/maester-config.json
+++ b/tests/maester-config.json
@@ -1,5 +1,5 @@
 {
-  "ModuleVersion": "2.0.0",
+  "ModuleVersion": "2.2.0",
   "ConfigVersion": "",
   "GlobalSettings": {
     "EmergencyAccessAccounts": [],


### PR DESCRIPTION
## Summary
- add explicit multi-target Active Directory connectivity support via Connect-Maester -ActiveDirectoryServer
- route AD cmdlets through selected target server across AD checks
- enrich Invoke-Maester AD run context and include forest context in reporting
- generate merged base multi-forest report output while keeping per-forest artifacts
- add local module loader helper for AD test sessions

## Validation
- Invoke-Pester -Path powershell/tests/functions/ActiveDirectoryOptIn.Tests.ps1, powershell/tests/functions/Connect-Maester.Tests.ps1, powershell/tests/functions/Invoke-Maester.Tests.ps1, powershell/tests/functions/Get-MtHtmlReport.Tests.ps1, powershell/tests/functions/Import-MtMaesterResult.Tests.ps1, powershell/tests/functions/Merge-MtMaesterResult.Tests.ps1, powershell/tests/functions/ConvertTo-MtMaesterResult.Tests.ps1 -Output Normal
- Result: 69 passed, 0 failed

Closes #2071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connect to one or more Active Directory servers or forest targets.
  * Run checks independently for each target with separate results and a combined report.
  * Reports now include forest, domain, and server details.
  * Added validation and clearer handling for unavailable targets.

* **Bug Fixes**
  * Improved query targeting, cache isolation, and progress display behavior.

* **Documentation**
  * Added local module setup guidance and multi-forest execution examples.
  * Updated the release version to 2.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->