### PR TITLE
fix(entra): fix customAuthenticationFactors null-handling bug in MT.1007

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.ps1
+++ b/powershell/public/maester/entra/Test-MtCaMfaForAllUsers.ps1
@@ -33,11 +33,19 @@
 
         $result = $false
         foreach ($policy in $policies) {
+            $hasCustomAuthenticationFactor = $false
+            if ($null -ne $policy.grantControls -and $null -ne $policy.grantControls.customAuthenticationFactors) {
+                $hasCustomAuthenticationFactor = @(
+                    $policy.grantControls.customAuthenticationFactors |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+                ).Count -gt 0
+            }
+
             if (
                 (
                     $policy.grantControls.builtInControls -contains 'mfa' -or
                     $policy.grantControls.authenticationStrength.requirementsSatisfied -contains 'mfa' -or
-                    $policy.grantControls.customAuthenticationFactors -ne ''
+                    $hasCustomAuthenticationFactor
                 ) -and
                 $policy.conditions.users.includeUsers -eq 'All' -and
                 $policy.conditions.applications.includeApplications -eq 'All'


### PR DESCRIPTION
This is a draft PR opened for review before it is considered ready to merge.

## Bug

`Test-MtCaMfaForAllUsers` (MT.1007) checks whether a Conditional Access policy grants access via `customAuthenticationFactors` using:

```powershell
$policy.grantControls.customAuthenticationFactors -ne ''
```

This is evaluated even when `$policy.grantControls` (or `.customAuthenticationFactors`) is entirely absent, i.e. `$null`. PowerShell's scalar `-ne` comparison against `$null` returns `$true` in that case (`$null -ne ''` evaluates to `$true`), so this branch of the `-or` chain can be satisfied by a policy that has **no grant controls at all** (only session controls). Combined with the surrounding `-and` conditions on `includeUsers -eq 'All'` and `includeApplications -eq 'All'`, this lets a policy that targets all users/apps but enforces no grant control whatsoever cause MT.1007 to report a false pass.

## Fix

Add an explicit null check before evaluating the collection, and filter out empty/whitespace entries so an empty-but-non-null collection can't accidentally satisfy the check either:

```powershell
$hasCustomAuthenticationFactor = $false
if ($null -ne $policy.grantControls -and $null -ne $policy.grantControls.customAuthenticationFactors) {
    $hasCustomAuthenticationFactor = @(
        $policy.grantControls.customAuthenticationFactors |
            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
    ).Count -gt 0
}
```

Note: simply wrapping the original expression in `@(...)` does **not** fix this — `@($null)` produces a one-element array containing `$null`, not an empty array, so a per-element `-ne ''` filter still keeps that null element and the array stays non-empty/truthy. The explicit null check above is required.

The `try`/`catch` error handling and the unrelated password-change policy filter earlier in the function are untouched — only the `customAuthenticationFactors` evaluation inside the `foreach` loop changed.

Fixes #2168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMrUUBhq2Z2a7VfVdm9XH3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the MFA-for-all-users check to correctly recognize configured custom authentication factors.
  - Policies with non-empty custom authentication factors are now properly evaluated alongside built-in MFA controls and authentication strength requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->