### PR TITLE
fix(MT.1024): exclude configured break-glass accounts from sign-in/user risk recommendations

### DIFF
--- a/powershell/internal/Test-MtRecommendationBreakGlassOnly.ps1
+++ b/powershell/internal/Test-MtRecommendationBreakGlassOnly.ps1
@@ -1,0 +1,57 @@
+﻿function Test-MtRecommendationBreakGlassOnly {
+    <#
+    .SYNOPSIS
+        Determines whether the only unresolved impacted resources of an Entra recommendation are configured emergency access (break-glass) accounts.
+
+    .DESCRIPTION
+        The sign-in risk and user risk recommendations (MT.1024.signinRiskPolicy / MT.1024.userRiskPolicy)
+        flag every account that is not protected by a risk-based policy. Emergency access (break-glass)
+        accounts are intentionally excluded from risk-based Conditional Access policies to avoid locking
+        out the accounts needed to recover the tenant, so they always surface as impacted resources that
+        will never be remediated.
+
+        This function returns $true only when there is at least one impacted resource still requiring
+        action and every such resource maps to a configured break-glass account (matched by subjectId or
+        id). In that case the break-glass accounts are the sole reason the recommendation is not complete
+        and it must not fail the test.
+
+        It returns $false when at least one non break-glass resource still requires action, when nothing
+        is still open, or when no break-glass object IDs are supplied (nothing to exclude).
+
+    .EXAMPLE
+        Test-MtRecommendationBreakGlassOnly -ImpactedResources $recommendation.impactedResources -BreakGlassObjectId $ids
+
+        Returns $true if the only impacted resources still requiring action are the configured break-glass accounts.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+        # The impactedResources collection of an Entra recommendation.
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        $ImpactedResources,
+
+        # Directory object IDs of the configured emergency access (break-glass) accounts.
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]] $BreakGlassObjectId
+    )
+
+    # Nothing configured to exclude - the recommendation must be evaluated as-is.
+    if (-not $BreakGlassObjectId) { return $false }
+
+    # Only resources the system has not already resolved still count against the recommendation.
+    $openResources = @($ImpactedResources | Where-Object { $_.status -ne 'completedBySystem' })
+    if ($openResources.Count -eq 0) { return $false }
+
+    # subjectId maps to the affected object (a user object id for the risk recommendations); id is
+    # matched as a fallback. Both are GUIDs, so a coincidental match against a break-glass id is not
+    # a practical concern.
+    $nonBreakGlass = @($openResources | Where-Object {
+        $_.subjectId -notin $BreakGlassObjectId -and $_.id -notin $BreakGlassObjectId
+    })
+
+    return ($nonBreakGlass.Count -eq 0)
+}

