### PR TITLE
pottential fix for EIDSCA generator

### DIFF
--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -448,6 +448,10 @@ function CreateFile($folderPath, $fileName, $content) {
     } else {
         $newLine = "`n"
     }
+    # Some content (e.g. remediation text pulled straight from the JSON source) may use
+    # `n-only line breaks even when the surrounding template uses `r`n. Normalize everything
+    # to the same style so generated files don't end up with mixed line endings.
+    $content = ($content -replace "`r`n", "`n") -replace "`n", $newLine
     $content = RemoveTrailingWhitespace $content
     $content = $content -replace '(\r?\n)+$', ''
     [System.IO.File]::WriteAllText($filePath, "$content$newLine", [System.Text.UTF8Encoding]::new($false))
@@ -555,6 +559,7 @@ if ($output -match "`r`n") {
 } else {
     $newLine = "`n"
 }
+$output = ($output -replace "`r`n", "`n") -replace "`n", $newLine
 $output = RemoveTrailingWhitespace $output
 $output = $output -replace '(\r?\n)+$', ''
 [System.IO.File]::WriteAllText($TestFilePath, "$output$newLine", [System.Text.UTF8Encoding]::new($false))

--- a/build/eidsca/Update-EidscaTests.ps1
+++ b/build/eidsca/Update-EidscaTests.ps1
@@ -443,17 +443,15 @@ function RemoveTrailingWhitespace($content) {
 
 function CreateFile($folderPath, $fileName, $content) {
     $filePath = Join-Path $folderPath $fileName
-    if ($content -match "`r`n") {
-        $newLine = "`r`n"
-    } else {
-        $newLine = "`n"
-    }
+    $newLine = [System.Environment]::NewLine
     # Some content (e.g. remediation text pulled straight from the JSON source) may use
-    # `n-only line breaks even when the surrounding template uses `r`n. Normalize everything
-    # to the same style so generated files don't end up with mixed line endings.
-    $content = ($content -replace "`r`n", "`n") -replace "`n", $newLine
+    # `n-only line breaks even when the surrounding template uses `r`n. Normalize to `n
+    # first so trailing-whitespace trimming matches consistently, then convert to the
+    # platform newline so generated files don't end up with mixed line endings.
+    $content = $content -replace "`r`n", "`n"
     $content = RemoveTrailingWhitespace $content
-    $content = $content -replace '(\r?\n)+$', ''
+    $content = $content -replace "`n+$", ''
+    $content = $content -replace "`n", $newLine
     [System.IO.File]::WriteAllText($filePath, "$content$newLine", [System.Text.UTF8Encoding]::new($false))
 }
 
@@ -554,12 +552,9 @@ $discoveryLines += [System.Environment]::NewLine
 $output = $output.Replace('<DiscoveryFromJson>', $discoveryLines)
 
 $output += $sb.ToString()
-if ($output -match "`r`n") {
-    $newLine = "`r`n"
-} else {
-    $newLine = "`n"
-}
-$output = ($output -replace "`r`n", "`n") -replace "`n", $newLine
+$newLine = [System.Environment]::NewLine
+$output = $output -replace "`r`n", "`n"
 $output = RemoveTrailingWhitespace $output
-$output = $output -replace '(\r?\n)+$', ''
+$output = $output -replace "`n+$", ''
+$output = $output -replace "`n", $newLine
 [System.IO.File]::WriteAllText($TestFilePath, "$output$newLine", [System.Text.UTF8Encoding]::new($false))


### PR DESCRIPTION
## 📑 Description

Block : EIDSCA generator Name : It generates canonical sources from fixture input Result : Failed Message : Expected $true, but got $false.

[21:46:37][pester.ps1] 1 tests out of 10394 tests failed! Exception: D:\a\maester\maester\powershell\tests\pester.ps1:236 Line | 236 | throw "$totalFailed / $totalRun tests failed!"
| ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| 1 / 10394 tests failed!
Error: Process completed with exit code 1.

Closes # I never created an issue for it

## ✅ Checks
<!-- Make sure your PR passes the CI checks and do check the following fields as needed:
-->
- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

## ℹ️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->

---

## How to Contribute

🏗️ Read our full [contributing guide](https://maester.dev/docs/contributing) for the Maester project.  
🧪 We also have additional instructions and a checklist for [creating tests](https://maester.dev/docs/contributing#checklist-for-writing-good-tests).  

Join us at the Maester repository [discussions](https://github.com/maester365/maester/discussions) or [Entra Discord](https://discord.maester.dev/) for more help and conversations!  
While you wait for a review, why not spread some Maester love on social media? Thank you! 💖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated test file consistency by normalizing line endings for the selected platform.
  * Removed inconsistent whitespace around generated file content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->