### PR TITLE
MT.1123: detect BitLocker configured via Settings catalog

### DIFF
--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.md
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.md
@@ -1,14 +1,13 @@
-Ensure at least one Intune Disk Encryption policy enforces BitLocker with **full disk encryption type**.
+Ensure at least one Intune policy enforces BitLocker **full encryption** on operating system drives.
 
-BitLocker Drive Encryption protects data on Windows devices by encrypting the disk.
-However, BitLocker supports two encryption types that have very different security implications:
+BitLocker offers two encryption types, and the difference matters:
 
-- **Full disk encryption** — encrypts the entire drive including free space. This is the recommended and secure option.
-- **Used space only encryption** — only encrypts sectors currently holding data. **This is dangerous on drives that previously contained unencrypted data**, because previously deleted files remain as raw data in unencrypted free space. This data can be recovered using commonly available data recovery software (e.g., Recuva, PhotoRec, or forensic imaging tools). NTFS marks deleted file sectors as "free" but does not zero them out — the original bytes stay on disk until overwritten by new data.
+- **Full encryption** encrypts the entire drive, including free space.
+- **Used Space Only encryption** encrypts only the sectors that currently hold data.
 
-**Bottom line:** If BitLocker is enabled with "Used space only" on a drive that already had data on it before encryption was turned on, that pre-existing deleted data is fully recoverable. Only "Full disk encryption" guarantees that the entire drive surface is protected.
+Used Space Only is the risk. When NTFS deletes a file it marks those sectors as free without zeroing them, so the original bytes stay on disk until something overwrites them. Enable BitLocker with Used Space Only on a drive that already held data and everything deleted beforehand remains recoverable with ordinary tools such as Recuva or PhotoRec, or with forensic imaging. Only Full encryption protects the whole drive surface.
 
-This test queries the Intune **Endpoint Security > Disk Encryption** policies via the `configurationPolicies` Graph API and inspects the BitLocker CSP settings to verify that **Enforce drive encryption type** is set to **Full encryption** for OS drives.
+BitLocker can be configured from either **Endpoint security** > **Disk encryption** or **Devices** > **Configuration** > **Settings catalog**. Both write the same settings, and both satisfy this check.
 
 #### Remediation action
 

--- a/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
+++ b/powershell/public/maester/intune/Test-MtBitLockerFullDiskEncryption.ps1
@@ -4,8 +4,9 @@
     Ensure at least one Intune Disk Encryption policy enforces BitLocker with full disk encryption type.
 
     .DESCRIPTION
-    Checks Intune Endpoint Security Disk Encryption policies (configurationPolicies API) for BitLocker
-    profiles that enforce full disk encryption rather than "Used space only" encryption.
+    Checks Intune Windows configuration policies (configurationPolicies API) for BitLocker settings
+    that enforce full disk encryption rather than "Used space only" encryption. Covers both Endpoint
+    Security Disk Encryption profiles and Settings catalog policies.
 
     BitLocker supports two encryption types with very different security implications:
     - "Full disk encryption" -- encrypts the entire drive including free space. This is the secure option.
@@ -14,16 +15,16 @@
       recovered using data recovery software (e.g., Recuva, PhotoRec, or forensic tools). This is because
       NTFS marks sectors as free but does not zero them out -- the raw data stays on disk until overwritten.
 
-    This test queries the configurationPolicies Graph API (used by Endpoint Security > Disk Encryption)
-    which exposes the actual BitLocker CSP settings including:
+    This test queries the configurationPolicies Graph API, which exposes the actual BitLocker CSP
+    settings including:
     - SystemDrivesEncryptionType (OS drive encryption type: full vs used space only)
     - FixedDrivesEncryptionType (fixed drive encryption type: full vs used space only)
     - RequireDeviceEncryption (require BitLocker encryption)
     - EncryptionMethodByDriveType (cipher strength: XTS-AES 128/256, AES-CBC 128/256)
 
