### PR TITLE
(MT.1178) - ASR rules in setting catalog policies were not detected

### DIFF
--- a/powershell/public/maester/intune/Test-MtIntuneASRRules.md
+++ b/powershell/public/maester/intune/Test-MtIntuneASRRules.md
@@ -27,6 +27,13 @@ See the [Microsoft Defender ASR rules deployment guide](https://learn.microsoft.
 
 Additional ASR rules detected in tenant policies are reported for visibility but do not affect the pass/fail result. **Warn** is a supported ASR rule state but does not satisfy the baseline. Baseline rules in **Audit** mode will trigger an informational note recommending a transition to **Block** mode.
 
+ASR rules can be configured from two places in Intune, and both count towards this check:
+
+- **Endpoint security** > **Attack surface reduction** (the Attack Surface Reduction Rules profile)
+- **Devices** > **Configuration** > **Settings catalog** (the **Defender** > **Attack Surface Reduction Rules** category)
+
+Both surfaces write the same underlying Defender settings, so the check evaluates every Windows configuration policy and reports which surface each policy was authored from.
+
 #### Remediation action
 
 1. Navigate to [Microsoft Intune admin center](https://intune.microsoft.com).

--- a/powershell/public/maester/intune/Test-MtIntuneASRRules.md
+++ b/powershell/public/maester/intune/Test-MtIntuneASRRules.md
@@ -1,38 +1,23 @@
-Ensure at least one Intune Attack Surface Reduction (ASR) policy has rules configured in **Block** or **Audit** mode.
+Ensure every rule in the Microsoft Defender ASR Standard Protection baseline is configured in **Block** or **Audit** mode.
 
-ASR rules reduce the attack surface of applications by preventing behaviors commonly abused by malware and threat actors. These rules target specific techniques such as:
+Attack surface reduction rules block the behaviors malware depends on but legitimate software rarely needs: Office macros spawning child processes, credential theft from LSASS, obfuscated scripts, executable content arriving by email, untrusted processes running from USB media, and persistence through WMI event subscriptions.
 
-- **Office macros** spawning child processes or injecting code into other processes
-- **Credential theft** from LSASS (Local Security Authority Subsystem Service)
-- **Script-based attacks** using obfuscated JavaScript, VBScript, or PowerShell
-- **Email-borne threats** executing content from Outlook or webmail
-- **Ransomware** advanced protection heuristics
-- **USB-based attacks** running untrusted unsigned processes
-- **Persistence** through WMI event subscriptions
+Each rule runs in one of four modes:
 
-Each ASR rule can operate in one of four modes:
+- **Block** prevents the behavior. This is the goal for production.
+- **Audit** logs it without blocking. Start here to measure impact.
+- **Warn** prompts the user, who can choose to continue anyway.
+- **Disabled** turns the rule off.
 
-- **Block**: Actively prevents the behavior (recommended for production after testing)
-- **Audit**: Logs the event without blocking (recommended for initial rollout)
-- **Warn**: Warns the user before allowing the behavior to proceed
-- **Disabled**: Rule is not active
-
-The test passes if **every rule in the Microsoft Defender ASR Standard Protection baseline** is configured in **Block** or **Audit** mode across the union of all ASR policies in the tenant. The Standard Protection baseline is the minimum recommended set Microsoft publishes for initial ASR deployment:
+This check passes when all three Standard Protection baseline rules are in **Block** or **Audit** somewhere in the tenant. Modes are pooled across policies, so rules split over several policies still count:
 
 1. Block abuse of exploited vulnerable signed drivers
 2. Block credential stealing from LSASS
 3. Block persistence through WMI event subscription
 
-See the [Microsoft Defender ASR rules deployment guide](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/attack-surface-reduction-rules-deployment-implement) for the canonical baseline definition.
+Microsoft publishes these as the [minimum set for an initial ASR deployment](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/attack-surface-reduction-rules-deployment-implement). Any other ASR rules found are listed for visibility but do not affect the result. **Warn** does not satisfy the baseline, and baseline rules left in **Audit** produce a note recommending a move to **Block**.
 
-Additional ASR rules detected in tenant policies are reported for visibility but do not affect the pass/fail result. **Warn** is a supported ASR rule state but does not satisfy the baseline. Baseline rules in **Audit** mode will trigger an informational note recommending a transition to **Block** mode.
-
-ASR rules can be configured from two places in Intune, and both count towards this check:
-
-- **Endpoint security** > **Attack surface reduction** (the Attack Surface Reduction Rules profile)
-- **Devices** > **Configuration** > **Settings catalog** (the **Defender** > **Attack Surface Reduction Rules** category)
-
-Both surfaces write the same underlying Defender settings, so the check evaluates every Windows configuration policy and reports which surface each policy was authored from.
+ASR rules can be configured from either **Endpoint security** > **Attack surface reduction** or **Devices** > **Configuration** > **Settings catalog** (under **Defender**). Both write the same settings, and both satisfy this check.
 
 #### Remediation action
 

--- a/powershell/public/maester/intune/Test-MtIntuneASRRules.ps1
+++ b/powershell/public/maester/intune/Test-MtIntuneASRRules.ps1
@@ -146,9 +146,6 @@
                 }
             }
 
