### PR TITLE
fix(MT.1191): skip when break-glass exclusion cannot be verified

### DIFF
--- a/powershell/public/maester/globalsecureaccess/Test-MtGsaCompliantNetworkBreakGlassExcluded.ps1
+++ b/powershell/public/maester/globalsecureaccess/Test-MtGsaCompliantNetworkBreakGlassExcluded.ps1
@@ -45,7 +45,7 @@
 
         $emergencyAccounts = Get-MtEmergencyAccessAccount
         if (-not $emergencyAccounts) {
-            Add-MtTestResultDetail -Result 'No emergency access accounts are configured in maester-config.json (EmergencyAccessAccounts), so break-glass exclusion cannot be verified.'
+            Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason 'No emergency access accounts are configured in maester-config.json (EmergencyAccessAccounts), so break-glass exclusion cannot be verified.'
             return $null
         }
 

--- a/powershell/tests/functions/Test-MtGsaCompliantNetworkBreakGlassExcluded.Tests.ps1
+++ b/powershell/tests/functions/Test-MtGsaCompliantNetworkBreakGlassExcluded.Tests.ps1
@@ -1,0 +1,76 @@
+﻿BeforeAll {
+    Import-Module "$PSScriptRoot/../../Maester.psd1" -Force
+}
+
+Describe 'Test-MtGsaCompliantNetworkBreakGlassExcluded' {
+    Context 'When no emergency access accounts are configured' {
+        It 'Skips the test instead of letting it be counted as passed' {
+            # The check states that break-glass exclusion cannot be verified and returns
+            # $null. The bundled MT.1191 wrapper only asserts when the result is non-null,
+            # so without a skip reason the It block completes with no assertion at all and
+            # Pester reports Passed. Add-MtTestResultDetail calls Set-ItResult -Skipped only
+            # when -SkippedBecause is supplied, which is what keeps an unverifiable control
+            # out of the passed count.
+            InModuleScope Maester {
+                Mock Test-MtConnection { $true }
+                Mock Get-MtLicenseInformation { 'P1' }
+                Mock Get-MtCompliantNetworkPolicy {
+                    @([pscustomobject]@{ displayName = 'Compliant Network'; id = 'policy-01' })
+                }
+                Mock Get-MtEmergencyAccessAccount { @() }
+                Mock Add-MtTestResultDetail { }
+
+                $result = Test-MtGsaCompliantNetworkBreakGlassExcluded
+
+                $result | Should -BeNullOrEmpty
+                Should -Invoke Add-MtTestResultDetail -Times 1 -Exactly -ParameterFilter {
+                    $SkippedBecause -eq 'Custom' -and $SkippedCustomReason -like '*cannot be verified*'
+                }
+            }
+        }
+    }
+
+    Context 'When emergency access accounts are configured' {
+        It 'Returns false when a policy does not exclude a break-glass account' {
+            InModuleScope Maester {
+                Mock Test-MtConnection { $true }
+                Mock Get-MtLicenseInformation { 'P1' }
+                Mock Get-MtCompliantNetworkPolicy {
+                    @([pscustomobject]@{
+                            displayName = 'Compliant Network'
+                            id          = 'policy-01'
+                            conditions  = @{ users = @{ excludeUsers = @(); excludeGroups = @() } }
+                        })
+                }
+                Mock Get-MtEmergencyAccessAccount {
+                    @([pscustomobject]@{ ObjectId = 'bg-user-01'; DisplayName = 'Break Glass 01'; Type = 'user' })
+                }
+                Mock Invoke-MtGraphRequest { @() }
+                Mock Add-MtTestResultDetail { }
+
+                Test-MtGsaCompliantNetworkBreakGlassExcluded | Should -BeFalse
+            }
+        }
+
+        It 'Returns true when the break-glass account is excluded' {
+            InModuleScope Maester {
+                Mock Test-MtConnection { $true }
+                Mock Get-MtLicenseInformation { 'P1' }
+                Mock Get-MtCompliantNetworkPolicy {
+                    @([pscustomobject]@{
+                            displayName = 'Compliant Network'
+                            id          = 'policy-01'
+                            conditions  = @{ users = @{ excludeUsers = @('bg-user-01'); excludeGroups = @() } }
+                        })
+                }
+                Mock Get-MtEmergencyAccessAccount {
+                    @([pscustomobject]@{ ObjectId = 'bg-user-01'; DisplayName = 'Break Glass 01'; Type = 'user' })
+                }
+                Mock Invoke-MtGraphRequest { @() }
+                Mock Add-MtTestResultDetail { }
+
+                Test-MtGsaCompliantNetworkBreakGlassExcluded | Should -BeTrue
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2114.

## The problem

MT.1191 is counted as **Passed** in exactly the situation where it has just reported that it could not check anything.

When no emergency access accounts are configured in `maester-config.json`, `Test-MtGsaCompliantNetworkBreakGlassExcluded` records *"break-glass exclusion cannot be verified"* and returns `$null`. The bundled wrapper only asserts when the result is non-null:

```powershell
$result = Test-MtGsaCompliantNetworkBreakGlassExcluded

if ($null -ne $result) {
    $result | Should -Be $true -Because "..."
}
```

So the `It` block completes without executing a single assertion, and Pester reports Passed. A control that states its own requirement is unverifiable lands in the passed count — which is the reading most likely to stop someone from looking.

## The fix

`Add-MtTestResultDetail` calls `Set-ItResult -Skipped` only when `-SkippedBecause` is supplied. Passing `-SkippedBecause Custom` with the same message keeps the wording identical and moves the result from Passed to Skipped:

```diff
-Add-MtTestResultDetail -Result No emergency access accounts are configured...
+Add-MtTestResultDetail -SkippedBecause Custom -SkippedCustomReason No emergency access accounts are configured...
```

That pattern is already used in 153 places in this repository, so this introduces nothing new.

## Tests

Adds `powershell/tests/functions/Test-MtGsaCompliantNetworkBreakGlassExcluded.Tests.ps1` covering three branches: the unverifiable case now skips, an unexcluded break-glass account still returns `$false`, and an excluded one still returns `$true`.

The first test was checked by **reverting the one-line fix and confirming it fails** (`Expected Add-MtTestResultDetail to be called 1 time exactly, but was called 0 times`). Without that check it would pass with or without the bug and prove nothing.

Full unit suite after the change: **4103 passed, 0 failed** (Pester 6.1.0, pwsh 7.6.2, Linux).

## Deliberately not changed

The sibling `"No enabled Compliant Network enforcement policy was found"` branch, and the equivalent branches in the other GSA checks, are left alone. Those are genuinely **not applicable** rather than **unverifiable** — with no such policy there is no lock-out risk — and they follow the convention established across the GSA family. Happy to revisit separately if you see it differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compliance results to clearly show when verification is skipped because no emergency access accounts are configured.
  * Prevented unverifiable controls from being incorrectly counted as passed.
  * Preserved accurate pass/fail results for network policies that do or do not exclude break-glass accounts.

* **Tests**
  * Added coverage for skipped, compliant, and non-compliant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->