-    The test passes only if at least one BitLocker Disk Encryption policy has the OS drive encryption
-    type set to "Full encryption". It fails if no policies exist, if encryption type is set to
-    "Used space only", or if the encryption type setting is not configured.
+    The test passes only if at least one BitLocker policy has the OS drive encryption type set to
+    "Full encryption". It fails if no BitLocker settings exist in any policy, if encryption type is
+    set to "Used space only", or if the encryption type setting is not configured.
 
     .EXAMPLE
     Test-MtBitLockerFullDiskEncryption
@@ -37,25 +38,24 @@
     [OutputType([bool])]
     param()
 
+    if (!(Test-MtConnection Graph)) {
+        Add-MtTestResultDetail -SkippedBecause NotConnectedGraph
+        return $null
+    }
+
     if (-not (Get-MtLicenseInformation -Product Intune)) {
         Add-MtTestResultDetail -SkippedBecause NotLicensedIntune
         return $null
     }
 
     try {
-        # Query Endpoint Security Disk Encryption policies (server-side filter).
-        # This template family can include non-BitLocker templates (e.g., Personal Data Encryption);
-        # BitLocker-specific settings are evaluated per-policy below.
-        Write-Verbose "Querying Intune Endpoint Security Disk Encryption policies..."
-        $diskEncryptionPolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=templateReference/templateFamily eq 'endpointSecurityDiskEncryption'&`$select=id,name,description,templateReference" -ApiVersion beta)
+        # BitLocker settings carry visibility 'settingsCatalog,template', so they can be configured
+        # from either Endpoint Security > Disk Encryption or the Settings catalog. Filtering on
+        # template family misses the latter, so identify BitLocker policies by their settings.
+        Write-Verbose "Querying Intune Windows configuration policies..."
+        $candidatePolicies = @(Invoke-MtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=platforms has 'windows10'&`$select=id,name,description,templateReference" -ApiVersion beta)
 
-        if ($diskEncryptionPolicies.Count -eq 0) {
-            $testResultMarkdown = "No Endpoint Security Disk Encryption policies found in Intune.`n`n"
-            $testResultMarkdown += "Create a Disk Encryption policy under **Endpoint Security > Disk Encryption** with "
-            $testResultMarkdown += "**Enforce drive encryption type** set to **Full encryption** for OS and fixed data drives."
-            Add-MtTestResultDetail -Result $testResultMarkdown
-            return $false
-        }
+        Write-Verbose "Found $($candidatePolicies.Count) Windows configuration policies to inspect."
 
         # Setting definition IDs for BitLocker CSP settings
         $osEncryptionTypeId = 'device_vendor_msft_bitlocker_systemdrivesencryptiontype'
@@ -84,13 +84,14 @@
         $policyResults = [System.Collections.Generic.List[hashtable]]::new()
         $hasFullEncryption = $false
 
-        foreach ($policy in $diskEncryptionPolicies) {
+        foreach ($policy in $candidatePolicies) {
             # Fetch settings for this policy with definitions expanded
             $settingsUri = "deviceManagement/configurationPolicies('$($policy.id)')/settings?`$expand=settingDefinitions&`$top=1000"
             $settingsResponse = @(Invoke-MtGraphRequest -RelativeUri $settingsUri -ApiVersion beta)
 
             $policyDetail = @{
                 Name               = $policy.name
+                Source             = if ($policy.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption') { 'Endpoint Security' } else { 'Settings catalog' }
                 RequireEncryption  = 'Not configured'
                 OsEncryptionType   = 'Not configured'
                 FixedEncryptionType = 'Not configured'
@@ -172,26 +173,25 @@
                 }
             }
 
+            if (-not $policyDetail.IsBitLockerPolicy) { continue }
             $policyResults.Add($policyDetail)
         }
 
-        # Filter to only BitLocker policies (those with BitLocker CSP settings)
-        $bitLockerPolicies = @($policyResults | Where-Object { $_.IsBitLockerPolicy })
+        $bitLockerPolicies = @($policyResults)
 
         if ($bitLockerPolicies.Count -eq 0) {
-            $testResultMarkdown = "Found $($diskEncryptionPolicies.Count) Disk Encryption policy/policies in Intune, but none are BitLocker policies.`n`n"
+            $testResultMarkdown = "No BitLocker settings found in any Intune Windows configuration policy.`n`n"
             $testResultMarkdown += "Create a BitLocker policy under **Endpoint Security > Disk Encryption** with "
             $testResultMarkdown += "**Enforce drive encryption type** set to **Full encryption** for OS and fixed data drives."
             Add-MtTestResultDetail -Result $testResultMarkdown
             return $false
         }
 
-        # Build result markdown (only BitLocker policies)
-        $testResultMarkdown = "Found $($bitLockerPolicies.Count) BitLocker Disk Encryption policy/policies in Intune.`n`n"
-        $testResultMarkdown += "| Policy | Require Encryption | OS Encryption Type | Fixed Encryption Type | OS Cipher |`n"
-        $testResultMarkdown += "| --- | --- | --- | --- | --- |`n"
+        $testResultMarkdown = "Found $($bitLockerPolicies.Count) BitLocker policy/policies in Intune.`n`n"
+        $testResultMarkdown += "| Policy | Configured via | Require Encryption | OS Encryption Type | Fixed Encryption Type | OS Cipher |`n"
+        $testResultMarkdown += "| --- | --- | --- | --- | --- | --- |`n"
         foreach ($p in $bitLockerPolicies) {
-            $testResultMarkdown += "| $($p.Name) | $($p.RequireEncryption) | $($p.OsEncryptionType) | $($p.FixedEncryptionType) | $($p.OsEncryptionMethod) |`n"
+            $testResultMarkdown += "| $($p.Name) | $($p.Source) | $($p.RequireEncryption) | $($p.OsEncryptionType) | $($p.FixedEncryptionType) | $($p.OsEncryptionMethod) |`n"
         }
 
         if ($hasFullEncryption) {

--- a/powershell/tests/functions/Test-MtBitLockerFullDiskEncryption.Tests.ps1
+++ b/powershell/tests/functions/Test-MtBitLockerFullDiskEncryption.Tests.ps1
@@ -1,0 +1,150 @@
+﻿Describe 'Test-MtBitLockerFullDiskEncryption' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../Maester.psd1 -Force
+
+        $script:OsType = 'device_vendor_msft_bitlocker_systemdrivesencryptiontype'
+        $script:OsTypeDropdown = "$($script:OsType)_osencryptiontypedropdown_name"
+        $script:RequireEncryption = 'device_vendor_msft_bitlocker_requiredeviceencryption'
+
+        # OS drive encryption type: _0 allow user to choose, _1 full encryption, _2 used space only.
+        function Get-OsEncryptionTypeSetting {
+            param([string] $TypeSuffix)
+
+            return [PSCustomObject]@{
+                settingInstance = [PSCustomObject]@{
+                    settingDefinitionId = $script:OsType
+                    choiceSettingValue  = [PSCustomObject]@{
+                        value    = "$($script:OsType)_1"
+                        children = @(
+                            [PSCustomObject]@{
+                                settingDefinitionId = $script:OsTypeDropdown
+                                choiceSettingValue  = [PSCustomObject]@{ value = "$($script:OsTypeDropdown)$TypeSuffix" }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        function Get-TestPolicy {
+            param([string] $Id, [string] $Name, [string] $TemplateFamily)
+
+            return [PSCustomObject]@{
+                id                = $Id
+                name              = $Name
+                templateReference = [PSCustomObject]@{ templateFamily = $TemplateFamily }
+            }
+        }
+    }
+
+    BeforeEach {
+        $script:Result = $null
+        $script:SkippedBecause = $null
+
+        Mock -ModuleName Maester Test-MtConnection { return $true }
+        Mock -ModuleName Maester Get-MtLicenseInformation { return 'Intune Plan 1' }
+        Mock -ModuleName Maester Add-MtTestResultDetail {
+            param($Result, $SkippedBecause)
+            $script:Result = $Result
+            $script:SkippedBecause = $SkippedBecause
+        }
+    }
+
+    It 'finds BitLocker full encryption configured in a Settings catalog policy' {
+        # Regression: filtering on templateReference/templateFamily missed settings catalog policies.
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri)
+
+            # '?' is a single-character wildcard for -like, so match /settings first.
+            if ($RelativeUri -notlike '*/settings*') {
+                $RelativeUri | Should -BeLike "*platforms has 'windows10'*"
+                return @(Get-TestPolicy -Id 'cis-bl' -Name 'CIS (BL) BitLocker' -TemplateFamily 'none')
+            }
+
+            return @(Get-OsEncryptionTypeSetting -TypeSuffix '_1')
+        }
+
+        Test-MtBitLockerFullDiskEncryption | Should -Be $true
+        $script:Result | Should -BeLike '*CIS (BL) BitLocker*'
+        $script:Result | Should -BeLike '*Settings catalog*'
+    }
+
+    It 'ignores Disk Encryption policies that configure no BitLocker settings' {
+        # Personal Data Encryption shares the endpointSecurityDiskEncryption template family.
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri)
+
+            if ($RelativeUri -notlike '*/settings*') {
+                return @(
+                    (Get-TestPolicy -Id 'bl' -Name 'BitLocker' -TemplateFamily 'endpointSecurityDiskEncryption'),
+                    (Get-TestPolicy -Id 'pde' -Name 'Personal Data Encryption' -TemplateFamily 'endpointSecurityDiskEncryption')
+                )
+            }
+
+            if ($RelativeUri -like "*('pde')*") {
+                return @([PSCustomObject]@{
+                        settingInstance = [PSCustomObject]@{
+                            settingDefinitionId = 'device_vendor_msft_policy_config_pde_enablepersonaldataencryption'
+                        }
+                    })
+            }
+
+            return @(Get-OsEncryptionTypeSetting -TypeSuffix '_1')
+        }
+
+        Test-MtBitLockerFullDiskEncryption | Should -Be $true
+        $script:Result | Should -BeLike '*Found 1 BitLocker policy/policies*'
+        $script:Result | Should -Not -BeLike '*Personal Data Encryption*'
+        $script:Result | Should -BeLike '*Endpoint Security*'
+    }
+
+    It 'fails when the only BitLocker policy uses Used Space Only encryption' {
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri)
+
+            if ($RelativeUri -notlike '*/settings*') {
+                return @(Get-TestPolicy -Id 'used-space' -Name 'BitLocker used space' -TemplateFamily 'none')
+            }
+
+            return @(Get-OsEncryptionTypeSetting -TypeSuffix '_2')
+        }
+
+        Test-MtBitLockerFullDiskEncryption | Should -Be $false
+        # The policy is still reported, rather than claiming no policy exists.
+        $script:Result | Should -BeLike '*BitLocker used space*'
+        $script:Result | Should -BeLike '*Used Space Only*'
+    }
+
+    It 'fails when no policy configures BitLocker settings' {
+        Mock -ModuleName Maester Invoke-MtGraphRequest {
+            param($RelativeUri)
+
+            if ($RelativeUri -notlike '*/settings*') {
+                return @(Get-TestPolicy -Id 'other' -Name 'Some other policy' -TemplateFamily 'none')
+            }
+
+            return @([PSCustomObject]@{
+                    settingInstance = [PSCustomObject]@{
+                        settingDefinitionId = 'device_vendor_msft_policy_config_autoplay_turnoffautoplay'
+                    }
+                })
+        }
+
+        Test-MtBitLockerFullDiskEncryption | Should -Be $false
+        $script:Result | Should -BeLike '*No BitLocker settings found*'
+    }
+
+    It 'skips when Graph is not connected' {
+        Mock -ModuleName Maester Test-MtConnection { return $false }
+
+        Test-MtBitLockerFullDiskEncryption | Should -BeNull
+        $script:SkippedBecause | Should -Be 'NotConnectedGraph'
+    }
+
+    It 'skips when Intune is not licensed' {
+        Mock -ModuleName Maester Get-MtLicenseInformation { return $null }
+
+        Test-MtBitLockerFullDiskEncryption | Should -BeNull
+        $script:SkippedBecause | Should -Be 'NotLicensedIntune'
+    }
+}


### PR DESCRIPTION
Same root cause as #2143, different test.

## Problem

`Test-MtBitLockerFullDiskEncryption` filters policies on `templateReference/templateFamily eq 'endpointSecurityDiskEncryption'`, which only matches profiles created under **Endpoint security > Disk encryption**.

Every `device_vendor_msft_bitlocker_*` setting definition is published with `visibility: "settingsCatalog,template"` — including the four this test reads (`systemdrivesencryptiontype`, `fixeddrivesencryptiontype`, `requiredeviceencryption`, `encryptionmethodbydrivetype`). BitLocker configured through **Devices > Configuration > Settings catalog** therefore lands on `templateFamily: "none"` and is invisible to the test.

Verified against a tenant holding a `CIS (BL) BitLocker - Windows 11 Intune 5.0.0` settings-catalog policy with 7 BitLocker settings configured. MT.1123 reported:

> No Endpoint Security Disk Encryption policies found in Intune. Create a Disk Encryption policy under **Endpoint Security > Disk Encryption**…

That policy exists. It just has **Used Space Only** on OS drives — so the check still fails, but for the wrong reason and with remediation advice that sends the admin to create a duplicate policy instead of changing one dropdown in the one they have. In any tenant where a settings-catalog BitLocker policy *does* set Full encryption, it's a straight false negative.

Related: **Personal Data Encryption** profiles also carry the `endpointSecurityDiskEncryption` family, so they counted towards the Disk Encryption policy total despite configuring no BitLocker settings.

## Fix

- Query Windows configuration policies (`$filter=platforms has 'windows10'`) and identify BitLocker policies by the settings they contain, not by template family.
- Skip policies with no BitLocker settings — drops Personal Data Encryption automatically.
- Add the missing `Test-MtConnection Graph` check, which this helper lacked.
- Report shows whether each policy was configured via **Endpoint Security** or the **Settings catalog**.

Trade-off: one `/settings` call per Windows policy. Graph has no server-side filter on setting definition IDs, so this is unavoidable for correctness; `platforms has 'windows10'` narrows the set and the `Invoke-MtGraphRequest` session cache absorbs repeats.

## Testing

New `powershell/tests/functions/Test-MtBitLockerFullDiskEncryption.Tests.ps1`, 6/6 passing:

- BitLocker full encryption in a Settings catalog policy → `$true` (the regression)
- Personal Data Encryption profile excluded from the report
- Used Space Only → `$false`, with the policy still named in the output rather than claiming none exists
- No BitLocker settings anywhere → `$false`
- Graph not connected → skipped
- Intune not licensed → skipped

PSScriptAnalyzer clean.

## Docs

Companion `.md` updated: notes that both authoring surfaces count, and the rationale section was tightened. Generated pages (`MT.1123.md`, the command `.mdx`) left untouched — `update-test-docs.yaml` and `update-module-docs.yaml` refresh those on push to `main`.

One thing worth deciding before you open it: the test still gates only on the OS drive. That CIS policy has FixedEncryptType: Not configured, which stays unflagged even now that the policy is visible. That's existing design, not a regression, so I left it out of scope — but it may be worth raising in the PR thread or as a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BitLocker full-disk encryption checks now cover configurations from both Endpoint security and Settings catalog policies.
  * Reports identify the configuration source and flag operating system drives configured for Used Space Only encryption.

* **Bug Fixes**
  * Improved handling when no applicable BitLocker settings are found.
  * Added clearer outcomes for unavailable Graph connectivity or Intune licensing.

* **Documentation**
  * Clarified full encryption requirements, risks of Used Space Only encryption, and supported configuration locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->