### PR TITLE
Fix EIDSCA generator test on Windows

### DIFF
--- a/powershell/tests/general/EidscaGenerator.Tests.ps1
+++ b/powershell/tests/general/EidscaGenerator.Tests.ps1
@@ -115,8 +115,10 @@ Describe 'EIDSCA generator' {
 
 Use [the portal](https://example.invalid) or run: ```$literal $$ $& $1```
 '@
+        $expectedRemediation = $expectedRemediation.Trim() -replace '\r\n?', "`n"
         $remediationMarkdown = Get-Content -Path $remediationMarkdownPath -Raw
-        $remediationMarkdown.Contains($expectedRemediation.Trim()) | Should -BeTrue
+        $remediationMarkdown = $remediationMarkdown -replace '\r\n?', "`n"
+        $remediationMarkdown.Contains($expectedRemediation) | Should -BeTrue
         Get-Content -Path (Join-Path $internalPath 'Test-MtEidscaZZ98.md') -Raw | Should -Not -Match 'Remediation action'
         Get-Content -Path (Join-Path $internalPath 'Test-MtEidscaZZ97.md') -Raw | Should -Not -Match 'Remediation action'
         Should -Invoke Invoke-WebRequest -Times 1 -Exactly


### PR DESCRIPTION
## 📑 Description

Normalizes CRLF and CR line endings to LF before comparing generated EIDSCA remediation Markdown
with the expected fixture content.

The existing assertion used a multiline `.Contains()` comparison without normalizing line endings.
On Windows runners, the expected here-string could use CRLF while the generated remediation text
used LF, causing `EIDSCA generator` to fail even though the generated content was correct.

## ✅ Checks

- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation as required.
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally.

Validation completed:

- focused `EidscaGenerator.Tests.ps1`: 2 passed, 0 failed
- complete local Pester suite: 10,341 passed, 0 failed
- PSScriptAnalyzer on the changed file: no findings
- fork `build-validation`: Ubuntu, macOS, Windows PowerShell 7, Windows PowerShell 5.1,
  and module validation passed

## ℹ️ Additional Information

This failure was reproduced twice on the Windows runner while Ubuntu and macOS passed. The fix is
limited to the cross-platform fixture assertion and does not change EIDSCA generation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remediation-content validation by normalizing Markdown line endings and trimming expected content, preventing false test failures caused by formatting differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->