### PR TITLE
Fix EIDSCA generator website docs dependency

### DIFF
--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -15,9 +15,6 @@ param (
     # Folder where generated test file should be written to.
     [string] $TestFilePath = "$PSScriptRoot/../../tests/EIDSCA/Test-EIDSCA.Generated.Tests.ps1",
 
-    # Folder where docs should be generated
-    [string] $DocsPath = "$PSScriptRoot/../../website/docs/tests/eidsca",
-
     # Folder where control functions should be generated
     [string] $PowerShellFunctionsPath = "$PSScriptRoot/../../powershell/internal/eidsca",
 
@@ -467,11 +464,10 @@ $aadsc = ($aadsc | Where-Object { $_.CollectedBy -eq "Maester" }).ControlArea
 $Discovery = ($aadsc | Where-Object { $_.discovery -ne "" }).Discovery
 
 # Remove previously generated files
-Get-ChildItem -Path $DocsPath -Filter "*.md" -Exclude "readme.md" | Remove-Item -Force
 Get-ChildItem -Path $PowerShellFunctionsPath -Filter "*" -Exclude "@template*" | Remove-Item -Force
 
-$docsTemplate = GetTemplate $DocsPath
 $psTemplate = GetTemplate $PowerShellFunctionsPath "@templateps1.txt" # Use the .txt extension to avoid running the script
+# The website docs generator consumes the internal Markdown generated from this template.
 $psMarkdownTemplate = GetTemplate $PowerShellFunctionsPath "@template.md"
 
 $sb = [System.Text.StringBuilder]::new()
@@ -509,7 +505,6 @@ Describe "EIDSCA" -Tag "EIDSCA",  "%CheckId%" {
 '@
 
         $testOutput = UpdateTemplate -template $testTemplate -control $control -controlItem $controlItem -docName $docName
-        $docsOutput = UpdateTemplate -template $docsTemplate -control $control -controlItem $controlItem -docName $docName -isDoc $true
         $psOutput = UpdateTemplate -template $psTemplate -control $control -controlItem $controlItem -docName $docName
 
         $psMarkdownOutput = UpdateTemplate -template $psMarkdownTemplate -control $control -controlItem $controlItem -docName $docName -isDoc $true
@@ -517,7 +512,6 @@ Describe "EIDSCA" -Tag "EIDSCA",  "%CheckId%" {
         if ($testOutput -ne '') {
             [void]$testOutputList.AppendLine($testOutput)
 
-            CreateFile $DocsPath "$docName.md" $docsOutput
             $psFunctionName = GetEidscaPsFunctionName -checkId $controlItem.CheckId
             CreateFile $PowerShellFunctionsPath "$psFunctionName.ps1" $psOutput
             CreateFile $PowerShellFunctionsPath "$psFunctionName.md" $psMarkdownOutput

--- a/powershell/tests/general/EidscaGenerator.Tests.ps1
+++ b/powershell/tests/general/EidscaGenerator.Tests.ps1
@@ -1,0 +1,77 @@
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path "$PSScriptRoot/../../..").Path
+    $script:EidscaBuildScript = Join-Path $script:RepoRoot 'build/eidsca/Update-EidscaTests.ps1'
+}
+
+Describe 'EIDSCA generator' {
+    It 'does not manage generated website test documentation' {
+        $scriptContent = Get-Content -Path $script:EidscaBuildScript -Raw
+
+        $scriptContent | Should -Not -Match 'DocsPath'
+        $scriptContent | Should -Not -Match 'website[/\\]docs[/\\]tests'
+    }
+
+    It 'generates canonical sources from fixture input' {
+        $internalPath = Join-Path $TestDrive 'internal'
+        $publicPath = Join-Path $TestDrive 'public'
+        $testFilePath = Join-Path $TestDrive 'Test-EIDSCA.Generated.Tests.ps1'
+        $null = New-Item -Path $internalPath -ItemType Directory
+        $null = New-Item -Path $publicPath -ItemType Directory
+
+        Copy-Item -Path (Join-Path $script:RepoRoot 'powershell/internal/eidsca/@templateps1.txt') -Destination $internalPath
+        Copy-Item -Path (Join-Path $script:RepoRoot 'powershell/internal/eidsca/@template.md') -Destination $internalPath
+        Copy-Item -Path (Join-Path $script:RepoRoot 'powershell/public/eidsca/@Test-MtEidscaControl.txt') -Destination $publicPath
+
+        $fixtureJson = @'
+[
+  {
+    "CollectedBy": "Maester",
+    "ControlArea": [
+      {
+        "ControlName": "Fixture control",
+        "Description": "Fixture control description",
+        "Discovery": ["$FixtureDiscovery = $true"],
+        "GraphUri": "https://graph.microsoft.com/v1.0/fixture/settings",
+        "GraphEndpoint": "fixture/settings",
+        "GraphDocsUrl": "",
+        "Controls": [
+          {
+            "CheckId": "EIDSCA.ZZ99",
+            "Name": "FixtureSetting",
+            "DisplayName": "Fixture setting",
+            "Description": "Fixture setting description",
+            "Severity": "Medium",
+            "RecommendedValue": "true",
+            "DefaultValue": "false",
+            "CurrentValue": "isEnabled",
+            "Recommendation": "",
+            "PortalDeepLink": "",
+            "HowToFix": "Enable the fixture setting.",
+            "MitreTactic": [],
+            "MitreTechnique": [],
+            "MitreMitigation": [],
+            "SkipCondition": "",
+            "SkipReason": ""
+          }
+        ]
+      }
+    ]
+  }
+]
+'@
+        Mock Invoke-WebRequest { $fixtureJson } -ParameterFilter { $Uri -eq 'https://fixture.invalid/EidscaConfig.json' }
+
+        & $script:EidscaBuildScript `
+            -TestFilePath $testFilePath `
+            -PowerShellFunctionsPath $internalPath `
+            -PublicFunctionPath $publicPath `
+            -AadSecConfigUrl 'https://fixture.invalid/EidscaConfig.json'
+
+        Join-Path $internalPath 'Test-MtEidscaZZ99.ps1' | Should -Exist
+        Join-Path $internalPath 'Test-MtEidscaZZ99.md' | Should -Exist
+        Join-Path $publicPath 'Test-MtEidscaControl.ps1' | Should -Exist
+        $testFilePath | Should -Exist
+        Get-Content -Path $testFilePath -Raw | Should -Match 'EIDSCA\.ZZ99'
+        Should -Invoke Invoke-WebRequest -Times 1 -Exactly
+    }
+}


### PR DESCRIPTION
## Root cause

The EIDSCA PowerShell generator still treated website/docs/tests/eidsca as an output directory and read its removed @template.txt file. The website test pages moved to website/scripts/generate-test-docs.mjs, but the old deletion, template read, and page-write steps remained. As a result, the generator emitted a missing-file error and temporarily removed or rewrote generated EIDSCA website pages.

## Changes

- Remove the obsolete DocsPath parameter and all direct management of generated website test pages.
- Keep generating the canonical EIDSCA test file, internal PowerShell functions, internal Markdown sources, and public dispatcher.
- Document that the Node website generator consumes the internal Markdown sources.
- Add a focused regression test that runs the generator with a controlled one-control fixture and temporary output directories, and asserts there is no website docs dependency.

## Validation

- Full PowerShell suite: 10,341 tests passed.
- Focused EIDSCA generator fixture: 2 tests passed.
- PSScriptAnalyzer and generated-file formatting tests passed as part of the full suite.
- npm run generate-test-docs followed by npm run check-test-docs: passed for 408 pages; unrelated contributor snapshot drift was intentionally restored and excluded.
- npm run build: Docusaurus production build passed with Node.js 24.
- git diff --check: passed.

No live upstream EIDSCA output or contributor snapshot changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified documentation generation by removing the separate documentation output configuration.
  * Markdown documentation is now generated alongside internal PowerShell functions.
  * Existing test and function outputs continue to be generated as before.

* **Tests**
  * Added coverage validating generated files, fixture identifiers, documentation handling, and web request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->