--- a/powershell/tests/functions/Test-MtRecommendationBreakGlassOnly.Tests.ps1
+++ b/powershell/tests/functions/Test-MtRecommendationBreakGlassOnly.Tests.ps1
@@ -1,0 +1,93 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../../Maester.psd1" -Force
+}
+
+Describe 'Test-MtRecommendationBreakGlassOnly' {
+    BeforeAll {
+        # subjectId maps to the affected object (a user object id for the risk recommendations).
+        $script:breakGlassA = '11111111-1111-1111-1111-111111111111'
+        $script:breakGlassB = '22222222-2222-2222-2222-222222222222'
+        $script:regularUser = '33333333-3333-3333-3333-333333333333'
+    }
+
+    It 'Returns $false when no break-glass object IDs are supplied' {
+        $impacted = @(
+            [pscustomobject]@{ subjectId = $regularUser; id = 'r1'; status = 'active'; displayName = 'Regular User' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted } {
+            param($Impacted)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId @()
+        } | Should -BeFalse
+    }
+
+    It 'Returns $true when the only open impacted resource is a break-glass account (matched by subjectId)' {
+        $impacted = @(
+            [pscustomobject]@{ subjectId = $breakGlassA; id = 'r1'; status = 'active'; displayName = 'Break Glass 1' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted; Bg = @($breakGlassA, $breakGlassB) } {
+            param($Impacted, $Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId $Bg
+        } | Should -BeTrue
+    }
+
+    It 'Returns $true when every open impacted resource is a break-glass account (multiple)' {
+        $impacted = @(
+            [pscustomobject]@{ subjectId = $breakGlassA; id = 'r1'; status = 'active'; displayName = 'Break Glass 1' }
+            [pscustomobject]@{ subjectId = $breakGlassB; id = 'r2'; status = 'active'; displayName = 'Break Glass 2' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted; Bg = @($breakGlassA, $breakGlassB) } {
+            param($Impacted, $Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId $Bg
+        } | Should -BeTrue
+    }
+
+    It 'Returns $false when a non break-glass account still requires action' {
+        $impacted = @(
+            [pscustomobject]@{ subjectId = $breakGlassA; id = 'r1'; status = 'active'; displayName = 'Break Glass 1' }
+            [pscustomobject]@{ subjectId = $regularUser; id = 'r2'; status = 'active'; displayName = 'Regular User' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted; Bg = @($breakGlassA, $breakGlassB) } {
+            param($Impacted, $Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId $Bg
+        } | Should -BeFalse
+    }
+
+    It 'Ignores resources already resolved by the system (completedBySystem)' {
+        # The regular user is completed, so only the break-glass account is still open.
+        $impacted = @(
+            [pscustomobject]@{ subjectId = $regularUser; id = 'r1'; status = 'completedBySystem'; displayName = 'Regular User' }
+            [pscustomobject]@{ subjectId = $breakGlassA; id = 'r2'; status = 'active'; displayName = 'Break Glass 1' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted; Bg = @($breakGlassA) } {
+            param($Impacted, $Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId $Bg
+        } | Should -BeTrue
+    }
+
+    It 'Returns $false when there are no open impacted resources' {
+        $impacted = @(
+            [pscustomobject]@{ subjectId = $regularUser; id = 'r1'; status = 'completedBySystem'; displayName = 'Regular User' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted; Bg = @($breakGlassA) } {
+            param($Impacted, $Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId $Bg
+        } | Should -BeFalse
+    }
+
+    It 'Matches a break-glass account by id when subjectId does not match' {
+        $impacted = @(
+            [pscustomobject]@{ subjectId = 'unmapped'; id = $breakGlassA; status = 'active'; displayName = 'Break Glass 1' }
+        )
+        InModuleScope Maester -Parameters @{ Impacted = $impacted; Bg = @($breakGlassA) } {
+            param($Impacted, $Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $Impacted -BreakGlassObjectId $Bg
+        } | Should -BeTrue
+    }
+
+    It 'Returns $false when the impacted resources collection is $null' {
+        InModuleScope Maester -Parameters @{ Bg = @($breakGlassA) } {
+            param($Bg)
+            Test-MtRecommendationBreakGlassOnly -ImpactedResources $null -BreakGlassObjectId $Bg
+        } | Should -BeFalse
+    }
+}

--- a/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
+++ b/tests/Maester/Entra/Test-EntraRecommendations.Tests.ps1
@@ -69,6 +69,33 @@ Describe "Maester/Entra" -Tag "Maester", "Entra",  "Recommendation" -ForEach $En
             Add-MtTestResultDetail -Description $descriptionMd -Severity $priority -SkippedBecause Custom -SkippedCustomReason "This recommendation has been **Dismissed** by an administrator.`n`nIf this test is valid for your tenant you can change its state from **Dismissed** to **Active**. $recommendationLinkMd"
             return $null
         }
+
+        # Break-glass (emergency access) accounts are intentionally excluded from risk-based Conditional
+        # Access policies to avoid locking out the accounts needed to recover the tenant, so the sign-in
+        # risk and user risk recommendations always flag them as impacted resources that are never
+        # remediated. When the configured break-glass accounts are the only accounts still flagged, they
+        # are the sole reason the recommendation is not complete and must not fail the test. See #2103.
+        $breakGlassAwareRecommendationTypes = @('userRiskPolicy', 'signinRiskPolicy')
+        if ( $_.status -ne 'completedBySystem' -and $_.recommendationType -in $breakGlassAwareRecommendationTypes ) {
+            try {
+                $breakGlassObjectId = @((Get-MtEmergencyAccessAccount).ObjectId)
+            } catch {
+                # A break-glass account that cannot be resolved must not become a false pass. Leave the
+                # list empty so the exclusion does not apply and the recommendation is evaluated as-is.
+                $breakGlassObjectId = @()
+                Write-Verbose "MT.1024: could not resolve emergency access accounts, evaluating recommendation without break-glass exclusion. $($_.Exception.Message)"
+            }
+
+            $onlyBreakGlassImpacted = Test-MtRecommendationBreakGlassOnly -ImpactedResources $_.impactedResources -BreakGlassObjectId $breakGlassObjectId
+            if ( $onlyBreakGlassImpacted ) {
+                $breakGlassNames = @($_.impactedResources | Where-Object { $_.status -ne 'completedBySystem' } | ForEach-Object { $_.displayName }) -join ', '
+                $breakGlassNote = "`n`n> ℹ️ The only impacted resources are configured emergency access (break-glass) accounts, which are intentionally excluded from risk-based policies and are reported here for information only: $breakGlassNames."
+                Add-MtTestResultDetail -Description $descriptionMd -Severity $priority -Result ($resultMd + $breakGlassNote)
+                $onlyBreakGlassImpacted | Should -BeTrue -Because "the only impacted resources are the configured emergency access (break-glass) accounts, which are intentionally excluded from risk-based policies"
+                return $null
+            }
+        }
+
         Add-MtTestResultDetail -Description $descriptionMd -Severity $priority -Result $resultMd
 
         # Actual test


### PR DESCRIPTION
Fixes #2103.

## The problem

`MT.1024.signinRiskPolicy` and `MT.1024.userRiskPolicy` are driven by the Entra recommendations returned from `directory/recommendations`. The check asserts the recommendation `status` is `completedBySystem`:

```powershell
$_.status | Should -Be "completedBySystem" -Because $_.benefits
```

These two recommendations flag **every** account that is not protected by a risk-based policy. Emergency access (break-glass) accounts are intentionally excluded from risk-based Conditional Access policies — that is the standard recommendation, precisely so the accounts needed to recover the tenant are never locked out by a risk detection. As a result they permanently surface as impacted resources, the recommendation never reaches `completedBySystem`, and the check fails even though the tenant is configured exactly as intended. This is what @blindzero reported, with the break-glass accounts already declared in `EmergencyAccessAccounts` in `maester-config.json`.

## The fix

For the two break-glass-relevant recommendation types only (`signinRiskPolicy`, `userRiskPolicy`), before the assertion the check now compares the still-open impacted resources against the configured emergency access accounts. If **every** impacted resource still requiring action maps to a configured break-glass account, the recommendation is treated as passed and the break-glass accounts are listed informationally in the result detail — matching the reporter's expectation that they "might be noted informationally, but should not influence the test result negatively."

The break-glass accounts are read via the existing internal `Get-MtEmergencyAccessAccount` helper (the same `EmergencyAccessAccounts` source and resolution used by `Test-MtGsaCompliantNetworkBreakGlassExcluded`), so no new configuration surface is introduced. Impacted resources are matched by `subjectId` (which maps to the affected user's object id) with `id` as a fallback.

This follows the break-glass handling precedent established in #2165 (MT.1191): reuse the configured emergency-access source, and never let the break-glass path turn into a false pass.

## Safety / what still fails

- A **real** unprotected account still fails the test — the override only applies when break-glass accounts are the *sole* remaining impacted resources.
- The scope is limited to `signinRiskPolicy` / `userRiskPolicy`; every other recommendation type is evaluated exactly as before.
- If the configured break-glass accounts **cannot be resolved**, the exclusion is skipped and the recommendation falls through to the normal (failing) assertion rather than passing — no false pass.

## Tests

Adds `powershell/internal/Test-MtRecommendationBreakGlassOnly.ps1` (the decision logic) and `powershell/tests/functions/Test-MtRecommendationBreakGlassOnly.Tests.ps1` covering: no accounts configured, single/multiple break-glass-only, a non-break-glass account still open, `completedBySystem` resources ignored, matching by `id` fallback, and a `$null` collection.

The new tests were validated by mutation — reverting the `.Count -eq 0` decision to `return $true` fails 2 of them, and dropping the `completedBySystem` filter fails 1 — so they fail if the fix is removed.

Full local suites after the change (Pester 6.1.0, pwsh 7.6.4, Linux):
- `tests/functions`: **4108 passed, 0 failed**, 800 skipped
- `tests/general`: **1186 passed, 0 failed**
- PSScriptAnalyzer suite: **987 passed, 0 failed**

The MT.1024 doc is generated by `website/scripts/generate-test-docs.mjs`, so it is not edited by hand.

## Out of scope

The issue also mentions `CISA.MS.AAD.7.5` (PIM assignment start date flagging break-glass). That is a separate check with a different data model and is intentionally left for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entra recommendation checks now recognize configured emergency access accounts for user and sign-in risk policies.
  * Recommendations pass when unresolved impacted resources consist only of those emergency access accounts, with an informational note identifying them.
  * Resources already completed by the system continue to be excluded from evaluation.

* **Bug Fixes**
  * Recommendations are evaluated normally when emergency access accounts cannot be identified, preventing incorrect passes.

* **Tests**
  * Added coverage for emergency access matching, unresolved resources, completed resources, and missing account data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->