-            # No ASR rules in this policy, so it is not an ASR policy. This also drops the
-            # Device Control and Exploit Protection profiles, which share the
-            # 'endpointSecurityAttackSurfaceReduction' template family but configure no ASR rules.
             if ($ruleDetails.Count -eq 0) { continue }
 
             $templateFamily = $policy.templateReference.templateFamily

--- a/powershell/public/maester/intune/Test-MtIntuneASRRules.ps1
+++ b/powershell/public/maester/intune/Test-MtIntuneASRRules.ps1
@@ -4,8 +4,9 @@
     Ensure the Microsoft Defender ASR Standard Protection baseline rules are configured in Block or Audit mode.
 
     .DESCRIPTION
-    Checks Intune Endpoint Security Attack Surface Reduction policies (configurationPolicies API) for
-    ASR rule configurations.
+    Checks Intune Windows configuration policies (configurationPolicies API) for ASR rule
+    configurations. Covers both Endpoint Security Attack Surface Reduction profiles and Settings
+    catalog policies, since ASR rules share the same setting definition IDs in both.
 
     ASR rules reduce the attack surface of applications by preventing behaviors commonly abused by malware,
     such as Office macros spawning child processes, credential theft from LSASS, or execution of obfuscated scripts.
@@ -53,18 +54,16 @@
     }
 
     try {
-        Write-Verbose "Querying Intune ASR policies..."
-        $asrPolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityAttackSurfaceReduction'&`$select=id,name,description,templateReference" -ApiVersion beta)
+        # ASR rules use identical setting definition IDs whether the policy was authored as an
+        # Endpoint Security ASR profile (templateFamily 'endpointSecurityAttackSurfaceReduction')
+        # or as a plain Settings catalog policy (templateFamily 'none') - the setting definition is
+        # published with visibility 'settingsCatalog,template'. Filtering on template family
+        # therefore misses every settings catalog policy, so narrow on platform here and identify
+        # ASR policies by the settings they actually contain.
+        Write-Verbose "Querying Intune Windows configuration policies..."
+        $candidatePolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=platforms has 'windows10'&`$select=id,name,description,templateReference" -ApiVersion beta)
 
-        Write-Verbose "Found $($asrPolicies.Count) ASR policies."
-
-        if ($asrPolicies.Count -eq 0) {
-            $testResultMarkdown = "No Endpoint Security Attack Surface Reduction policies found in Intune.`n`n"
-            $testResultMarkdown += "Create an ASR policy under **Endpoint Security > Attack Surface Reduction** with "
-            $testResultMarkdown += "ASR rules enabled in **Audit** or **Block** mode to protect against common attack techniques."
-            Add-MtTestResultDetail -Result $testResultMarkdown
-            return $false
-        }
+        Write-Verbose "Found $($candidatePolicies.Count) Windows configuration policies to inspect."
 
         # Friendly names for ASR rules (extracted from setting definition IDs)
         $asrRuleNames = @{
@@ -105,8 +104,8 @@
 
         $modeRank = @{ 'Block' = 4; 'Audit' = 3; 'Warn' = 2; 'Disabled' = 1; 'Not configured' = 0 }
 
-        foreach ($policy in $asrPolicies) {
-            Write-Verbose "Checking ASR policy: $($policy.name) ($($policy.id))"
+        foreach ($policy in $candidatePolicies) {
+            Write-Verbose "Checking policy: $($policy.name) ($($policy.id))"
             $settingsUri = "deviceManagement/configurationPolicies('$($policy.id)')/settings?`$expand=settingDefinitions&`$top=1000"
             $settingsResponse = @(Invoke-MtGraphRequest -RelativeUri $settingsUri -ApiVersion beta)
 
@@ -153,8 +152,15 @@
                 }
             }
 
+            # No ASR rules in this policy, so it is not an ASR policy. This also drops the
+            # Device Control and Exploit Protection profiles, which share the
+            # 'endpointSecurityAttackSurfaceReduction' template family but configure no ASR rules.
+            if ($ruleDetails.Count -eq 0) { continue }
+
+            $templateFamily = $policy.templateReference.templateFamily
             $policyResults.Add(@{
                 Name              = $policy.name
+                Source            = if ($templateFamily -eq 'endpointSecurityAttackSurfaceReduction') { 'Endpoint Security' } else { 'Settings catalog' }
                 BlockCount        = $blockCount
                 AuditCount        = $auditCount
                 WarnCount         = $warnCount
@@ -163,6 +169,14 @@
                 TotalRules        = $ruleDetails.Count
                 Rules             = $ruleDetails
             })
+        }
+
+        if ($policyResults.Count -eq 0) {
+            $testResultMarkdown = "No Attack Surface Reduction rules found in any Intune Windows configuration policy.`n`n"
+            $testResultMarkdown += "Create an ASR policy under **Endpoint Security > Attack Surface Reduction** with "
+            $testResultMarkdown += "ASR rules enabled in **Audit** or **Block** mode to protect against common attack techniques."
+            Add-MtTestResultDetail -Result $testResultMarkdown
+            return $false
         }
 
         # Evaluate baseline coverage across the union of all policies
@@ -176,7 +190,7 @@
         $baselinePassed = ($baselineMissing.Count -eq 0)
 
         # Build result markdown
-        $testResultMarkdown = "Found $($asrPolicies.Count) Attack Surface Reduction policy/policies in Intune.`n`n"
+        $testResultMarkdown = "Found $($policyResults.Count) policy/policies configuring Attack Surface Reduction rules in Intune.`n`n"
         $testResultMarkdown += "**Pass criteria:** Every rule in the Microsoft Defender ASR Standard Protection baseline must be configured in **Block** or **Audit** mode in at least one ASR policy.`n`n"
 
         $testResultMarkdown += "### Standard Protection baseline coverage (across all policies)`n"
@@ -188,6 +202,7 @@
 
         foreach ($p in $policyResults) {
             $testResultMarkdown += "### $($p.Name)`n"
+            $testResultMarkdown += "**Configured via:** $($p.Source)`n`n"
             $testResultMarkdown += "**$($p.TotalRules) rules:** $($p.BlockCount) Block, $($p.AuditCount) Audit, $($p.WarnCount) Warn, $($p.DisabledCount) Disabled, $($p.NotConfiguredCount) Not configured`n`n"
             $testResultMarkdown += "| Rule | Mode | Baseline |`n| --- | --- | --- |`n"
             foreach ($r in $p.Rules) {

--- a/powershell/public/maester/intune/Test-MtIntuneASRRules.ps1
+++ b/powershell/public/maester/intune/Test-MtIntuneASRRules.ps1
@@ -54,12 +54,6 @@
     }
 
     try {
-        # ASR rules use identical setting definition IDs whether the policy was authored as an
-        # Endpoint Security ASR profile (templateFamily 'endpointSecurityAttackSurfaceReduction')
-        # or as a plain Settings catalog policy (templateFamily 'none') - the setting definition is
-        # published with visibility 'settingsCatalog,template'. Filtering on template family
-        # therefore misses every settings catalog policy, so narrow on platform here and identify
-        # ASR policies by the settings they actually contain.
         Write-Verbose "Querying Intune Windows configuration policies..."
         $candidatePolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=platforms has 'windows10'&`$select=id,name,description,templateReference" -ApiVersion beta)
 

--- a/powershell/tests/functions/Test-MtIntuneASRRules.Tests.ps1
+++ b/powershell/tests/functions/Test-MtIntuneASRRules.Tests.ps1
@@ -1,0 +1,153 @@
+﻿Describe 'Test-MtIntuneASRRules' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../Maester.psd1 -Force
+
+        $script:AsrRoot = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules'
+
+        # Builds one groupSettingCollection settingInstance from a rule suffix -> mode-suffix map,
+        # matching the shape the configurationPolicies settings endpoint returns.
+        function New-AsrSettingInstance {
+            param([hashtable] $Rules)
+
+            $children = foreach ($suffix in $Rules.Keys) {
+                [PSCustomObject]@{
+                    settingDefinitionId = "$($script:AsrRoot)_$suffix"
+                    choiceSettingValue  = [PSCustomObject]@{ value = "$($script:AsrRoot)_$($suffix)_$($Rules[$suffix])" }
+                }
+            }
+
+            return [PSCustomObject]@{
+                settingInstance = [PSCustomObject]@{
+                    settingDefinitionId        = $script:AsrRoot
+                    groupSettingCollectionValue = @([PSCustomObject]@{ children = @($children) })
+                }
+            }
+        }
+
+        function New-Policy {
+            param([string] $Id, [string] $Name, [string] $TemplateFamily)
+
+            return [PSCustomObject]@{
+                id                = $Id
+                name              = $Name
+                templateReference = [PSCustomObject]@{ templateFamily = $TemplateFamily }
+            }
+        }
+    }
+
+    BeforeEach {
+        $script:Result = $null
+        $script:SkippedBecause = $null
+
+        Mock -ModuleName Maester Test-MtConnection { return $true }
+        Mock -ModuleName Maester Get-MtLicenseInformation { return 'Intune Plan 1' }
+        Mock -ModuleName Maester Add-MtTestResultDetail {
+            param($Result, $SkippedBecause, $SkippedError)
+            $script:Result = $Result
+            $script:SkippedBecause = $SkippedBecause
+        }
+    }
+
+    It 'finds ASR rules configured in a Settings catalog policy' {
+        # Regression: filtering on templateReference/templateFamily missed settings catalog
+        # policies entirely, so a fully compliant tenant reported "no ASR policies found".
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri, $ApiVersion)
+
+            # '?' is a single-character wildcard for -like, so match /settings first.
+            if ($RelativeUri -notlike '*/settings*') {
+                $RelativeUri | Should -BeLike "*platforms has 'windows10'*"
+                return @(New-Policy -Id 'def-l1' -Name 'Def L1' -TemplateFamily 'none')
+            }
+
+            return @(New-AsrSettingInstance -Rules @{
+                    'blockabuseofexploitedvulnerablesigneddrivers'                      = 'block'
+                    'blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem' = 'block'
+                    'blockpersistencethroughwmieventsubscription'                       = 'audit'
+                })
+        }
+
+        Test-MtIntuneASRRules | Should -Be $true
+        $script:Result | Should -BeLike '*Def L1*'
+        $script:Result | Should -BeLike '*Configured via:** Settings catalog*'
+    }
+
+    It 'ignores policies that share the ASR template family but configure no ASR rules' {
+        # Device Control and Exploit Protection both live under the
+        # endpointSecurityAttackSurfaceReduction template family.
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri, $ApiVersion)
+
+            if ($RelativeUri -notlike '*/settings*') {
+                return @(
+                    (New-Policy -Id 'asr' -Name 'ASR rules' -TemplateFamily 'endpointSecurityAttackSurfaceReduction'),
+                    (New-Policy -Id 'devctrl' -Name 'Device Control' -TemplateFamily 'endpointSecurityAttackSurfaceReduction')
+                )
+            }
+
+            if ($RelativeUri -like "*('devctrl')*") {
+                return @([PSCustomObject]@{
+                        settingInstance = [PSCustomObject]@{
+                            settingDefinitionId = 'device_vendor_msft_policy_config_defender_devicecontrolenabled'
+                        }
+                    })
+            }
+
+            return @(New-AsrSettingInstance -Rules @{
+                    'blockabuseofexploitedvulnerablesigneddrivers'                      = 'block'
+                    'blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem' = 'block'
+                    'blockpersistencethroughwmieventsubscription'                       = 'block'
+                })
+        }
+
+        Test-MtIntuneASRRules | Should -Be $true
+        $script:Result | Should -BeLike '*Found 1 policy/policies*'
+        $script:Result | Should -Not -BeLike '*Device Control*'
+        $script:Result | Should -BeLike '*Configured via:** Endpoint Security*'
+    }
+
+    It 'fails when a Standard Protection baseline rule is not in Block or Audit' {
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri, $ApiVersion)
+
+            if ($RelativeUri -notlike '*/settings*') {
+                return @(New-Policy -Id 'partial' -Name 'Partial ASR' -TemplateFamily 'none')
+            }
+
+            return @(New-AsrSettingInstance -Rules @{
+                    'blockabuseofexploitedvulnerablesigneddrivers'                      = 'block'
+                    'blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem' = 'block'
+                    'blockpersistencethroughwmieventsubscription'                       = 'off'
+                })
+        }
+
+        Test-MtIntuneASRRules | Should -Be $false
+        $script:Result | Should -BeLike '*Block persistence through WMI event subscription (current: Disabled)*'
+    }
+
+    It 'fails when no policy configures ASR rules' {
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri, $ApiVersion)
+
+            if ($RelativeUri -notlike '*/settings*') {
+                return @(New-Policy -Id 'other' -Name 'Some other policy' -TemplateFamily 'none')
+            }
+
+            return @([PSCustomObject]@{
+                    settingInstance = [PSCustomObject]@{
+                        settingDefinitionId = 'device_vendor_msft_policy_config_autoplay_turnoffautoplay'
+                    }
+                })
+        }
+
+        Test-MtIntuneASRRules | Should -Be $false
+        $script:Result | Should -BeLike '*No Attack Surface Reduction rules found*'
+    }
+
+    It 'skips when Intune is not licensed' {
+        Mock -ModuleName Maester Get-MtLicenseInformation { return $null }
+
+        Test-MtIntuneASRRules | Should -BeNull
+        $script:SkippedBecause | Should -Be 'NotLicensedIntune'
+    }
+}


### PR DESCRIPTION
## Problem

`Test-MtIntuneASRRules` filters policies on `templateReference/templateFamily eq 'endpointSecurityAttackSurfaceReduction'`, which only matches ASR profiles created under **Endpoint security > Attack surface reduction**.

ASR rules created via **Devices > Configuration > Settings catalog** land on a policy with `templateFamily: "none"` but use the *identical* setting definition IDs — the definitions are published with `visibility: "settingsCatalog,template"`, so it's one shared definition surfaced in both places.

Result: a tenant with all three Standard Protection baseline rules on **Block** via the Settings catalog reports *"No Endpoint Security Attack Surface Reduction policies found"* and MT.1178 fails. Verified against such a tenant — all 17 configured rules were invisible to the current query.

Related: **Device Control** and **Exploit Protection** profiles also carry the `endpointSecurityAttackSurfaceReduction` family, so they inflated the policy count and produced empty `0 rules` tables.

## Fix

- Query Windows configuration policies (`$filter=platforms has 'windows10'`) and identify ASR policies by the settings they contain, not by how they were authored.
- Skip policies with no ASR rules — this drops Device Control and Exploit Protection automatically.
- Move the "nothing found" branch downstream so it means *no ASR rules anywhere* rather than *no ES-family policies*.
- Report now shows whether each policy came from **Endpoint Security** or the **Settings catalog**.

<img width="857" height="1161" alt="CleanShot 2026-08-22 at 20 30 41" src="https://github.com/user-attachments/assets/7b617200-23ef-4612-8b3c-230063859154" />


## Testing

New `powershell/tests/functions/Test-MtIntuneASRRules.Tests.ps1`, 5/5 passing: settings-catalog detection (the regression), Device Control exclusion, baseline rule not in Block/Audit → `$false`, no ASR rules → `$false`, unlicensed → skipped. PSScriptAnalyzer clean.

## Docs

Companion `.md` updated to note both authoring surfaces count. Generated pages (`MT.1178.md`, the command `.mdx`) left untouched — bots refresh those on push to `main`.

## Known gap

ADMX-backed `ExploitGuard_ASR_Rules` stores rules as a GUID plus numeric state (`0`/`1`/`2`/`6`) instead of a `_block`/`_audit` suffix, so those still parse as *Not configured*. Left out rather than shipping untested parsing — happy to follow up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ASR rule checks now include Intune Endpoint security profiles and Settings catalog policies.
  * Results identify each policy’s source and exclude policies without ASR rules.

* **Bug Fixes**
  * Standard Protection rules must be set to Block or Audit; Warn no longer passes.
  * Improved reporting when no ASR configuration exists and updated compliance counts.

* **Documentation**
  * Clarified supported policy types, rule modes, and evaluation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
