### PR TITLE
fix(entra): MT.1011 recognize browser-scoped security info registration policy (#2105)

### DIFF
--- a/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.ps1
+++ b/powershell/public/maester/entra/Test-MtCaSecureSecurityInfoRegistration.ps1
@@ -6,6 +6,8 @@
     .Description
     Security info registration Conditional Access policy can secure the registration of security info for users in the tenant.
 
+    A policy is considered a match when it is enabled and configured to secure security info registration from a trusted location only, i.e. it targets all users, includes the 'urn:user:registersecurityinfo' user action, applies to the browser (or all) client apps, includes all locations, and excludes at least one (trusted) location.
+
     Learn more:
     https://learn.microsoft.com/entra/identity/conditional-access/howto-conditional-access-policy-registration
 
@@ -32,9 +34,13 @@
 
         $result = $false
         foreach ($policy in $policies) {
+            # Security info registration is performed through the browser, so a policy
+            # scoped to the browser client app secures it just as well as one scoped to
+            # all client apps. Requiring "all" rejected correctly scoped policies (#2105).
+            $securesBrowserRegistration = $policy.conditions.clientAppTypes -contains "all" -or $policy.conditions.clientAppTypes -contains "browser"
             if (
                 $policy.conditions.users.includeUsers -eq "All" -and
-                $policy.conditions.clientAppTypes -eq "all" -and
+                $securesBrowserRegistration -and
                 $policy.conditions.applications.includeUserActions -eq "urn:user:registersecurityinfo" -and
                 $policy.conditions.locations.includeLocations -eq "All" -and
                 $null -ne $policy.conditions.locations.excludeLocations
@@ -51,7 +57,7 @@
         if ( $result ) {
             $testResult = "The following Conditional Access policies secure security info registration.`n`n%TestResult%"
         } else {
-            $testResult = "No Conditional Access policy securing security info registration."
+            $testResult = "No Conditional Access policy secures security info registration from a trusted location only. A matching policy must target all users, include the 'urn:user:registersecurityinfo' user action, apply to the browser (or all) client apps, include all locations, and exclude at least one (trusted) location."
         }
         Add-MtTestResultDetail -Result $testResult -GraphObjects $policiesResult -GraphObjectType ConditionalAccess
 

--- a/powershell/tests/functions/Test-MtCaSecureSecurityInfoRegistration.Tests.ps1
+++ b/powershell/tests/functions/Test-MtCaSecureSecurityInfoRegistration.Tests.ps1
@@ -1,0 +1,253 @@
+Describe 'Test-MtCaSecureSecurityInfoRegistration' {
+  BeforeAll {
+    Import-Module $PSScriptRoot/../../Maester.psd1 -Force
+    Mock -ModuleName Maester Get-MtLicenseInformation { return "P1" }
+
+    # Valid "secure security info registration from a trusted location" policy,
+    # but scoped to the browser client app only (the client used to register
+    # security info). Regression case for issue #2105 - this must pass.
+    function Get-SecureRegistrationPolicyBrowserClientApp {
+      $policyJson = @"
+[
+  {
+    "state": "enabled",
+    "conditions": {
+      "clientAppTypes": [
+        "browser"
+      ],
+      "applications": {
+        "includeUserActions": [
+          "urn:user:registersecurityinfo"
+        ]
+      },
+      "users": {
+        "includeUsers": [
+          "All"
+        ]
+      },
+      "locations": {
+        "includeLocations": [
+          "All"
+        ],
+        "excludeLocations": [
+          "AllTrusted"
+        ]
+      }
+    },
+    "grantControls": {
+      "operator": "OR",
+      "builtInControls": [
+        "mfa"
+      ]
+    }
+  }
+]
+"@
+      return $policyJson | ConvertFrom-Json
+    }
+
+    # Same valid policy but scoped to all client apps.
+    function Get-SecureRegistrationPolicyAllClientApp {
+      $policyJson = @"
+[
+  {
+    "state": "enabled",
+    "conditions": {
+      "clientAppTypes": [
+        "all"
+      ],
+      "applications": {
+        "includeUserActions": [
+          "urn:user:registersecurityinfo"
+        ]
+      },
+      "users": {
+        "includeUsers": [
+          "All"
+        ]
+      },
+      "locations": {
+        "includeLocations": [
+          "All"
+        ],
+        "excludeLocations": [
+          "AllTrusted"
+        ]
+      }
+    },
+    "grantControls": {
+      "operator": "OR",
+      "builtInControls": [
+        "mfa"
+      ]
+    }
+  }
+]
+"@
+      return $policyJson | ConvertFrom-Json
+    }
+
+    # Registration policy that does not exclude any (trusted) location - this is
+    # not "from a trusted location only" and must fail.
+    function Get-SecureRegistrationPolicyNoExcludedLocation {
+      $policyJson = @"
+[
+  {
+    "state": "enabled",
+    "conditions": {
+      "clientAppTypes": [
+        "all"
+      ],
+      "applications": {
+        "includeUserActions": [
+          "urn:user:registersecurityinfo"
+        ]
+      },
+      "users": {
+        "includeUsers": [
+          "All"
+        ]
+      },
+      "locations": {
+        "includeLocations": [
+          "All"
+        ],
+        "excludeLocations": null
+      }
+    },
+    "grantControls": {
+      "operator": "OR",
+      "builtInControls": [
+        "mfa"
+      ]
+    }
+  }
+]
+"@
+      return $policyJson | ConvertFrom-Json
+    }
+
+    # Policy scoped only to non-interactive client apps (no browser). Security
+    # info registration happens in the browser, so this must fail.
+    function Get-SecureRegistrationPolicyMobileClientAppOnly {
+      $policyJson = @"
+[
+  {
+    "state": "enabled",
+    "conditions": {
+      "clientAppTypes": [
+        "mobileAppsAndDesktopClients"
+      ],
+      "applications": {
+        "includeUserActions": [
+          "urn:user:registersecurityinfo"
+        ]
+      },
+      "users": {
+        "includeUsers": [
+          "All"
+        ]
+      },
+      "locations": {
+        "includeLocations": [
+          "All"
+        ],
+        "excludeLocations": [
+          "AllTrusted"
+        ]
+      }
+    },
+    "grantControls": {
+      "operator": "OR",
+      "builtInControls": [
+        "mfa"
+      ]
+    }
+  }
+]
+"@
+      return $policyJson | ConvertFrom-Json
+    }
+
+    # Correctly scoped policy but targeting a resource instead of the
+    # registersecurityinfo user action - must fail.
+    function Get-SecureRegistrationPolicyWrongTarget {
+      $policyJson = @"
+[
+  {
+    "state": "enabled",
+    "conditions": {
+      "clientAppTypes": [
+        "all"
+      ],
+      "applications": {
+        "includeApplications": [
+          "All"
+        ]
+      },
+      "users": {
+        "includeUsers": [
+          "All"
+        ]
+      },
+      "locations": {
+        "includeLocations": [
+          "All"
+        ],
+        "excludeLocations": [
+          "AllTrusted"
+        ]
+      }
+    },
+    "grantControls": {
+      "operator": "OR",
+      "builtInControls": [
+        "mfa"
+      ]
+    }
+  }
+]
+"@
+      return $policyJson | ConvertFrom-Json
+    }
+  }
+
+  Context "CA: Secure security info registration" {
+
+    It 'Policy scoped to the browser client app should pass (regression #2105)' {
+      $policy = Get-SecureRegistrationPolicyBrowserClientApp
+      Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+
+      Test-MtCaSecureSecurityInfoRegistration | Should -BeTrue
+    }
+
+    It 'Policy scoped to all client apps should pass' {
+      $policy = Get-SecureRegistrationPolicyAllClientApp
+      Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+
+      Test-MtCaSecureSecurityInfoRegistration | Should -BeTrue
+    }
+
+    It 'Policy that does not exclude a trusted location should fail' {
+      $policy = Get-SecureRegistrationPolicyNoExcludedLocation
+      Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+
+      Test-MtCaSecureSecurityInfoRegistration | Should -BeFalse
+    }
+
+    It 'Policy scoped only to non-browser client apps should fail' {
+      $policy = Get-SecureRegistrationPolicyMobileClientAppOnly
+      Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+
+      Test-MtCaSecureSecurityInfoRegistration | Should -BeFalse
+    }
+
+    It 'Policy not targeting the registersecurityinfo user action should fail' {
+      $policy = Get-SecureRegistrationPolicyWrongTarget
+      Mock -ModuleName Maester Get-MtConditionalAccessPolicy { return $policy }
+
+      Test-MtCaSecureSecurityInfoRegistration | Should -BeFalse
+    }
+
+  }
+}


### PR DESCRIPTION
## 📑 Description

Fixes #2105

MT.1011 (`Test-MtCaSecureSecurityInfoRegistration`) reported a **false positive** — it failed even when a Conditional Access policy that secures security info registration existed.

### Root cause

The match required the policy to apply to **all** client app types:

```powershell
$policy.conditions.clientAppTypes -eq "all"
```

Security info registration (`urn:user:registersecurityinfo`) is an interactive, **browser-based** flow. A policy correctly scoped to the **browser** client app (`clientAppTypes = ["browser"]`) secures registration just as well as one scoped to `all`, but was rejected. In the reported environment the policy showed `Client apps: 1 included` (browser), which is exactly this case.

### Fix

Accept a policy whose `clientAppTypes` contains `"all"` **or** `"browser"`:

```powershell
$securesBrowserRegistration = $policy.conditions.clientAppTypes -contains "all" -or `
                              $policy.conditions.clientAppTypes -contains "browser"
```

A policy scoped only to non-interactive clients (e.g. `mobileAppsAndDesktopClients`) still does **not** match, since registration does not occur there — so no false negative is introduced. All other criteria (all users, `urn:user:registersecurityinfo` user action, all locations included, at least one trusted location excluded) are unchanged.

### Misleading output (also raised in the issue)

The generic failure message `"No Conditional Access policy securing security info registration."` did not explain why a policy did not match. It now states the exact criteria a matching policy must meet, and the command `.Description` was clarified to the same effect.

## ✅ Checks

- [x] My pull request adheres to the code style of this project.
- [x] My code requires changes to the documentation. *(command help `.Description` updated in-source; generated docs are produced by the build.)*
- [x] I have updated the documentation as required.
- [x] The build and unit tests pass locally.

## ℹ️ Additional Information

Adds `powershell/tests/functions/Test-MtCaSecureSecurityInfoRegistration.Tests.ps1` covering:

- ✅ Browser-scoped policy passes (**regression for #2105** — red before the fix, green after)
- ✅ All-client-apps policy passes
- ❌ Policy that excludes no trusted location fails
- ❌ Policy scoped only to non-browser clients fails
- ❌ Policy targeting a resource instead of the `registersecurityinfo` user action fails

`Invoke-Pester` → 5/5 pass. `Invoke-ScriptAnalyzer` on both changed files → 0 findings.

> Note on scope: MT.1011 specifically validates the "from a trusted location only" pattern (include all locations, exclude trusted). The broader alternative you mentioned — matching *any* CA on `urn:user:registersecurityinfo` regardless of location/user scope — would weaken the test (it would pass report-only or narrowly-scoped policies), so this PR keeps the location intent and instead removes the client-app false positive and makes the requirement explicit in the output. Happy to adjust if you'd prefer the broader semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security information registration checks to recognize policies targeting browser client apps, in addition to policies targeting all client apps.
  * Refined failure messaging and documentation to reflect the supported policy criteria.
* **Tests**
  * Added coverage for browser-app policies, all-client-app policies, invalid locations, unsupported client app types, and incorrect user actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->