### PR TITLE
fix(entra): surface Graph errors as Skipped in MT.1107-1109 instead of silent fail

### DIFF
--- a/powershell/public/maester/entra/Test-MtEntitlementManagementDeletedGroups.ps1
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementDeletedGroups.ps1
@@ -316,7 +316,7 @@
         return $result
 
     } catch {
-        Write-Error "Error checking access packages and catalogs: $($_.Exception.Message)"
-        return $false
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        return $null
     }
 }

--- a/powershell/public/maester/entra/Test-MtEntitlementManagementInactivePolicies.ps1
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementInactivePolicies.ps1
@@ -233,7 +233,7 @@
         return $result
 
     } catch {
-        Write-Error "Error checking access package assignment policies: $($_.Exception.Message)"
-        return $false
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        return $null
     }
 }

--- a/powershell/public/maester/entra/Test-MtEntitlementManagementValidApprovers.ps1
+++ b/powershell/public/maester/entra/Test-MtEntitlementManagementValidApprovers.ps1
@@ -329,7 +329,7 @@
         }
 
     } catch {
-        Write-Error "Error running test: $($_.Exception.Message)"
-        return $false
+        Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
+        return $null
     }
 }


### PR DESCRIPTION
## 📑 Description

Closes #2075

MT.1107, MT.1108 and MT.1109 report a bare **Failed** with no detail ("Test failed" and nothing else) when the entitlement-management Graph call raises an exception (e.g. in a tenant where entitlement management has never been provisioned / has no access packages).

### Root cause

All three tests already short-circuit the genuinely-empty case:

```powershell
if ($packages.Count -eq 0) {
    Add-MtTestResultDetail -Result "✅ No access packages found in the tenant."
    return $true
}
```

So a tenant with zero access packages that returns cleanly already **passes**. The reported failure comes from the *outer* `catch`, which swallows any exception without recording a result:

```powershell
} catch {
    Write-Error "Error checking ...: $($_.Exception.Message)"
    return $false
}
```

Because `Add-MtTestResultDetail` is never called on that path, the test surfaces as a **Failed** with no explanation — exactly the symptom in the issue. `return $false` also forces a hard fail for what is really an inability to evaluate the check.

### Fix

Replace the three outer catches with the module's standard error-handling pattern (used by ~200 other tests, e.g. `Test-MtTeamsRestrictParticipantGiveRequestControl`, the XSPM suite):

```powershell
} catch {
    Add-MtTestResultDetail -SkippedBecause Error -SkippedError $_
    return $null
}
```

`Add-MtTestResultDetail -SkippedBecause Error` records the underlying error in the report and calls `Set-ItResult -Skipped`, so the test now shows as **Skipped with the actual error message** instead of an information-less Failed — matching the expected behaviour in the issue ("whether Skipped or Error"). Returning `$null` is already handled by the Pester wrappers (`if ($null -ne $result) { ... }`).

The existing empty-tenant guard is untouched, so a tenant with no access packages continues to pass cleanly.

### Scope

Only the outer catch of the three affected tests is changed (6 lines). No change to the empty-state handling, the detection logic, or the docs.

## ✅ Checks

- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [x] I have updated the documentation as required. *(N/A — behaviour of the error path only; generated docs describe remediation, not the skip/error state.)*
- [x] The build and unit tests pass after running `/powershell/tests/pester.ps1` locally. *(Files parse clean, PSScriptAnalyzer reports 0 findings, and the empty/error paths were verified behaviourally: empty → Pass, exception → Skipped-with-detail + `$null`.)*

## ℹ️ Additional Information

Verified with mocked `Invoke-MtGraphRequest` for all three tests:

| Scenario | Before | After |
| --- | --- | --- |
| No access packages (clean empty) | Pass | Pass (unchanged) |
| Graph call throws | **Failed**, no detail | **Skipped**, error shown |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for entitlement management checks.
  - Failures are now reported as skipped test results with error details, rather than being marked as failed checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->